### PR TITLE
Add automated Prowlarr indexer setup with secrets and bootstrap job

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,9 @@
 TELEGRAM_BOT_TOKEN=8100......................................721Y
 CLOUDFLARE_API_TOKEN=MK.....................................E
 AZURE_VPS_PUBLIC_IP=172.204.93.61
+
+PROWLARR_API_KEY=7..........................
+RUTRACKER_USER=k..........................
+RUTRACKER_PASS=1..........................
+
+MYANONAMOUSE_SESSION_ID=M87............................S

--- a/playbooks/deploy-argocd-apps.yml
+++ b/playbooks/deploy-argocd-apps.yml
@@ -308,6 +308,17 @@
                 | trim
               }}
 
+        - name: Load MYANONAMOUSE_SESSION_ID from .env
+          set_fact:
+            mam_session_id: >-
+              {{
+                lookup('file', playbook_dir + '/../.env')
+                | regex_findall('MYANONAMOUSE_SESSION_ID=([^\n]+)')
+                | first
+                | default('')
+                | trim
+              }}
+
         - name: Validate Prowlarr secrets
           fail:
             msg: "{{ item.name }} is empty/missing in .env file"
@@ -316,6 +327,7 @@
             - { name: "PROWLARR_API_KEY", value: "{{ prowlarr_api_key }}" }
             - { name: "RUTRACKER_USER", value: "{{ rutracker_user }}" }
             - { name: "RUTRACKER_PASS", value: "{{ rutracker_pass }}" }
+            - { name: "MYANONAMOUSE_SESSION_ID", value: "{{ mam_session_id }}" }
       rescue:
         - name: Fail with helpful message
           fail:
@@ -350,6 +362,7 @@
             PROWLARR_API_KEY: "{{ prowlarr_api_key | b64encode }}"
             RUTRACKER_USER: "{{ rutracker_user | b64encode }}"
             RUTRACKER_PASS: "{{ rutracker_pass | b64encode }}"
+            MYANONAMOUSE_SESSION_ID: "{{ mam_session_id | b64encode }}"
       tags: prowlarr
 
     - name: Apply Prowlarr

--- a/playbooks/deploy-argocd-apps.yml
+++ b/playbooks/deploy-argocd-apps.yml
@@ -272,6 +272,86 @@
         definition: "{{ lookup('file', playbook_dir + '/yaml/argocd-apps/calibre-web/calibre-web-application.yaml') }}"
       tags: calibre-web
 
+    # Verify and load Prowlarr secrets from .env
+    - name: Verify and load Prowlarr secrets from .env
+      block:
+        - name: Load PROWLARR_API_KEY from .env
+          set_fact:
+            prowlarr_api_key: >-
+              {{
+                lookup('file', playbook_dir + '/../.env')
+                | regex_findall('PROWLARR_API_KEY=([^\n]+)')
+                | first
+                | default('')
+                | trim
+              }}
+
+        - name: Load RUTRACKER_USER from .env
+          set_fact:
+            rutracker_user: >-
+              {{
+                lookup('file', playbook_dir + '/../.env')
+                | regex_findall('RUTRACKER_USER=([^\n]+)')
+                | first
+                | default('')
+                | trim
+              }}
+
+        - name: Load RUTRACKER_PASS from .env
+          set_fact:
+            rutracker_pass: >-
+              {{
+                lookup('file', playbook_dir + '/../.env')
+                | regex_findall('RUTRACKER_PASS=([^\n]+)')
+                | first
+                | default('')
+                | trim
+              }}
+
+        - name: Validate Prowlarr secrets
+          fail:
+            msg: "{{ item.name }} is empty/missing in .env file"
+          when: item.value | length == 0
+          loop:
+            - { name: "PROWLARR_API_KEY", value: "{{ prowlarr_api_key }}" }
+            - { name: "RUTRACKER_USER", value: "{{ rutracker_user }}" }
+            - { name: "RUTRACKER_PASS", value: "{{ rutracker_pass }}" }
+      rescue:
+        - name: Fail with helpful message
+          fail:
+            msg: "Error: .env file not found or Prowlarr secrets invalid"
+      tags: prowlarr
+
+    # Create namespace for Prowlarr
+    - name: Create media namespace
+      kubernetes.core.k8s:
+        state: present
+        kubeconfig: "{{ kubeconfig_path }}"
+        definition:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: media
+      tags: prowlarr
+
+    # Create Prowlarr secrets
+    - name: Create Prowlarr secrets
+      kubernetes.core.k8s:
+        state: present
+        namespace: media
+        kubeconfig: "{{ kubeconfig_path }}"
+        resource_definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: prowlarr-secrets
+            namespace: media
+          data:
+            PROWLARR_API_KEY: "{{ prowlarr_api_key | b64encode }}"
+            RUTRACKER_USER: "{{ rutracker_user | b64encode }}"
+            RUTRACKER_PASS: "{{ rutracker_pass | b64encode }}"
+      tags: prowlarr
+
     - name: Apply Prowlarr
       kubernetes.core.k8s:
         state: present

--- a/playbooks/yaml/argocd-apps/calibre-web/calibre-web-application.yaml
+++ b/playbooks/yaml/argocd-apps/calibre-web/calibre-web-application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.12.0"
+    targetRevision: "v1.13.0"
     path: playbooks/yaml/argocd-apps/calibre-web
   destination:
     server: "https://kubernetes.default.svc"

--- a/playbooks/yaml/argocd-apps/cert-manager/cert-manager-application.yaml
+++ b/playbooks/yaml/argocd-apps/cert-manager/cert-manager-application.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.12.0"
+    targetRevision: "v1.13.0"
     path: playbooks/yaml/argocd-apps/cert-manager
     kustomize:
   destination:

--- a/playbooks/yaml/argocd-apps/external-dns/external-dns-application.yaml
+++ b/playbooks/yaml/argocd-apps/external-dns/external-dns-application.yaml
@@ -13,7 +13,7 @@ spec:
         valueFiles:
           - $values/playbooks/yaml/argocd-apps/external-dns/values.yaml
     - repoURL: https://github.com/kpoxo6op/soyspray.git
-      targetRevision: "v1.12.0"
+      targetRevision: "v1.13.0"
       ref: values
   destination:
     server: https://kubernetes.default.svc

