### PR TITLE
Configure Longhorn metrics integration with Prometheus

### DIFF
--- a/playbooks/yaml/argocd-apps/cert-manager/cert-manager-application.yaml
+++ b/playbooks/yaml/argocd-apps/cert-manager/cert-manager-application.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.7.3"
+    targetRevision: "v1.7.4"
     path: playbooks/yaml/argocd-apps/cert-manager
     kustomize:
   destination:

--- a/playbooks/yaml/argocd-apps/external-dns/external-dns-application.yaml
+++ b/playbooks/yaml/argocd-apps/external-dns/external-dns-application.yaml
@@ -13,7 +13,7 @@ spec:
         valueFiles:
           - $values/playbooks/yaml/argocd-apps/external-dns/values.yaml
     - repoURL: https://github.com/kpoxo6op/soyspray.git
-      targetRevision: "v1.7.3"
+      targetRevision: "v1.7.4"
       ref: values
   destination:
     server: https://kubernetes.default.svc

--- a/playbooks/yaml/argocd-apps/longhorn/longhorn-application.yaml
+++ b/playbooks/yaml/argocd-apps/longhorn/longhorn-application.yaml
@@ -13,7 +13,7 @@ spec:
         valueFiles:
           - $values/playbooks/yaml/argocd-apps/longhorn/values.yaml
     - repoURL: "https://github.com/kpoxo6op/soyspray.git"
-      targetRevision: "v1.7.3"
+      targetRevision: "v1.7.4"
       ref: values
   destination:
     server: "https://kubernetes.default.svc"

--- a/playbooks/yaml/argocd-apps/longhorn/values.yaml
+++ b/playbooks/yaml/argocd-apps/longhorn/values.yaml
@@ -3,6 +3,7 @@ persistence:
   defaultClassReplicaCount: 1
   defaultDataLocality: best-effort
   migratable: true
+  metricsPort: 9500
 
 defaultSettings:
   defaultDataPath: "/storage"
@@ -137,11 +138,15 @@ service:
   manager:
     type: ClusterIP
     nodePort: ""
+    ports:
+      manager: 9500
+      metrics: 9500
 
 metrics:
   serviceMonitor:
     enabled: true
     additionalLabels:
-      release: prometheus
+      release: kube-prometheus-stack
+    port: manager
     interval: 60s
     scrapeTimeout: 30s

--- a/playbooks/yaml/argocd-apps/pihole-exporter/pihole-exporter-application.yaml
+++ b/playbooks/yaml/argocd-apps/pihole-exporter/pihole-exporter-application.yaml
@@ -8,7 +8,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.7.3"
+    targetRevision: "v1.7.4"
     path: playbooks/yaml/argocd-apps/pihole-exporter
     kustomize:
   destination:

--- a/playbooks/yaml/argocd-apps/pihole/pihole-application.yaml
+++ b/playbooks/yaml/argocd-apps/pihole/pihole-application.yaml
@@ -11,7 +11,7 @@ spec:
     namespace: pihole
   sources:
     - repoURL: "https://github.com/kpoxo6op/soyspray.git"
-      targetRevision: "v1.7.3"
+      targetRevision: "v1.7.4"
       path: playbooks/yaml/argocd-apps/pihole
       kustomize:
   syncPolicy:

--- a/playbooks/yaml/argocd-apps/prometheus/prometheus-application.yaml
+++ b/playbooks/yaml/argocd-apps/prometheus/prometheus-application.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.7.3"
+    targetRevision: "v1.7.4"
     path: playbooks/yaml/argocd-apps/prometheus
     kustomize:
       helm:


### PR DESCRIPTION
Configure Longhorn metrics integration with Prometheus

This PR adds proper metrics configuration for Longhorn storage to enable monitoring in Grafana.

Changes:
- Configure Longhorn metrics port (9500)
- Add explicit port configuration for manager and metrics endpoints
- Update ServiceMonitor label to match kube-prometheus-stack (`release: kube-prometheus-stack`)
- Set correct port name for ServiceMonitor to target
- Update all application versions to v1.7.4

Testing:
- Verified metrics are being scraped by Prometheus
- Confirmed Longhorn metrics are visible in Grafana dashboards
- Tested direct access to metrics endpoint from within the cluster