### PR TITLE
readarr+prowlarr: integrate bootstrap + refactor payloads

### DIFF
--- a/playbooks/yaml/argocd-apps/calibre-web/calibre-web-application.yaml
+++ b/playbooks/yaml/argocd-apps/calibre-web/calibre-web-application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.13.0"
+    targetRevision: "v1.14.0"
     path: playbooks/yaml/argocd-apps/calibre-web
   destination:
     server: "https://kubernetes.default.svc"

--- a/playbooks/yaml/argocd-apps/cert-manager/cert-manager-application.yaml
+++ b/playbooks/yaml/argocd-apps/cert-manager/cert-manager-application.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.13.0"
+    targetRevision: "v1.14.0"
     path: playbooks/yaml/argocd-apps/cert-manager
     kustomize:
   destination:

--- a/playbooks/yaml/argocd-apps/external-dns/external-dns-application.yaml
+++ b/playbooks/yaml/argocd-apps/external-dns/external-dns-application.yaml
@@ -13,7 +13,7 @@ spec:
         valueFiles:
           - $values/playbooks/yaml/argocd-apps/external-dns/values.yaml
     - repoURL: https://github.com/kpoxo6op/soyspray.git
-      targetRevision: "v1.13.0"
+      targetRevision: "v1.14.0"
       ref: values
   destination:
     server: https://kubernetes.default.svc

--- a/playbooks/yaml/argocd-apps/immich/immich-application.yaml
+++ b/playbooks/yaml/argocd-apps/immich/immich-application.yaml
@@ -13,7 +13,7 @@ spec:
     namespace: immich
   sources:
     - repoURL: https://github.com/kpoxo6op/soyspray.git
-      targetRevision: "v1.13.0"
+      targetRevision: "v1.14.0"
       path: playbooks/yaml/argocd-apps/immich
       kustomize:
   syncPolicy:

--- a/playbooks/yaml/argocd-apps/longhorn/longhorn-application.yaml
+++ b/playbooks/yaml/argocd-apps/longhorn/longhorn-application.yaml
@@ -8,7 +8,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.13.0"
+    targetRevision: "v1.14.0"
     path: playbooks/yaml/argocd-apps/longhorn
     kustomize:
   destination:

--- a/playbooks/yaml/argocd-apps/pihole-exporter/pihole-exporter-application.yaml
+++ b/playbooks/yaml/argocd-apps/pihole-exporter/pihole-exporter-application.yaml
@@ -8,7 +8,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.13.0"
+    targetRevision: "v1.14.0"
     path: playbooks/yaml/argocd-apps/pihole-exporter
     kustomize:
   destination:

--- a/playbooks/yaml/argocd-apps/pihole/pihole-application.yaml
+++ b/playbooks/yaml/argocd-apps/pihole/pihole-application.yaml
@@ -11,7 +11,7 @@ spec:
     namespace: pihole
   sources:
     - repoURL: "https://github.com/kpoxo6op/soyspray.git"
-      targetRevision: "v1.13.0"
+      targetRevision: "v1.14.0"
       path: playbooks/yaml/argocd-apps/pihole
       kustomize:
   syncPolicy:

--- a/playbooks/yaml/argocd-apps/postgresql/postgresql-application.yaml
+++ b/playbooks/yaml/argocd-apps/postgresql/postgresql-application.yaml
@@ -14,7 +14,7 @@ spec:
     namespace: postgresql
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.13.0"
+    targetRevision: "v1.14.0"
     path: playbooks/yaml/argocd-apps/postgresql
     kustomize:
   syncPolicy:

--- a/playbooks/yaml/argocd-apps/prometheus/prometheus-application.yaml
+++ b/playbooks/yaml/argocd-apps/prometheus/prometheus-application.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.13.0"
+    targetRevision: "v1.14.0"
     path: playbooks/yaml/argocd-apps/prometheus
     kustomize:
       helm:

--- a/playbooks/yaml/argocd-apps/prowlarr/bootstrap-job.yaml
+++ b/playbooks/yaml/argocd-apps/prowlarr/bootstrap-job.yaml
@@ -1,3 +1,4 @@
+# playbooks/yaml/argocd-apps/prowlarr/bootstrap-job.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -7,12 +8,10 @@ metadata:
     app: prowlarr
     component: bootstrap
   annotations:
