### PR TITLE
Standardize ArgoCD configurations and improve system settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Run Soyspray Runbook
 ```sh
 cd soyspray
 ansible-playbook -i kubespray/inventory/soycluster/hosts.yml --become --become-user=root --user ubuntu playbooks/hello-soy.yml
+ansible-playbook -i kubespray/inventory/soycluster/hosts.yml --become --become-user=root --user ubuntu playbooks/manage-argocd-apps.yml --tags pihole
 ```
 
 ## Bookmarks

--- a/playbooks/hello-soy.yml
+++ b/playbooks/hello-soy.yml
@@ -3,10 +3,10 @@
 - name: Common tasks for every playbook
   import_playbook: ../kubespray/playbooks/boilerplate.yml
 
-- name: Soy Hello 
+- name: Soy Hello
   hosts: etcd:k8s_cluster:calico_rr
   gather_facts: false
-  become: yes
+  become: true
   become_user: root
   serial: 1
   tasks:

--- a/playbooks/yaml/argocd-apps/nginx/nginx-application.yaml
+++ b/playbooks/yaml/argocd-apps/nginx/nginx-application.yaml
@@ -14,7 +14,7 @@ spec:
         valueFiles:
         - $values/playbooks/yaml/argocd-apps/nginx/values.yaml
     - repoURL: 'https://github.com/kpoxo6op/soyspray.git'
-      targetRevision: work
+      targetRevision: '1.0.0'
       ref: values
   destination:
     server: 'https://kubernetes.default.svc'

--- a/playbooks/yaml/argocd-apps/pihole-exporter/pihole-exporter-application.yaml
+++ b/playbooks/yaml/argocd-apps/pihole-exporter/pihole-exporter-application.yaml
@@ -8,7 +8,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: work
+    targetRevision: '1.0.0'
     path: playbooks/yaml/argocd-apps/pihole-exporter
     kustomize:
   destination:

--- a/playbooks/yaml/argocd-apps/pihole/pihole-application.yaml
+++ b/playbooks/yaml/argocd-apps/pihole/pihole-application.yaml
@@ -11,7 +11,7 @@ spec:
     namespace: pihole
   sources:
     - repoURL: 'https://github.com/kpoxo6op/soyspray.git'
-      targetRevision: work
+      targetRevision: '1.0.0'
       path: playbooks/yaml/argocd-apps/pihole
       kustomize:
   syncPolicy:

--- a/playbooks/yaml/argocd-apps/prometheus/prometheus-application.yaml
+++ b/playbooks/yaml/argocd-apps/prometheus/prometheus-application.yaml
@@ -11,7 +11,7 @@ spec:
     namespace: monitoring
   sources:
     - repoURL: 'https://github.com/kpoxo6op/soyspray.git'
-      targetRevision: work
+      targetRevision: '1.0.0'
       path: playbooks/yaml/argocd-apps/prometheus
       kustomize:
   syncPolicy:

--- a/playbooks/yaml/argocd-apps/prometheus/values.yaml
+++ b/playbooks/yaml/argocd-apps/prometheus/values.yaml
@@ -18,6 +18,9 @@ prometheus:
       key: additional-scrape-configs.yaml
 
 grafana:
+  grafana.ini:
+    date:
+      default_timezone: "Pacific/Auckland"
   sidecar:
     dashboards:
       enabled: true


### PR DESCRIPTION
### Changes
1. **ArgoCD Applications**
   - Standardized targetRevision from 'work' to '1.0.0' across all applications:
     - nginx
     - pihole-exporter
     - pihole
     - prometheus

2. **Playbook Improvements**
   - Updated hello-soy.yml privilege escalation settings:
     - Changed `become: yes` to `become: true` for consistency
     - Retained `become_user: root` setting

3. **Grafana Configuration**
   - Added timezone configuration for Grafana:
     - Set default_timezone to "Pacific/Auckland"

4. **Documentation**
   - Added new command in README.md for managing ArgoCD apps with Pi-hole tag