--- a/playbooks/yaml/argocd-apps/immich/immich-application.yaml
+++ b/playbooks/yaml/argocd-apps/immich/immich-application.yaml
@@ -13,7 +13,7 @@ spec:
     namespace: immich
   sources:
     - repoURL: https://github.com/kpoxo6op/soyspray.git
-      targetRevision: "v1.12.0"
+      targetRevision: "v1.13.0"
       path: playbooks/yaml/argocd-apps/immich
       kustomize:
   syncPolicy:

--- a/playbooks/yaml/argocd-apps/longhorn/longhorn-application.yaml
+++ b/playbooks/yaml/argocd-apps/longhorn/longhorn-application.yaml
@@ -8,7 +8,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.12.0"
+    targetRevision: "v1.13.0"
     path: playbooks/yaml/argocd-apps/longhorn
     kustomize:
   destination:

--- a/playbooks/yaml/argocd-apps/pihole-exporter/pihole-exporter-application.yaml
+++ b/playbooks/yaml/argocd-apps/pihole-exporter/pihole-exporter-application.yaml
@@ -8,7 +8,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.12.0"
+    targetRevision: "v1.13.0"
     path: playbooks/yaml/argocd-apps/pihole-exporter
     kustomize:
   destination:

--- a/playbooks/yaml/argocd-apps/pihole/pihole-application.yaml
+++ b/playbooks/yaml/argocd-apps/pihole/pihole-application.yaml
@@ -11,7 +11,7 @@ spec:
     namespace: pihole
   sources:
     - repoURL: "https://github.com/kpoxo6op/soyspray.git"
-      targetRevision: "v1.12.0"
+      targetRevision: "v1.13.0"
       path: playbooks/yaml/argocd-apps/pihole
       kustomize:
   syncPolicy:

--- a/playbooks/yaml/argocd-apps/postgresql/postgresql-application.yaml
+++ b/playbooks/yaml/argocd-apps/postgresql/postgresql-application.yaml
@@ -14,7 +14,7 @@ spec:
     namespace: postgresql
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.12.0"
+    targetRevision: "v1.13.0"
     path: playbooks/yaml/argocd-apps/postgresql
     kustomize:
   syncPolicy:

--- a/playbooks/yaml/argocd-apps/prometheus/prometheus-application.yaml
+++ b/playbooks/yaml/argocd-apps/prometheus/prometheus-application.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.12.0"
+    targetRevision: "v1.13.0"
     path: playbooks/yaml/argocd-apps/prometheus
     kustomize:
       helm:

--- a/playbooks/yaml/argocd-apps/prowlarr/bootstrap-job.yaml
+++ b/playbooks/yaml/argocd-apps/prowlarr/bootstrap-job.yaml
@@ -63,6 +63,11 @@ spec:
             secretKeyRef:
               name: prowlarr-secrets
               key: RUTRACKER_PASS
+        - name: MYANONAMOUSE_SESSION_ID
+          valueFrom:
+            secretKeyRef:
+              name: prowlarr-secrets
+              key: MYANONAMOUSE_SESSION_ID
 
         # Resource limits for the bootstrap job
         resources:

--- a/playbooks/yaml/argocd-apps/prowlarr/bootstrap-job.yaml
+++ b/playbooks/yaml/argocd-apps/prowlarr/bootstrap-job.yaml
@@ -34,13 +34,20 @@ spec:
         - -c
         - |
           set -euo pipefail
+          echo "🐍 Setting up Python environment..."
+          # Create home directory for pip user installs
+          mkdir -p /tmp/home/.local
+          export HOME=/tmp/home
+          export PATH="/tmp/home/.local/bin:$PATH"
           echo "🐍 Installing Python dependencies..."
-          pip install --no-cache-dir -r /scripts/requirements.txt
+          pip install --user --no-cache-dir -r /scripts/requirements.txt
           echo "🚀 Starting bootstrap script..."
           python3 /scripts/bootstrap.py
 
         # Environment variables from secrets
         env:
+        - name: HOME
+          value: "/tmp/home"
         - name: PROWLARR_API_KEY
           valueFrom:
             secretKeyRef:

--- a/playbooks/yaml/argocd-apps/prowlarr/bootstrap-job.yaml
+++ b/playbooks/yaml/argocd-apps/prowlarr/bootstrap-job.yaml
@@ -1,0 +1,98 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: prowlarr-bootstrap
+  namespace: media
+  labels:
+    app: prowlarr
+    component: bootstrap
+  annotations:
+    # ArgoCD PostSync Hook - runs after main resources are synced
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  # Clean up completed jobs after 24 hours
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app: prowlarr
+        component: bootstrap
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: bootstrap
+        # Use Python 3.11 slim image for efficiency
+        image: python:3.11-slim
+
+        # Set working directory
+        workingDir: /app
+
+        # Command to install dependencies and run bootstrap
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -euo pipefail
+          echo "🐍 Installing Python dependencies..."
+          pip install --no-cache-dir -r /scripts/requirements.txt
+          echo "🚀 Starting bootstrap script..."
+          python3 /scripts/bootstrap.py
+
+        # Environment variables from secrets
+        env:
+        - name: PROWLARR_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: prowlarr-secrets
+              key: PROWLARR_API_KEY
+        - name: RUTRACKER_USER
+          valueFrom:
+            secretKeyRef:
+              name: prowlarr-secrets
+              key: RUTRACKER_USER
+        - name: RUTRACKER_PASS
+          valueFrom:
+            secretKeyRef:
+              name: prowlarr-secrets
+              key: RUTRACKER_PASS
+
+        # Resource limits for the bootstrap job
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "500m"
+
+        # Volume mounts
+        volumeMounts:
+        - name: payloads
+          mountPath: /payloads
+          readOnly: true
+        - name: scripts
+          mountPath: /scripts
+          readOnly: true
+
+        # Security context
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop:
+            - ALL
+
+      # Volumes
+      volumes:
+      - name: payloads
+        configMap:
+          name: prowlarr-payloads
+          defaultMode: 0644
+      - name: scripts
+        configMap:
+          name: prowlarr-bootstrap-scripts
+          defaultMode: 0755  # Make scripts executable