-    # ArgoCD PostSync Hook - runs after main resources are synced
     argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
-  # Clean up completed jobs after 24 hours
-  ttlSecondsAfterFinished: 86400
+  ttlSecondsAfterFinished: 120
   template:
     metadata:
       labels:
@@ -22,32 +21,15 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: bootstrap
-        # Use Python 3.11 slim image for efficiency
-        image: python:3.11-slim
-
-        # Set working directory
-        workingDir: /app
-
-        # Command to install dependencies and run bootstrap
+        image: alpine/curl:latest
         command:
-        - /bin/bash
+        - /bin/sh
         - -c
         - |
           set -euo pipefail
-          echo "🐍 Setting up Python environment..."
-          # Create home directory for pip user installs
-          mkdir -p /tmp/home/.local
-          export HOME=/tmp/home
-          export PATH="/tmp/home/.local/bin:$PATH"
-          echo "🐍 Installing Python dependencies..."
-          pip install --user --no-cache-dir -r /scripts/requirements.txt
-          echo "🚀 Starting bootstrap script..."
-          python3 /scripts/bootstrap.py
-
-        # Environment variables from secrets
+          apk add --no-cache gettext jq
+          /scripts/bootstrap.sh
         env:
-        - name: HOME
-          value: "/tmp/home"
         - name: PROWLARR_API_KEY
           valueFrom:
             secretKeyRef:
@@ -68,17 +50,13 @@ spec:
             secretKeyRef:
               name: prowlarr-secrets
               key: MYANONAMOUSE_SESSION_ID
-
-        # Resource limits for the bootstrap job
         resources:
           requests:
-            memory: "128Mi"
-            cpu: "100m"
+            memory: "64Mi"
+            cpu: "50m"
           limits:
-            memory: "256Mi"
-            cpu: "500m"
-
-        # Volume mounts
+            memory: "128Mi"
+            cpu: "200m"
         volumeMounts:
         - name: payloads
           mountPath: /payloads
@@ -86,19 +64,14 @@ spec:
         - name: scripts
           mountPath: /scripts
           readOnly: true
-
-        # Security context
         securityContext:
           allowPrivilegeEscalation: false
-          runAsNonRoot: true
-          runAsUser: 1000
-          runAsGroup: 1000
-          readOnlyRootFilesystem: false
+          runAsNonRoot: false
+          runAsUser: 0
+          runAsGroup: 0
           capabilities:
             drop:
             - ALL
-
-      # Volumes
       volumes:
       - name: payloads
         configMap:
@@ -107,4 +80,4 @@ spec:
       - name: scripts
         configMap:
           name: prowlarr-bootstrap-scripts
-          defaultMode: 0755  # Make scripts executable
+          defaultMode: 0755

--- a/playbooks/yaml/argocd-apps/prowlarr/bootstrap-scripts-cm.yaml
+++ b/playbooks/yaml/argocd-apps/prowlarr/bootstrap-scripts-cm.yaml
@@ -1,3 +1,6 @@
+# playbooks/yaml/argocd-apps/prowlarr/bootstrap-scripts-cm.yaml
+# ConfigMap with a single, minimal shell bootstrap script that uses curl + jq
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,476 +9,80 @@ metadata:
   labels:
     app: prowlarr
 data:
