### PR TITLE
Apply Standard Resource Limits to Core Components

### DIFF
--- a/playbooks/apply-resource-limits.yml
+++ b/playbooks/apply-resource-limits.yml
@@ -1,0 +1,80 @@
+---
+# This playbook applies resource requests and limits to specific core components
+# (MetalLB Speaker, Ingress Nginx Controller, Pi-hole Exporter).
+# On resource-constrained nodes (like the Celeron nodes in this cluster),
+# pods without explicit requests/limits are often the first candidates for
+# termination (e.g., OOM kills) or CPU throttling when the node is under pressure.
+# Setting reasonable requests helps the Kubernetes scheduler place pods appropriately,
+# and setting limits prevents them from consuming excessive resources.
+# This aims to improve stability and reduce restarts for these components by making
+# them more predictable to the Kubernetes resource management system.
+
+# playbooks/apply-resource-limits.yml
+- name: Apply Standard Resource Limits to Core Components
+  hosts: kube_control_plane[0]
+  become: true
+  vars:
+    kubeconfig_path: /etc/kubernetes/admin.conf
+  tasks:
+    - name: Apply resource limits to metallb speaker (DaemonSet)
+      kubernetes.core.k8s:
+        state: present
+        kubeconfig: "{{ kubeconfig_path }}"
+        kind: DaemonSet
+        namespace: metallb-system
+        name: speaker
+        definition:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: speaker
+                    resources:
+                      requests:
+                        cpu: 50m
+                        memory: 64Mi
+                      limits:
+                        cpu: 100m
+                        memory: 128Mi
+
+    - name: Apply resource limits to ingress-nginx controller (DaemonSet)
+      kubernetes.core.k8s:
+        state: present
+        kubeconfig: "{{ kubeconfig_path }}"
+        kind: DaemonSet
+        namespace: ingress-nginx
+        name: ingress-nginx-controller
+        definition:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: ingress-nginx-controller
+                    resources:
+                      requests:
+                        cpu: 100m
+                        memory: 128Mi
+                      limits:
+                        cpu: 500m
+                        memory: 512Mi
+
+    - name: Apply resource limits to pihole-exporter (Deployment)
+      kubernetes.core.k8s:
+        state: present
+        kubeconfig: "{{ kubeconfig_path }}"
+        kind: Deployment
+        namespace: pihole
+        name: pihole-exporter
+        definition:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: pihole-exporter
+                    resources:
+                      requests:
+                        cpu: 25m
+                        memory: 32Mi
+                      limits:
+                        cpu: 50m
+                        memory: 64Mi


### PR DESCRIPTION
This playbook applies standard resource requests and limits to core Kubernetes components to improve stability on resource-constrained nodes.

**Problem:**
Several pods (MetalLB speaker, Ingress Nginx controller, Pi-hole exporter) were observed to have high restart counts, likely due to node resource pressure (Memory, Disk, PID) on the Celeron cluster nodes. Pods without explicit requests/limits are often the first targets for OOM kills or CPU throttling under such conditions.

**Solution:**
This playbook uses the `kubernetes.core.k8s` Ansible module to patch the following resources with defined requests and limits:
*   `metallb-system/speaker` (DaemonSet)
*   `ingress-nginx/ingress-nginx-controller` (DaemonSet)
*   `pihole/pihole-exporter` (Deployment)

**Implementation:**
*   The playbook targets `kube_control_plane[0]` and uses `become: true` with the admin kubeconfig, consistent with the `manage-argocd-apps.yml` pattern.
*   Initial resource values are set based on component roles, aiming to provide better scheduling hints and prevent excessive resource consumption.

This change aims to reduce pod restarts and improve overall cluster stability until the underlying hardware limitations are addressed.