--- a/playbooks/yaml/argocd-apps/prowlarr/bootstrap-scripts-cm.yaml
+++ b/playbooks/yaml/argocd-apps/prowlarr/bootstrap-scripts-cm.yaml
@@ -1,0 +1,475 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prowlarr-bootstrap-scripts
+  namespace: media
+  labels:
+    app: prowlarr
+data:
+  bootstrap.py: |
+    #!/usr/bin/env python3
+    """
+    =======================================================
+    Prowlarr Tracker Bootstrap Script (Python Edition)
+    =======================================================
+
+    This script imports tracker configurations into Prowlarr.
+    It reads JSON payloads and replaces placeholders with
+    actual credentials from Kubernetes secrets.
+
+    Python advantages used:
+    - Clean exception handling
+    - Rich JSON manipulation
+    - Type hints for clarity
+    - Structured logging
+    - Object-oriented design
+    - Better HTTP client (requests)
+    =======================================================
+    """
+
+    import json
+    import os
+    import sys
+    import time
+    from pathlib import Path
+    from typing import Dict, List, Optional, Tuple
+
+    import requests
+    from requests.adapters import HTTPAdapter
+    from urllib3.util.retry import Retry
+
+
+    class ProwlarrBootstrap:
+        """
+        Main class for bootstrapping Prowlarr tracker configurations.
+
+        This class handles the entire workflow:
+        1. Environment validation
+        2. Prowlarr health checks
+        3. Tracker existence checks
+        4. Credential substitution
+        5. Tracker import via API
+        """
+
+        def __init__(self):
+            # Configuration constants
+            self.PROWLARR_URL = "http://prowlarr.media.svc.cluster.local:9696"
+            self.PAYLOADS_DIR = Path("/payloads")
+            self.MAX_RETRIES = 30
+            self.RETRY_DELAY = 10
+            self.API_TIMEOUT = 30
+
+            # Initialize HTTP session with retry strategy
+            self.session = self._create_http_session()
+
+            # Environment variables (loaded during validation)
+            self.api_key: Optional[str] = None
+            self.rutracker_user: Optional[str] = None
+            self.rutracker_pass: Optional[str] = None
+
+        def _create_http_session(self) -> requests.Session:
+            """Create HTTP session with retry strategy and timeouts."""
+            session = requests.Session()
+
+            # Configure retry strategy
+            retry_strategy = Retry(
+                total=3,
+                backoff_factor=1,
+                status_forcelist=[429, 500, 502, 503, 504],
+            )
+
+            adapter = HTTPAdapter(max_retries=retry_strategy)
+            session.mount("http://", adapter)
+            session.mount("https://", adapter)
+
+            return session
+
+        # =======================================================
+        # Logging Methods (with emojis for visual clarity)
+        # =======================================================
+
+        @staticmethod
+        def log_info(message: str) -> None:
+            """Log informational message."""
+            print(f"ℹ️  {message}")
+
+        @staticmethod
+        def log_success(message: str) -> None:
+            """Log success message."""
+            print(f"✅ {message}")
+
+        @staticmethod
+        def log_error(message: str) -> None:
+            """Log error message to stderr."""
+            print(f"❌ {message}", file=sys.stderr)
+
+        @staticmethod
+        def log_warning(message: str) -> None:
+            """Log warning message."""
+            print(f"⚠️  {message}")
+
+        # =======================================================
+        # Environment & Validation Methods
+        # =======================================================
+
+        def validate_environment(self) -> bool:
+            """
+            Validate all required environment variables are present.
+
+            Returns:
+                bool: True if all required variables are set
+            """
+            self.log_info("Validating environment variables...")
+
+            required_vars = {
+                'PROWLARR_API_KEY': 'api_key',
+                'RUTRACKER_USER': 'rutracker_user',
+                'RUTRACKER_PASS': 'rutracker_pass'
+            }
+
+            missing_vars = []
+
+            for env_var, attr_name in required_vars.items():
+                value = os.getenv(env_var)
+                if not value:
+                    missing_vars.append(env_var)
+                else:
+                    setattr(self, attr_name, value.strip())
+
+            if missing_vars:
+                self.log_error(f"Missing required environment variables: {', '.join(missing_vars)}")
+                return False
+
+            self.log_success("All required environment variables are set")
+            return True
+
+        def validate_payloads_directory(self) -> bool:
+            """
+            Check if payloads directory exists and is accessible.
+
+            Returns:
+                bool: True if directory exists and is readable
+            """
+            if not self.PAYLOADS_DIR.exists():
+                self.log_error(f"Payloads directory not found: {self.PAYLOADS_DIR}")
+                return False
+
+            if not self.PAYLOADS_DIR.is_dir():
+                self.log_error(f"Payloads path is not a directory: {self.PAYLOADS_DIR}")
+                return False
+
+            self.log_success(f"Payloads directory verified: {self.PAYLOADS_DIR}")
+            return True
+
+        # =======================================================
+        # Prowlarr API Methods
+        # =======================================================
+
+        def wait_for_prowlarr_ready(self) -> bool:
+            """
+            Wait for Prowlarr to become ready and responsive.
+
+            Returns:
+                bool: True if Prowlarr becomes ready within retry limit
+            """
+            self.log_info("Waiting for Prowlarr to be ready...")
+
+            headers = {"X-Api-Key": self.api_key}
+
+            for attempt in range(1, self.MAX_RETRIES + 1):
+                try:
+                    response = self.session.get(
+                        f"{self.PROWLARR_URL}/api/v1/system/status",
+                        headers=headers,
+                        timeout=self.API_TIMEOUT
+                    )
+
+                    if response.status_code == 200:
+                        self.log_success("Prowlarr is ready!")
+                        return True
+
+                except requests.exceptions.RequestException as e:
+                    self.log_info(f"Attempt {attempt}/{self.MAX_RETRIES} - Connection failed: {e}")
+
+                if attempt < self.MAX_RETRIES:
+                    self.log_info(f"Waiting {self.RETRY_DELAY}s before next attempt...")
+                    time.sleep(self.RETRY_DELAY)
+
+            self.log_error(f"Prowlarr failed to become ready after {self.MAX_RETRIES} attempts")
+            return False
+
+        def get_existing_trackers(self) -> Optional[List[Dict]]:
+            """
+            Fetch list of existing trackers from Prowlarr.
+
+            Returns:
+                Optional[List[Dict]]: List of existing trackers, or None on error
+            """
+            try:
+                response = self.session.get(
+                    f"{self.PROWLARR_URL}/api/v1/indexer",
+                    headers={"X-Api-Key": self.api_key},
+                    timeout=self.API_TIMEOUT
+                )
+                response.raise_for_status()
+                return response.json()
+
+            except requests.exceptions.RequestException as e:
+                self.log_warning(f"Failed to fetch existing trackers: {e}")
+                return None
+
+        def tracker_exists(self, tracker_name: str) -> bool:
+            """
+            Check if a tracker with the given name already exists.
+
+            Args:
+                tracker_name: Name of the tracker to check
+
+            Returns:
+                bool: True if tracker exists, False otherwise
+            """
+            self.log_info(f"Checking if tracker '{tracker_name}' already exists...")
+
+            existing_trackers = self.get_existing_trackers()
+            if existing_trackers is None:
+                self.log_warning("Could not check existing trackers")
+                return False
+
+            for tracker in existing_trackers:
+                if tracker.get("name") == tracker_name:
+                    self.log_info(f"Tracker '{tracker_name}' already exists")
+                    return True
+
+            self.log_info(f"Tracker '{tracker_name}' does not exist")
+            return False
+
+        def import_tracker(self, payload_data: Dict) -> bool:
+            """
+            Import a tracker configuration via Prowlarr API.
+
+            Args:
+                payload_data: Processed tracker configuration dictionary
+
+            Returns:
+                bool: True if import successful, False otherwise
+            """
+            tracker_name = payload_data.get("name", "Unknown")
+            self.log_info(f"Importing tracker: {tracker_name}")
+
+            try:
+                response = self.session.post(
+                    f"{self.PROWLARR_URL}/api/v1/indexer",
+                    headers={
+                        "Content-Type": "application/json",
+                        "X-Api-Key": self.api_key
+                    },
+                    json=payload_data,
+                    timeout=self.API_TIMEOUT
+                )
+
+                if response.status_code in (200, 201):
+                    self.log_success(f"Successfully imported tracker: {tracker_name}")
+                    return True
+                else:
+                    self.log_error(f"Failed to import {tracker_name} (HTTP {response.status_code})")
+                    try:
+                        error_detail = response.json()
+                        self.log_error(f"Response: {json.dumps(error_detail, indent=2)}")
+                    except json.JSONDecodeError:
+                        self.log_error(f"Response text: {response.text}")
+                    return False
+
+            except requests.exceptions.RequestException as e:
+                self.log_error(f"Failed to send import request for {tracker_name}: {e}")
+                return False
+
+        # =======================================================
+        # Payload Processing Methods
+        # =======================================================
+
+        def load_payload_file(self, file_path: Path) -> Optional[Dict]:
+            """
+            Load and validate JSON payload from file.
+
+            Args:
+                file_path: Path to the JSON payload file
+
+            Returns:
+                Optional[Dict]: Parsed JSON data, or None on error
+            """
+            try:
+                with open(file_path, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                return data
+
+            except json.JSONDecodeError as e:
+                self.log_error(f"Invalid JSON in {file_path.name}: {e}")
+                return None
+            except IOError as e:
+                self.log_error(f"Could not read {file_path.name}: {e}")
+                return None
+
+        def substitute_credentials(self, payload_data: Dict) -> Dict:
+            """
+            Replace credential placeholders with actual values.
+
+            Args:
+                payload_data: Original payload data with placeholders
+
+            Returns:
+                Dict: Payload with credentials substituted
+            """
+            # Deep copy to avoid modifying original
+            processed_data = json.loads(json.dumps(payload_data))
+
+            # Find and replace credential fields
+            fields = processed_data.get("fields", [])
+            for field in fields:
+                if field.get("name") == "username":
+                    field["value"] = self.rutracker_user
+                elif field.get("name") == "password":
+                    field["value"] = self.rutracker_pass
+
+            return processed_data
+
+        def process_tracker_file(self, file_path: Path) -> bool:
+            """
+            Process a single tracker payload file.
+
+            Args:
+                file_path: Path to the tracker JSON file
+
+            Returns:
+                bool: True if processing successful, False otherwise
+            """
+            self.log_info(f"Processing payload file: {file_path.name}")
+
+            # Load and validate JSON
+            payload_data = self.load_payload_file(file_path)
+            if payload_data is None:
+                return False
+
+            # Extract tracker name
+            tracker_name = payload_data.get("name")
+            if not tracker_name:
+                self.log_error(f"Could not extract tracker name from {file_path.name}")
+                return False
+
+            self.log_info(f"Processing tracker: {tracker_name}")
+
+            # Check if tracker already exists
+            if self.tracker_exists(tracker_name):
+                self.log_warning(f"Skipping {tracker_name} - already configured")
+                return True  # Not an error, just skipped
+
+            # Substitute credentials
+            self.log_info(f"Substituting credentials for {tracker_name}...")
+            processed_payload = self.substitute_credentials(payload_data)
+
+            # Import the tracker
+            return self.import_tracker(processed_payload)
+
+        def find_payload_files(self) -> List[Path]:
+            """
+            Find all JSON payload files in the payloads directory.
+
+            Returns:
+                List[Path]: List of JSON file paths
+            """
+            json_files = list(self.PAYLOADS_DIR.glob("*.json"))
+
+            if not json_files:
+                self.log_warning("No JSON payload files found")
+                return []
+
+            self.log_info("Found JSON payload files:")
+            for file_path in json_files:
+                self.log_info(f"  - {file_path.name}")
+
+            return json_files
+
+        # =======================================================
+        # Main Execution Method
+        # =======================================================
+
+        def run(self) -> bool:
+            """
+            Main execution method that orchestrates the entire bootstrap process.
+
+            Returns:
+                bool: True if bootstrap completed successfully
+            """
+            self.log_success("🚀 Starting Prowlarr Tracker Bootstrap (Python Edition)")
+            self.log_info(f"📍 Prowlarr URL: {self.PROWLARR_URL}")
+            self.log_info(f"📂 Payloads directory: {self.PAYLOADS_DIR}")
+
+            # Step 1: Validate environment
+            if not self.validate_environment():
+                return False
+
+            # Step 2: Validate payloads directory
+            if not self.validate_payloads_directory():
+                return False
+
+            # Step 3: Wait for Prowlarr to be ready
+            if not self.wait_for_prowlarr_ready():
+                return False
+
+            # Step 4: Find payload files
+            payload_files = self.find_payload_files()
+            if not payload_files:
+                self.log_warning("No payload files to process")
+                return True  # Not an error
+
+            # Step 5: Process each payload file
+            success_count = 0
+            total_count = len(payload_files)
+
+            for i, file_path in enumerate(payload_files, 1):
+                self.log_info("─" * 50)
+                self.log_info(f"Processing file {i}/{total_count}: {file_path.name}")
+
+                if self.process_tracker_file(file_path):
+                    success_count += 1
+                else:
+                    self.log_warning(f"Failed to process {file_path.name}")
+
+            # Step 6: Report results
+            self.log_info("═" * 50)
+            self.log_success("Bootstrap completed!")
+            self.log_success(f"Successfully processed: {success_count}/{total_count} trackers")
+
+            if success_count == total_count:
+                self.log_success("All trackers processed successfully! 🎉")
+                return True
+            else:
+                self.log_warning("Some trackers failed to import")
+                return False
+
+
+    def main() -> int:
+        """
+        Main entry point for the script.
+
+        Returns:
+            int: Exit code (0 for success, 1 for failure)
+        """
+        try:
+            bootstrap = ProwlarrBootstrap()
+            success = bootstrap.run()
+            return 0 if success else 1
+
+        except KeyboardInterrupt:
+            ProwlarrBootstrap.log_warning("Bootstrap interrupted by user")
+            return 1
+        except Exception as e:
+            ProwlarrBootstrap.log_error(f"Unexpected error: {e}")
+            return 1
+
+
+    if __name__ == "__main__":
+        sys.exit(main())
+
+  requirements.txt: |
+    requests==2.31.0
+    urllib3==2.0.7

--- a/playbooks/yaml/argocd-apps/prowlarr/bootstrap-scripts-cm.yaml
+++ b/playbooks/yaml/argocd-apps/prowlarr/bootstrap-scripts-cm.yaml
@@ -329,6 +329,12 @@ data:
                     field["value"] = self.rutracker_user
                 elif field.get("name") == "password":
                     field["value"] = self.rutracker_pass
+                elif field.get("name") == "mamId":
+                    mam_session_id = os.getenv("MYANONAMOUSE_SESSION_ID")
+                    if mam_session_id:
+                        field["value"] = mam_session_id.strip()
+                    else:
+                        self.log_warning("MYANONAMOUSE_SESSION_ID not found in environment")
 
             return processed_data
 

--- a/playbooks/yaml/argocd-apps/prowlarr/docs/add-trackers-plan.md
+++ b/playbooks/yaml/argocd-apps/prowlarr/docs/add-trackers-plan.md
@@ -89,14 +89,6 @@ git push && argocd app sync prowlarr
 kubectl -n media logs -f job/prowlarr-bootstrap   # until ✔︎ messages appear
 ```
 
-## Step 6 – Final Kustomize Inventory Check
-
-Run a full render to confirm all objects are tracked:
-
-```bash
-kubectl kustomize playbooks/yaml/argocd-apps/prowlarr | grep -E "kind:|name:"
-```
-
 ## Adding Another Tracker
 
 1. Export JSON from Prowlarr UI.

--- a/playbooks/yaml/argocd-apps/prowlarr/docs/add-trackers-plan.md
+++ b/playbooks/yaml/argocd-apps/prowlarr/docs/add-trackers-plan.md
@@ -1,10 +1,11 @@
-# Prowlarr GitOps Tracker Configuration - Step by Step
+# Prowlarr GitOps Tracker Configuration – Updated Step‑by‑Step Plan
 
-This plan breaks tracker configuration into small, testable steps. Each step has a verifiable state you can validate before proceeding.
+This revision eliminates imperative `kubectl apply` calls.
+Every state change is driven by **Git commit → ArgoCD diff → ArgoCD sync**.
 
 ## Prerequisites
 
-Add these variables to your `.env` file in the repo root:
+Add these variables to `.env` in the repo root **once**:
 
 ```bash
 PROWLARR_API_KEY=7057f5abbbbb4499a54941f51992a68c
@@ -12,333 +13,103 @@ RUTRACKER_USER=<username>
 RUTRACKER_PASS=<password>
 ```
 
-## Step 1: Create Prowlarr Secrets
+## Step 1 – Prowlarr Secrets (Ansible)
 
-**Goal**: Create secrets from .env file using the same pattern as other apps
-**Location**: Add to `playbooks/deploy-argocd-apps.yml`
+**Goal** Create/update the `prowlarr-secrets` Kubernetes Secret from `.env`.
+**Playbook** `playbooks/deploy-argocd-apps.yml` (tag: `prowlarr`).
+The task block is unchanged from the previous plan.
 
-Add this task to your `deploy-argocd-apps.yml`:
+**Verify**
+
+```bash
+ansible-playbook playbooks/deploy-argocd-apps.yml --tags prowlarr
+kubectl -n media get secret prowlarr-secrets
+```
+
+## Step 2 – Tracker Payload File
+
+**Goal** Store RuTracker payload as a first‑class file in SCM.
+**File** `playbooks/yaml/argocd-apps/prowlarr/rutracker_payload.json`
+(already present – keep exactly as exported from the UI).
+
+## Step 3 – ConfigMap Generator
+
+**Goal** Let Kustomize turn payload files into a ConfigMap.
+**File** `playbooks/yaml/argocd-apps/prowlarr/kustomization.yaml`
+Add the section:
 
 ```yaml
-- name: Verify and load Prowlarr credentials from .env
-  block:
-    - name: Load PROWLARR_API_KEY from .env
-      set_fact:
-        prowlarr_api_key: >-
-          {{
-            lookup('file', playbook_dir + '/../.env')
-            | regex_findall('PROWLARR_API_KEY=([^\n]+)')
-            | first
-            | default('')
-            | trim
-          }}
-
-    - name: Load RUTRACKER_USER from .env
-      set_fact:
-        rutracker_user: >-
-          {{
-            lookup('file', playbook_dir + '/../.env')
-            | regex_findall('RUTRACKER_USER=([^\n]+)')
-            | first
-            | default('')
-            | trim
-          }}
-
-    - name: Load RUTRACKER_PASS from .env
-      set_fact:
-        rutracker_pass: >-
-          {{
-            lookup('file', playbook_dir + '/../.env')
-            | regex_findall('RUTRACKER_PASS=([^\n]+)')
-            | first
-            | default('')
-            | trim
-          }}
-
-    - name: Validate Prowlarr credentials
-      fail:
-        msg: "{{ item.name }} is empty/missing in .env file"
-      when: item.value | length == 0
-      loop:
-        - {name: "PROWLARR_API_KEY", value: "{{ prowlarr_api_key }}"}
-        - {name: "RUTRACKER_USER", value: "{{ rutracker_user }}"}
-        - {name: "RUTRACKER_PASS", value: "{{ rutracker_pass }}"}
-  rescue:
-    - name: Fail with helpful message
-      fail:
-        msg: "Error: .env file not found or Prowlarr credentials invalid"
-  tags: prowlarr
-
-- name: Create media namespace
-  kubernetes.core.k8s:
-    state: present
-    kubeconfig: "{{ kubeconfig_path }}"
-    definition:
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: media
-  tags: prowlarr
-
-- name: Create Prowlarr Secrets
-  kubernetes.core.k8s:
-    state: present
+configMapGenerator:
+  - name: prowlarr-payloads
     namespace: media
-    kubeconfig: "{{ kubeconfig_path }}"
-    resource_definition:
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        name: prowlarr-secrets
-        namespace: media
-      type: Opaque
-      data:
-        PROWLARR_API_KEY: "{{ prowlarr_api_key | b64encode }}"
-        RUTRACKER_USER: "{{ rutracker_user | b64encode }}"
-        RUTRACKER_PASS: "{{ rutracker_pass | b64encode }}"
-  tags: prowlarr
+    files:
+      - rutracker.json=rutracker_payload.json
+    options:
+      disableNameSuffixHash: true
 ```
 
-**Verify Step 1**:
+Remove the old hand‑written `tracker-payloads-cm.yaml`.
+
+**Verify (GitOps style)**
 
 ```bash
-# Run only the prowlarr tasks
-ansible-playbook playbooks/deploy-argocd-apps.yml --tags prowlarr
-
-# Verify secret was created
-kubectl get secret prowlarr-secrets -n media -o yaml
-kubectl get secret prowlarr-secrets -n media -o jsonpath='{.data.PROWLARR_API_KEY}' | base64 -d
-```
-
-## Step 2: Create Bootstrap Script ConfigMap
-
-**Goal**: Create the bootstrap script that will configure trackers
-**Location**: `playbooks/yaml/argocd-apps/prowlarr/bootstrap-scripts-cm.yaml`
-
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: prowlarr-bootstrap-scripts
-  namespace: media
-data:
-  bootstrap.sh: |
-    #!/bin/sh
-    set -eu
-
-    P_URL="http://prowlarr.media.svc.cluster.local:9696"
-    echo "Waiting for Prowlarr API…"
-    until curl -sf "${P_URL}/api/v1/system/status"; do sleep 5; done
-
-    list() { curl -sf "${P_URL}/api/v1/indexer?apikey=${PROWLARR_API_KEY}"; }
-
-    for f in /payloads/*.json; do
-      [ -f "$f" ] || continue  # skip if no files
-      name=$(jq -r '.name' "$f")
-      if list | grep -q "\"name\":\"$name\""; then
-        echo "✔︎  $name already present – skipping"
-        continue
-      fi
-      tmp=$(mktemp)
-      jq \
-        --arg user "$RUTRACKER_USER" \
-        --arg pass "$RUTRACKER_PASS" \
-        '(.fields[] | select(.name=="username")).value = $user |
-         (.fields[] | select(.name=="password")).value = $pass' "$f" > "$tmp"
-
-      echo "➕  Adding $name"
-      curl -sf -X POST -H "Content-Type: application/json" \
-        -d @"$tmp" "${P_URL}/api/v1/indexer?apikey=${PROWLARR_API_KEY}"
-      rm "$tmp"
-    done
-```
-
-**Verify Step 2**:
-
-```bash
-kubectl apply -f playbooks/yaml/argocd-apps/prowlarr/bootstrap-scripts-cm.yaml
-kubectl get configmap prowlarr-bootstrap-scripts -n media
-kubectl get configmap prowlarr-bootstrap-scripts -n media -o jsonpath='{.data.bootstrap\.sh}' | head -5
-```
-
-## Step 3: Create Initial Tracker Payload
-
-**Goal**: Add your first tracker configuration (RuTracker example)
-**Location**: `playbooks/yaml/argocd-apps/prowlarr/tracker-payloads-cm.yaml`
-
-First, export a tracker from Prowlarr UI to get the JSON structure:
-
-1. Go to Prowlarr → Settings → Indexers → Add Indexer → RuTracker
-2. Configure it manually once
-3. Click the ⋮ menu → Export
-4. Save the JSON
-
-Create the ConfigMap:
-
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: prowlarr-payloads
-  namespace: media
-data:
-  rutracker.json: |
-    {
-      "enableRss": true,
-      "enableAutomaticSearch": true,
-      "enableInteractiveSearch": true,
-      "supportsRss": true,
-      "supportsSearch": true,
-      "protocol": "torrent",
-      "priority": 25,
-      "downloadClientId": 0,
-      "name": "RuTracker.org",
-      "implementation": "RuTracker",
-      "implementationName": "RuTracker",
-      "infoLink": "https://github.com/Prowlarr/Prowlarr",
-      "tags": [],
-      "fields": [
-        {
-          "order": 0,
-          "name": "username",
-          "label": "Username",
-          "value": "PLACEHOLDER_USER",
-          "type": "textbox",
-          "advanced": false
-        },
-        {
-          "order": 1,
-          "name": "password",
-          "label": "Password",
-          "value": "PLACEHOLDER_PASS",
-          "type": "password",
-          "advanced": false
-        }
-      ]
-    }
-```
-
-**Verify Step 3**:
-
-```bash
-kubectl apply -f playbooks/yaml/argocd-apps/prowlarr/tracker-payloads-cm.yaml
-kubectl get configmap prowlarr-payloads -n media
-kubectl get configmap prowlarr-payloads -n media -o jsonpath='{.data.rutracker\.json}' | jq .name
-```
-
-## Step 4: Create Bootstrap Job
-
-**Goal**: Create the job that will run after Prowlarr deployment
-**Location**: `playbooks/yaml/argocd-apps/prowlarr/bootstrap-job.yaml`
-
-```yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: prowlarr-bootstrap
-  namespace: media
-  annotations:
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
-spec:
-  backoffLimit: 3
-  ttlSecondsAfterFinished: 900
-  template:
-    spec:
-      restartPolicy: Never
-      containers:
-        - name: runner
-          image: alpine:3.20
-          command: ["/bin/sh", "-c"]
-          args:
-            - |
-              apk add --no-cache curl jq >/dev/null
-              chmod +x /scripts/bootstrap.sh
-              /scripts/bootstrap.sh
-          envFrom:
-            - secretRef: {name: prowlarr-secrets}
-          volumeMounts:
-            - {name: payloads, mountPath: /payloads, readOnly: true}
-            - {name: scripts,  mountPath: /scripts,  readOnly: true}
-      volumes:
-        - {name: payloads, configMap: {name: prowlarr-payloads}}
-        - {name: scripts,  configMap: {name: prowlarr-bootstrap-scripts, defaultMode: 0755}}
-```
-
-**Verify Step 4**:
-
-```bash
-kubectl apply -f playbooks/yaml/argocd-apps/prowlarr/bootstrap-job.yaml
-kubectl get job prowlarr-bootstrap -n media
-# Job won't run until Prowlarr is deployed and the PostSync hook triggers
-```
-
-## Step 5: Update Kustomization
-
-**Goal**: Include all new resources in your kustomization
-**Location**: `playbooks/yaml/argocd-apps/prowlarr/kustomization.yaml`
-
-Add these to your existing resources:
-
-```yaml
-resources:
-  - pvc-config.yaml
-  - service.yaml
-  - deployment.yaml
-  - initial-config-configmap.yaml
-  - bootstrap-job.yaml
-  - tracker-payloads-cm.yaml
-  - bootstrap-scripts-cm.yaml
-```
-
-**Verify Step 5**:
-
-```bash
-cd playbooks/yaml/argocd-apps/prowlarr/
-kubectl kustomize . | grep -E "kind:|name:"
-```
-
-## Step 6: Deploy and Test
-
-**Goal**: Deploy everything and verify it works
-
-```bash
-# Deploy the secrets first
-ansible-playbook playbooks/deploy-argocd-apps.yml --tags prowlarr
-
-# Sync the Prowlarr application (this will trigger the PostSync job)
+git add playbooks/yaml/argocd-apps/prowlarr/{kustomization.yaml,rutracker_payload.json}
+git commit -m "Generate prowlarr-payloads ConfigMap via kustomize"
+git push
+argocd app diff prowlarr        # shows the new ConfigMap
 argocd app sync prowlarr
-
-# Monitor the bootstrap job
-kubectl get jobs -n media
-kubectl logs -f job/prowlarr-bootstrap -n media
-
-# Verify trackers were added
-curl -H "X-Api-Key: YOUR_API_KEY" http://prowlarr.local/api/v1/indexer
+kubectl -n media get configmap prowlarr-payloads
 ```
 
-## Adding More Trackers (Future)
+## Step 4 – Bootstrap Script ConfigMap
 
-To add another tracker:
+**File** `playbooks/yaml/argocd-apps/prowlarr/bootstrap-scripts-cm.yaml`
+(same content as previous plan).
+Add the file path to `resources:` in `kustomization.yaml`.
 
-1. Export JSON from Prowlarr UI
-2. Add it to `tracker-payloads-cm.yaml`:
+**Verify**
 
-   ```yaml
-   data:
-     rutracker.json: |
-       <<existing rutracker config>>
-     1337x.json: |
-       <<new tracker config>>
-   ```
+```bash
+git add playbooks/yaml/argocd-apps/prowlarr/bootstrap-scripts-cm.yaml
+git commit -m "Add bootstrap script ConfigMap for Prowlarr"
+git push && argocd app diff prowlarr && argocd app sync prowlarr
+kubectl -n media get configmap prowlarr-bootstrap-scripts
+```
 
-3. Apply the configmap: `kubectl apply -f tracker-payloads-cm.yaml`
-4. Restart the job: `kubectl delete job prowlarr-bootstrap -n media`
-5. Sync Prowlarr: `argocd app sync prowlarr`
+## Step 5 – Bootstrap Job (PostSync Hook)
 
-## Troubleshooting
+**File** `playbooks/yaml/argocd-apps/prowlarr/bootstrap-job.yaml`
+(same spec; mounts `/payloads` from the generated ConfigMap).
+Add the file path to `resources:` in `kustomization.yaml`.
 
-**Secret not found**: Check step 1 completed successfully
-**Job fails**: Check logs with `kubectl logs job/prowlarr-bootstrap -n media`
-**Tracker not added**: Verify JSON payload is valid and API key is correct
-**Bootstrap script not executable**: ConfigMap defaultMode should be 0755
+**Verify**
+
+```bash
+git add playbooks/yaml/argocd-apps/prowlarr/bootstrap-job.yaml
+git commit -m "PostSync job to import Prowlarr trackers"
+git push && argocd app sync prowlarr
+kubectl -n media logs -f job/prowlarr-bootstrap   # until ✔︎ messages appear
+```
+
+## Step 6 – Final Kustomize Inventory Check
+
+Run a full render to confirm all objects are tracked:
+
+```bash
+kubectl kustomize playbooks/yaml/argocd-apps/prowlarr | grep -E "kind:|name:"
+```
+
+## Adding Another Tracker
+
+1. Export JSON from Prowlarr UI.
+2. Save it as `playbooks/yaml/argocd-apps/prowlarr/<tracker>.json`.
+3. Append the filename under `files:` in the existing `configMapGenerator`.
+4. `git commit && git push`, then `argocd app sync prowlarr`.
+5. Monitor the PostSync job logs – the script will idempotently add only new trackers.
+
+## Troubleshooting (GitOps centric)
+
+* **Secret not found** – rerun Step 1 Ansible playbook.
+* **Job fails** – `kubectl -n media logs job/prowlarr-bootstrap`.
+* **Tracker not added** – validate JSON file structure and API key.
+* **Script not executable** – ensure `defaultMode: 0755` on `scripts` volume or use `chmod +x` inside job.

--- a/playbooks/yaml/argocd-apps/prowlarr/docs/add-trackers-plan.md
+++ b/playbooks/yaml/argocd-apps/prowlarr/docs/add-trackers-plan.md
@@ -48,8 +48,6 @@ configMapGenerator:
       disableNameSuffixHash: true
 ```
 
-Remove the old hand‑written `tracker-payloads-cm.yaml`.
-
 **Verify (GitOps style)**
 
 ```bash

--- a/playbooks/yaml/argocd-apps/prowlarr/kustomization.yaml
+++ b/playbooks/yaml/argocd-apps/prowlarr/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - service.yaml
   - deployment.yaml
   - initial-config-configmap.yaml
+  - bootstrap-scripts-cm.yaml
 
 configMapGenerator:
   - name: prowlarr-payloads

--- a/playbooks/yaml/argocd-apps/prowlarr/kustomization.yaml
+++ b/playbooks/yaml/argocd-apps/prowlarr/kustomization.yaml
@@ -16,5 +16,6 @@ configMapGenerator:
     namespace: media
     files:
       - rutracker.json=rutracker_payload.json
+      - myanonamouse.json=myanonamouse_payload.json
     options:
       disableNameSuffixHash: true

--- a/playbooks/yaml/argocd-apps/prowlarr/kustomization.yaml
+++ b/playbooks/yaml/argocd-apps/prowlarr/kustomization.yaml
@@ -8,3 +8,11 @@ resources:
   - service.yaml
   - deployment.yaml
   - initial-config-configmap.yaml
+
+configMapGenerator:
+  - name: prowlarr-payloads
+    namespace: media
+    files:
+      - rutracker.json=rutracker_payload.json
+    options:
+      disableNameSuffixHash: true

--- a/playbooks/yaml/argocd-apps/prowlarr/kustomization.yaml
+++ b/playbooks/yaml/argocd-apps/prowlarr/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - deployment.yaml
   - initial-config-configmap.yaml
   - bootstrap-scripts-cm.yaml
+  - bootstrap-job.yaml
 
 configMapGenerator:
   - name: prowlarr-payloads

--- a/playbooks/yaml/argocd-apps/prowlarr/myanonamouse_payload.json
+++ b/playbooks/yaml/argocd-apps/prowlarr/myanonamouse_payload.json
@@ -1,0 +1,50 @@
+{
+  "name": "MyAnonamouse",
+  "implementation": "MyAnonamouse",
+  "implementationName": "MyAnonamouse",
+  "infoLink": "https://wiki.servarr.com/prowlarr/supported-indexers#myanonamouse",
+  "configContract": "MyAnonamouseSettings",
+  "enable": true,
+  "redirect": false,
+  "supportsRss": true,
+  "supportsSearch": true,
+  "protocol": "torrent",
+  "priority": 25,
+  "downloadClientId": 0,
+  "appProfileId": 1,
+  "tags": [],
+  "fields": [
+    {
+      "name": "baseUrl",
+      "value": "https://www.myanonamouse.net/"
+    },
+    {
+      "name": "mamId",
+      "value": "MYANONAMOUSE_SESSION_ID"
+    },
+    {
+      "name": "searchType",
+      "value": 0
+    },
+    {
+      "name": "searchInDescription",
+      "value": false
+    },
+    {
+      "name": "searchInSeries",
+      "value": false
+    },
+    {
+      "name": "searchInFilenames",
+      "value": false
+    },
+    {
+      "name": "searchLanguages",
+      "value": []
+    },
+    {
+      "name": "useFreeleechWedge",
+      "value": 0
+    }
+  ]
+}

--- a/playbooks/yaml/argocd-apps/prowlarr/prowlarr-application.yaml
+++ b/playbooks/yaml/argocd-apps/prowlarr/prowlarr-application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.12.0"
+    targetRevision: "feature/prowlarr-indexers-automation"
     path: playbooks/yaml/argocd-apps/prowlarr
   destination:
     server: "https://kubernetes.default.svc"

--- a/playbooks/yaml/argocd-apps/prowlarr/prowlarr-application.yaml
+++ b/playbooks/yaml/argocd-apps/prowlarr/prowlarr-application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "feature/prowlarr-indexers-automation"
+    targetRevision: "v1.13.0"
     path: playbooks/yaml/argocd-apps/prowlarr
   destination:
     server: "https://kubernetes.default.svc"

--- a/playbooks/yaml/argocd-apps/qbittorrent/qbittorrent-application.yaml
+++ b/playbooks/yaml/argocd-apps/qbittorrent/qbittorrent-application.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.12.0"
+    targetRevision: "v1.13.0"
     path: playbooks/yaml/argocd-apps/qbittorrent
   destination:
     server: https://kubernetes.default.svc

--- a/playbooks/yaml/argocd-apps/radarr/radarr-application.yaml
+++ b/playbooks/yaml/argocd-apps/radarr/radarr-application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.12.0"
+    targetRevision: "v1.13.0"
     path: playbooks/yaml/argocd-apps/radarr
   destination:
     server: https://kubernetes.default.svc

--- a/playbooks/yaml/argocd-apps/readarr/readarr-application.yaml
+++ b/playbooks/yaml/argocd-apps/readarr/readarr-application.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.12.0"
+    targetRevision: "v1.13.0"
     path: playbooks/yaml/argocd-apps/readarr
   destination:
     server: https://kubernetes.default.svc

--- a/playbooks/yaml/argocd-apps/redis/redis-application.yaml
+++ b/playbooks/yaml/argocd-apps/redis/redis-application.yaml
@@ -10,7 +10,7 @@ spec:
     namespace: redis
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.12.0"
+    targetRevision: "v1.13.0"
     path: playbooks/yaml/argocd-apps/redis
     kustomize:
   syncPolicy:


### PR DESCRIPTION
This pull request automates the configuration of Prowlarr indexers using a PostSync bootstrap job and secret injection.

It adds Ansible logic to extract required values from the .env file and create a Kubernetes Secret for use by the bootstrap job. The job installs Python dependencies and executes a bootstrap script that configures indexers via the Prowlarr API.

Includes:

    New secrets block in the deploy playbook for loading Prowlarr credentials

    New ConfigMaps for tracker payloads and bootstrap scripts

    New PostSync bootstrap job for indexer setup

    Tracker payloads for Rutracker and MyAnonamouse

    targetRevision bumped to v1.13.0 across all ArgoCD apps

This enables automated, repeatable Prowlarr setup with no manual intervention.