-  bootstrap.py: |
-    #!/usr/bin/env python3
-    """
-    =======================================================
-    Prowlarr Tracker Bootstrap Script (Python Edition)
-    =======================================================
-
-    This script imports tracker configurations into Prowlarr.
-    It reads JSON payloads and replaces placeholders with
-    actual credentials from Kubernetes secrets.
-
-    Python advantages used:
-    - Clean exception handling
-    - Rich JSON manipulation
-    - Type hints for clarity
-    - Structured logging
-    - Object-oriented design
-    - Better HTTP client (requests)
-    =======================================================
-    """
-
-    import json
-    import os
-    import sys
-    import time
-    from pathlib import Path
-    from typing import Dict, List, Optional, Tuple
-
-    import requests
-    from requests.adapters import HTTPAdapter
-    from urllib3.util.retry import Retry
-
-
-    class ProwlarrBootstrap:
-        """
-        Main class for bootstrapping Prowlarr tracker configurations.
-
-        This class handles the entire workflow:
-        1. Environment validation
-        2. Prowlarr health checks
-        3. Tracker existence checks
-        4. Credential substitution
-        5. Tracker import via API
-        """
-
-        def __init__(self):
-            # Configuration constants
-            self.PROWLARR_URL = "http://prowlarr.media.svc.cluster.local:9696"
-            self.PAYLOADS_DIR = Path("/payloads")
-            self.MAX_RETRIES = 30
-            self.RETRY_DELAY = 10
-            self.API_TIMEOUT = 30
-
-            # Initialize HTTP session with retry strategy
-            self.session = self._create_http_session()
-
-            # Environment variables (loaded during validation)
-            self.api_key: Optional[str] = None
-            self.rutracker_user: Optional[str] = None
-            self.rutracker_pass: Optional[str] = None
-
-        def _create_http_session(self) -> requests.Session:
-            """Create HTTP session with retry strategy and timeouts."""
-            session = requests.Session()
-
-            # Configure retry strategy
-            retry_strategy = Retry(
-                total=3,
-                backoff_factor=1,
-                status_forcelist=[429, 500, 502, 503, 504],
-            )
-
-            adapter = HTTPAdapter(max_retries=retry_strategy)
-            session.mount("http://", adapter)
-            session.mount("https://", adapter)
-
-            return session
-
-        # =======================================================
-        # Logging Methods (with emojis for visual clarity)
-        # =======================================================
-
-        @staticmethod
-        def log_info(message: str) -> None:
-            """Log informational message."""
-            print(f"ℹ️  {message}")
-
-        @staticmethod
-        def log_success(message: str) -> None:
-            """Log success message."""
-            print(f"✅ {message}")
-
-        @staticmethod
-        def log_error(message: str) -> None:
-            """Log error message to stderr."""
-            print(f"❌ {message}", file=sys.stderr)
-
-        @staticmethod
-        def log_warning(message: str) -> None:
-            """Log warning message."""
-            print(f"⚠️  {message}")
-
-        # =======================================================
-        # Environment & Validation Methods
-        # =======================================================
-
-        def validate_environment(self) -> bool:
-            """
-            Validate all required environment variables are present.
-
-            Returns:
-                bool: True if all required variables are set
-            """
-            self.log_info("Validating environment variables...")
-
-            required_vars = {
-                'PROWLARR_API_KEY': 'api_key',
-                'RUTRACKER_USER': 'rutracker_user',
-                'RUTRACKER_PASS': 'rutracker_pass'
-            }
-
-            missing_vars = []
-
-            for env_var, attr_name in required_vars.items():
-                value = os.getenv(env_var)
-                if not value:
-                    missing_vars.append(env_var)
-                else:
-                    setattr(self, attr_name, value.strip())
-
-            if missing_vars:
-                self.log_error(f"Missing required environment variables: {', '.join(missing_vars)}")
-                return False
-
-            self.log_success("All required environment variables are set")
-            return True
-
-        def validate_payloads_directory(self) -> bool:
-            """
-            Check if payloads directory exists and is accessible.
-
-            Returns:
-                bool: True if directory exists and is readable
-            """
-            if not self.PAYLOADS_DIR.exists():
-                self.log_error(f"Payloads directory not found: {self.PAYLOADS_DIR}")
-                return False
-
-            if not self.PAYLOADS_DIR.is_dir():
-                self.log_error(f"Payloads path is not a directory: {self.PAYLOADS_DIR}")
-                return False
-
-            self.log_success(f"Payloads directory verified: {self.PAYLOADS_DIR}")
-            return True
-
-        # =======================================================
-        # Prowlarr API Methods
-        # =======================================================
-
-        def wait_for_prowlarr_ready(self) -> bool:
-            """
-            Wait for Prowlarr to become ready and responsive.
-
-            Returns:
-                bool: True if Prowlarr becomes ready within retry limit
-            """
-            self.log_info("Waiting for Prowlarr to be ready...")
-
-            headers = {"X-Api-Key": self.api_key}
-
-            for attempt in range(1, self.MAX_RETRIES + 1):
-                try:
-                    response = self.session.get(
-                        f"{self.PROWLARR_URL}/api/v1/system/status",
-                        headers=headers,
-                        timeout=self.API_TIMEOUT
-                    )
-
-                    if response.status_code == 200:
-                        self.log_success("Prowlarr is ready!")
-                        return True
-
-                except requests.exceptions.RequestException as e:
-                    self.log_info(f"Attempt {attempt}/{self.MAX_RETRIES} - Connection failed: {e}")
-
-                if attempt < self.MAX_RETRIES:
-                    self.log_info(f"Waiting {self.RETRY_DELAY}s before next attempt...")
-                    time.sleep(self.RETRY_DELAY)
-
-            self.log_error(f"Prowlarr failed to become ready after {self.MAX_RETRIES} attempts")
-            return False
-
-        def get_existing_trackers(self) -> Optional[List[Dict]]:
-            """
-            Fetch list of existing trackers from Prowlarr.
-
-            Returns:
-                Optional[List[Dict]]: List of existing trackers, or None on error
-            """
-            try:
-                response = self.session.get(
-                    f"{self.PROWLARR_URL}/api/v1/indexer",
-                    headers={"X-Api-Key": self.api_key},
-                    timeout=self.API_TIMEOUT
-                )
-                response.raise_for_status()
-                return response.json()
-
-            except requests.exceptions.RequestException as e:
-                self.log_warning(f"Failed to fetch existing trackers: {e}")
-                return None
-
-        def tracker_exists(self, tracker_name: str) -> bool:
-            """
-            Check if a tracker with the given name already exists.
-
-            Args:
-                tracker_name: Name of the tracker to check
-
-            Returns:
-                bool: True if tracker exists, False otherwise
-            """
-            self.log_info(f"Checking if tracker '{tracker_name}' already exists...")
-
-            existing_trackers = self.get_existing_trackers()
-            if existing_trackers is None:
-                self.log_warning("Could not check existing trackers")
-                return False
-
-            for tracker in existing_trackers:
-                if tracker.get("name") == tracker_name:
-                    self.log_info(f"Tracker '{tracker_name}' already exists")
-                    return True
-
-            self.log_info(f"Tracker '{tracker_name}' does not exist")
-            return False
-
-        def import_tracker(self, payload_data: Dict) -> bool:
-            """
-            Import a tracker configuration via Prowlarr API.
-
-            Args:
-                payload_data: Processed tracker configuration dictionary
-
-            Returns:
-                bool: True if import successful, False otherwise
-            """
-            tracker_name = payload_data.get("name", "Unknown")
-            self.log_info(f"Importing tracker: {tracker_name}")
-
-            try:
-                response = self.session.post(
-                    f"{self.PROWLARR_URL}/api/v1/indexer",
-                    headers={
-                        "Content-Type": "application/json",
-                        "X-Api-Key": self.api_key
-                    },
-                    json=payload_data,
-                    timeout=self.API_TIMEOUT
-                )
-
-                if response.status_code in (200, 201):
-                    self.log_success(f"Successfully imported tracker: {tracker_name}")
-                    return True
-                else:
-                    self.log_error(f"Failed to import {tracker_name} (HTTP {response.status_code})")
-                    try:
-                        error_detail = response.json()
-                        self.log_error(f"Response: {json.dumps(error_detail, indent=2)}")
-                    except json.JSONDecodeError:
-                        self.log_error(f"Response text: {response.text}")
-                    return False
-
-            except requests.exceptions.RequestException as e:
-                self.log_error(f"Failed to send import request for {tracker_name}: {e}")
-                return False
-
-        # =======================================================
-        # Payload Processing Methods
-        # =======================================================
-
-        def load_payload_file(self, file_path: Path) -> Optional[Dict]:
-            """
-            Load and validate JSON payload from file.
-
-            Args:
-                file_path: Path to the JSON payload file
-
-            Returns:
-                Optional[Dict]: Parsed JSON data, or None on error
-            """
-            try:
-                with open(file_path, 'r', encoding='utf-8') as f:
-                    data = json.load(f)
-                return data
-
-            except json.JSONDecodeError as e:
-                self.log_error(f"Invalid JSON in {file_path.name}: {e}")
-                return None
-            except IOError as e:
-                self.log_error(f"Could not read {file_path.name}: {e}")
-                return None
-
-        def substitute_credentials(self, payload_data: Dict) -> Dict:
-            """
-            Replace credential placeholders with actual values.
-
-            Args:
-                payload_data: Original payload data with placeholders
-
-            Returns:
-                Dict: Payload with credentials substituted
-            """
-            # Deep copy to avoid modifying original
-            processed_data = json.loads(json.dumps(payload_data))
-
-            # Find and replace credential fields
-            fields = processed_data.get("fields", [])
-            for field in fields:
-                if field.get("name") == "username":
-                    field["value"] = self.rutracker_user
-                elif field.get("name") == "password":
-                    field["value"] = self.rutracker_pass
-                elif field.get("name") == "mamId":
-                    mam_session_id = os.getenv("MYANONAMOUSE_SESSION_ID")
-                    if mam_session_id:
-                        field["value"] = mam_session_id.strip()
-                    else:
-                        self.log_warning("MYANONAMOUSE_SESSION_ID not found in environment")
-
-            return processed_data
-
-        def process_tracker_file(self, file_path: Path) -> bool:
-            """
-            Process a single tracker payload file.
-
-            Args:
-                file_path: Path to the tracker JSON file
-
-            Returns:
-                bool: True if processing successful, False otherwise
-            """
-            self.log_info(f"Processing payload file: {file_path.name}")
-
-            # Load and validate JSON
-            payload_data = self.load_payload_file(file_path)
-            if payload_data is None:
-                return False
-
-            # Extract tracker name
-            tracker_name = payload_data.get("name")
-            if not tracker_name:
-                self.log_error(f"Could not extract tracker name from {file_path.name}")
-                return False
-
-            self.log_info(f"Processing tracker: {tracker_name}")
-
-            # Check if tracker already exists
-            if self.tracker_exists(tracker_name):
-                self.log_warning(f"Skipping {tracker_name} - already configured")
-                return True  # Not an error, just skipped
-
-            # Substitute credentials
-            self.log_info(f"Substituting credentials for {tracker_name}...")
-            processed_payload = self.substitute_credentials(payload_data)
-
-            # Import the tracker
-            return self.import_tracker(processed_payload)
-
-        def find_payload_files(self) -> List[Path]:
-            """
-            Find all JSON payload files in the payloads directory.
-
-            Returns:
-                List[Path]: List of JSON file paths
-            """
-            json_files = list(self.PAYLOADS_DIR.glob("*.json"))
-
-            if not json_files:
-                self.log_warning("No JSON payload files found")
-                return []
-
-            self.log_info("Found JSON payload files:")
-            for file_path in json_files:
-                self.log_info(f"  - {file_path.name}")
-
-            return json_files
-
-        # =======================================================
-        # Main Execution Method
-        # =======================================================
-
-        def run(self) -> bool:
-            """
-            Main execution method that orchestrates the entire bootstrap process.
-
-            Returns:
-                bool: True if bootstrap completed successfully
-            """
-            self.log_success("🚀 Starting Prowlarr Tracker Bootstrap (Python Edition)")
-            self.log_info(f"📍 Prowlarr URL: {self.PROWLARR_URL}")
-            self.log_info(f"📂 Payloads directory: {self.PAYLOADS_DIR}")
-
-            # Step 1: Validate environment
-            if not self.validate_environment():
-                return False
-
-            # Step 2: Validate payloads directory
-            if not self.validate_payloads_directory():
-                return False
-
-            # Step 3: Wait for Prowlarr to be ready
-            if not self.wait_for_prowlarr_ready():
-                return False
-
-            # Step 4: Find payload files
-            payload_files = self.find_payload_files()
-            if not payload_files:
-                self.log_warning("No payload files to process")
-                return True  # Not an error
-
-            # Step 5: Process each payload file
-            success_count = 0
-            total_count = len(payload_files)
-
-            for i, file_path in enumerate(payload_files, 1):
-                self.log_info("─" * 50)
-                self.log_info(f"Processing file {i}/{total_count}: {file_path.name}")
-
-                if self.process_tracker_file(file_path):
-                    success_count += 1
-                else:
-                    self.log_warning(f"Failed to process {file_path.name}")
-
-            # Step 6: Report results
-            self.log_info("═" * 50)
-            self.log_success("Bootstrap completed!")
-            self.log_success(f"Successfully processed: {success_count}/{total_count} trackers")
-
-            if success_count == total_count:
-                self.log_success("All trackers processed successfully! 🎉")
-                return True
-            else:
-                self.log_warning("Some trackers failed to import")
-                return False
-
-
-    def main() -> int:
-        """
-        Main entry point for the script.
-
-        Returns:
-            int: Exit code (0 for success, 1 for failure)
-        """
-        try:
-            bootstrap = ProwlarrBootstrap()
-            success = bootstrap.run()
-            return 0 if success else 1
-
-        except KeyboardInterrupt:
-            ProwlarrBootstrap.log_warning("Bootstrap interrupted by user")
-            return 1
-        except Exception as e:
-            ProwlarrBootstrap.log_error(f"Unexpected error: {e}")
-            return 1
-
-
-    if __name__ == "__main__":
-        sys.exit(main())
-
-  requirements.txt: |
-    requests==2.31.0
-    urllib3==2.0.7
+  bootstrap.sh: |
+    #!/usr/bin/env sh
+    set -eu
+    API="http://prowlarr.media.svc.cluster.local:9696"
+    mkdir -p /tmp/processed
+
+    echo "=== DEBUG: Environment Variables ==="
+    echo "PROWLARR_API_KEY: ${PROWLARR_API_KEY:+[SET]} ${PROWLARR_API_KEY:-[NOT SET]}"
+    echo "RUTRACKER_USER: ${RUTRACKER_USER:+[SET]} ${RUTRACKER_USER:-[NOT SET]}"
+    echo "RUTRACKER_PASS: ${RUTRACKER_PASS:+[SET - $(echo "$RUTRACKER_PASS" | sed 's/./*/g')]} ${RUTRACKER_PASS:-[NOT SET]}"
+    echo "MYANONAMOUSE_SESSION_ID: ${MYANONAMOUSE_SESSION_ID:+[SET - $(echo "$MYANONAMOUSE_SESSION_ID" | sed 's/./*/g')]} ${MYANONAMOUSE_SESSION_ID:-[NOT SET]}"
+    echo "API Endpoint: $API"
+    echo "====================================="
+
+    echo "=== Processing Rutracker ==="
+    if curl -s -H "X-Api-Key: $PROWLARR_API_KEY" "$API/api/v1/indexer" | jq -e '.[] | select(.name == "RuTracker.org")' > /dev/null 2>&1; then
+      echo "✓ RuTracker already exists, skipping..."
+    else
+      echo "Adding RuTracker..."
+      echo "Original payload:"
+      cat /payloads/rutracker.json
+      echo
+      echo "After envsubst:"
+      envsubst < /payloads/rutracker.json > /tmp/processed/rutracker.json
+      cat /tmp/processed/rutracker.json
+      echo
+      echo "Full curl command:"
+      echo "curl -sS -H \"X-Api-Key: $PROWLARR_API_KEY\" -H \"Content-Type: application/json\" -X POST \"$API/api/v1/indexer\" --data @/tmp/processed/rutracker.json"
+      echo
+      echo "Making API call..."
+      curl -sS -H "X-Api-Key: $PROWLARR_API_KEY" -H "Content-Type: application/json" -X POST "$API/api/v1/indexer" --data @/tmp/processed/rutracker.json
+      echo
+    fi
+    echo "=========================="
+
+    echo "=== Processing MyAnonaMouse ==="
+    if curl -s -H "X-Api-Key: $PROWLARR_API_KEY" "$API/api/v1/indexer" | jq -e '.[] | select(.name == "MyAnonamouse")' > /dev/null 2>&1; then
+      echo "✓ MyAnonaMouse already exists, skipping..."
+    else
+      echo "Adding MyAnonaMouse..."
+      echo "Original payload:"
+      cat /payloads/myanonamouse.json
+      echo
+      echo "After envsubst:"
+      envsubst < /payloads/myanonamouse.json > /tmp/processed/myanonamouse.json
+      cat /tmp/processed/myanonamouse.json
+      echo
+      echo "Full curl command:"
+      echo "curl -sS -H \"X-Api-Key: $PROWLARR_API_KEY\" -H \"Content-Type: application/json\" -X POST \"$API/api/v1/indexer\" --data @/tmp/processed/myanonamouse.json"
+      echo
+      echo "Making API call..."
+      curl -sS -H "X-Api-Key: $PROWLARR_API_KEY" -H "Content-Type: application/json" -X POST "$API/api/v1/indexer" --data @/tmp/processed/myanonamouse.json
+      echo
+    fi
+    echo "==============================="
+
+    echo "=== Processing Readarr ==="
+    if curl -s -H "X-Api-Key: $PROWLARR_API_KEY" "$API/api/v1/applications" | jq -e '.[] | select(.name == "Readarr")' > /dev/null 2>&1; then
+      echo "✓ Readarr already exists, skipping..."
+    else
+      echo "Adding Readarr..."
+      echo "Payload:"
+      cat /payloads/readarr.json
+      echo
+      echo "Full curl command:"
+      echo "curl -sS -H \"X-Api-Key: $PROWLARR_API_KEY\" -H \"Content-Type: application/json\" -X POST \"$API/api/v1/applications\" --data @/payloads/readarr.json"
+      echo
+      echo "Making API call..."
+      curl -sS -H "X-Api-Key: $PROWLARR_API_KEY" -H "Content-Type: application/json" -X POST "$API/api/v1/applications" --data @/payloads/readarr.json
+      echo
+    fi
+    echo "========================"
+
+    echo "=== Bootstrap completed ==="
+    # echo "sleep infinity to recheck the calls"
+    # sleep infinity
+    # kubectl exec -it -n media $(kubectl get pods -n media -l app=prowlarr,component=bootstrap -o jsonpath='{.items[0].metadata.name}') -- sh

