### PR TITLE
Add Flask route tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,12 @@ source soyspray-venv/bin/activate
 cd kubespray
 pip install -U -r requirements.txt
 ```
+
+## Testing
+
+Install requirements and run the Flask tests with pytest:
+
+```sh
+pip install -r flask_test/requirements.txt pytest
+pytest flask_test/test_app.py
+```

--- a/flask_test/test_app.py
+++ b/flask_test/test_app.py
@@ -1,0 +1,16 @@
+"""Tests for the Flask app.
+
+Run with pytest:
+
+    pytest flask_test/test_app.py
+"""
+
+from app import app
+
+
+def test_index():
+    client = app.test_client()
+    response = client.get('/')
+    assert response.status_code == 200
+    assert b"WireGuard Tunnel Test" in response.data
+


### PR DESCRIPTION
## Summary
- add pytest-based tests for the Flask demo
- document how to run tests with pytest

## Testing
- `pip install -r flask_test/requirements.txt pytest` *(fails: cannot connect to proxy)*