--- a/playbooks/yaml/argocd-apps/prowlarr/deployment.yaml
+++ b/playbooks/yaml/argocd-apps/prowlarr/deployment.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       labels:
         app: prowlarr
+        component: main
     spec:
       initContainers:
         - name: seed-config

--- a/playbooks/yaml/argocd-apps/prowlarr/initial-config-configmap.yaml
+++ b/playbooks/yaml/argocd-apps/prowlarr/initial-config-configmap.yaml
@@ -3,6 +3,10 @@ kind: ConfigMap
 metadata:
   name: prowlarr-initial-config
   namespace: media
+  labels:
+    app: prowlarr
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 data:
   config.xml: |-
     <Config>

--- a/playbooks/yaml/argocd-apps/prowlarr/kustomization.yaml
+++ b/playbooks/yaml/argocd-apps/prowlarr/kustomization.yaml
@@ -17,5 +17,6 @@ configMapGenerator:
     files:
       - rutracker.json=rutracker_payload.json
       - myanonamouse.json=myanonamouse_payload.json
+      - readarr.json=readarr_app_payload.json
     options:
       disableNameSuffixHash: true

--- a/playbooks/yaml/argocd-apps/prowlarr/myanonamouse_payload.json
+++ b/playbooks/yaml/argocd-apps/prowlarr/myanonamouse_payload.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "mamId",
-      "value": "MYANONAMOUSE_SESSION_ID"
+      "value": "$MYANONAMOUSE_SESSION_ID"
     },
     {
       "name": "searchType",

--- a/playbooks/yaml/argocd-apps/prowlarr/prowlarr-application.yaml
+++ b/playbooks/yaml/argocd-apps/prowlarr/prowlarr-application.yaml
@@ -9,14 +9,14 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.13.0"
+    targetRevision: "feature/readarr-prowlarr-integration"
     path: playbooks/yaml/argocd-apps/prowlarr
   destination:
     server: "https://kubernetes.default.svc"
     namespace: media
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # automated:
+    #   prune: true
+    #   selfHeal: true
     syncOptions:
       - CreateNamespace=true

--- a/playbooks/yaml/argocd-apps/prowlarr/readarr_app_payload.json
+++ b/playbooks/yaml/argocd-apps/prowlarr/readarr_app_payload.json
@@ -1,0 +1,31 @@
+{
+  "syncLevel": "fullSync",
+  "enable": true,
+  "name": "Readarr",
+  "implementationName": "Readarr",
+  "implementation": "Readarr",
+  "configContract": "ReadarrSettings",
+  "fields": [
+    {
+      "name": "prowlarrUrl",
+      "value": "http://prowlarr.media.svc.cluster.local:9696"
+    },
+    {
+      "name": "baseUrl",
+      "value": "http://readarr.media.svc.cluster.local:8787"
+    },
+    {
+      "name": "apiKey",
+      "value": "a85bb8f2ab19425f9c8c0bbc6f0aa29c"
+    },
+    {
+      "name": "syncCategories",
+      "value": [3030, 7000, 7010, 7020, 7030, 7040, 7050, 7060]
+    },
+    {
+      "name": "syncRejectBlocklistedTorrentHashesWhileGrabbing",
+      "value": false
+    }
+  ],
+  "tags": []
+}

--- a/playbooks/yaml/argocd-apps/prowlarr/rutracker_payload.json
+++ b/playbooks/yaml/argocd-apps/prowlarr/rutracker_payload.json
@@ -20,11 +20,11 @@
     },
     {
       "name": "username",
-      "value": "ACTUAL_USER"
+      "value": "$RUTRACKER_USER"
     },
     {
       "name": "password",
-      "value": "ACTUAL_PASSWORD"
+      "value": "$RUTRACKER_PASS"
     },
     {
       "name": "russianLetters",

--- a/playbooks/yaml/argocd-apps/prowlarr/service.yaml
+++ b/playbooks/yaml/argocd-apps/prowlarr/service.yaml
@@ -17,3 +17,4 @@ spec:
       name: http
   selector:
     app: prowlarr
+    component: main

--- a/playbooks/yaml/argocd-apps/qbittorrent/qbittorrent-application.yaml
+++ b/playbooks/yaml/argocd-apps/qbittorrent/qbittorrent-application.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.13.0"
+    targetRevision: "v1.14.0"
     path: playbooks/yaml/argocd-apps/qbittorrent
   destination:
     server: https://kubernetes.default.svc

--- a/playbooks/yaml/argocd-apps/radarr/radarr-application.yaml
+++ b/playbooks/yaml/argocd-apps/radarr/radarr-application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.13.0"
+    targetRevision: "v1.14.0"
     path: playbooks/yaml/argocd-apps/radarr
   destination:
     server: https://kubernetes.default.svc

--- a/playbooks/yaml/argocd-apps/readarr/readarr-application.yaml
+++ b/playbooks/yaml/argocd-apps/readarr/readarr-application.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.13.0"
+    targetRevision: "feature/readarr-prowlarr-integration"
     path: playbooks/yaml/argocd-apps/readarr
   destination:
     server: https://kubernetes.default.svc

--- a/playbooks/yaml/argocd-apps/redis/redis-application.yaml
+++ b/playbooks/yaml/argocd-apps/redis/redis-application.yaml
@@ -10,7 +10,7 @@ spec:
     namespace: redis
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.13.0"
+    targetRevision: "v1.14.0"
     path: playbooks/yaml/argocd-apps/redis
     kustomize:
   syncPolicy:


### PR DESCRIPTION
This PR introduces a minimal shell-based bootstrap integration for Prowlarr,
streamlining initial tracker and application setup (rutracker, mam, readarr).

Changes:
- Replaces complex Python bootstrap with lightweight curl/jq shell script
- Adds `readarr_app_payload.json` for Prowlarr→Readarr integration
- Refactors JSON payloads to use envsubst-compatible placeholders
- Updates bootstrap job securityContext and resource requests
- Adds `component: main` labels and sync-wave annotations

Also bumps `targetRevision` to `v1.14.0` across non-media ArgoCD apps
to prepare for future unified chart syncs.