### PR TITLE
Automate Readarr <-> qBittorrent integration #35

### DIFF
--- a/playbooks/yaml/argocd-apps/calibre-web/calibre-web-application.yaml
+++ b/playbooks/yaml/argocd-apps/calibre-web/calibre-web-application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.14.0"
+    targetRevision: "v1.15.0"
     path: playbooks/yaml/argocd-apps/calibre-web
   destination:
     server: "https://kubernetes.default.svc"

--- a/playbooks/yaml/argocd-apps/cert-manager/cert-manager-application.yaml
+++ b/playbooks/yaml/argocd-apps/cert-manager/cert-manager-application.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.14.0"
+    targetRevision: "v1.15.0"
     path: playbooks/yaml/argocd-apps/cert-manager
     kustomize:
   destination:

--- a/playbooks/yaml/argocd-apps/external-dns/external-dns-application.yaml
+++ b/playbooks/yaml/argocd-apps/external-dns/external-dns-application.yaml
@@ -13,7 +13,7 @@ spec:
         valueFiles:
           - $values/playbooks/yaml/argocd-apps/external-dns/values.yaml
     - repoURL: https://github.com/kpoxo6op/soyspray.git
-      targetRevision: "v1.14.0"
+      targetRevision: "v1.15.0"
       ref: values
   destination:
     server: https://kubernetes.default.svc

--- a/playbooks/yaml/argocd-apps/immich/immich-application.yaml
+++ b/playbooks/yaml/argocd-apps/immich/immich-application.yaml
@@ -13,7 +13,7 @@ spec:
     namespace: immich
   sources:
     - repoURL: https://github.com/kpoxo6op/soyspray.git
-      targetRevision: "v1.14.0"
+      targetRevision: "v1.15.0"
       path: playbooks/yaml/argocd-apps/immich
       kustomize:
   syncPolicy:

--- a/playbooks/yaml/argocd-apps/longhorn/longhorn-application.yaml
+++ b/playbooks/yaml/argocd-apps/longhorn/longhorn-application.yaml
@@ -8,7 +8,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.14.0"
+    targetRevision: "v1.15.0"
     path: playbooks/yaml/argocd-apps/longhorn
     kustomize:
   destination:

--- a/playbooks/yaml/argocd-apps/pihole-exporter/pihole-exporter-application.yaml
+++ b/playbooks/yaml/argocd-apps/pihole-exporter/pihole-exporter-application.yaml
@@ -8,7 +8,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.14.0"
+    targetRevision: "v1.15.0"
     path: playbooks/yaml/argocd-apps/pihole-exporter
     kustomize:
   destination:

--- a/playbooks/yaml/argocd-apps/pihole/pihole-application.yaml
+++ b/playbooks/yaml/argocd-apps/pihole/pihole-application.yaml
@@ -11,7 +11,7 @@ spec:
     namespace: pihole
   sources:
     - repoURL: "https://github.com/kpoxo6op/soyspray.git"
-      targetRevision: "v1.14.0"
+      targetRevision: "v1.15.0"
       path: playbooks/yaml/argocd-apps/pihole
       kustomize:
   syncPolicy:

--- a/playbooks/yaml/argocd-apps/postgresql/postgresql-application.yaml
+++ b/playbooks/yaml/argocd-apps/postgresql/postgresql-application.yaml
@@ -14,7 +14,7 @@ spec:
     namespace: postgresql
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.14.0"
+    targetRevision: "v1.15.0"
     path: playbooks/yaml/argocd-apps/postgresql
     kustomize:
   syncPolicy:

--- a/playbooks/yaml/argocd-apps/prometheus/prometheus-application.yaml
+++ b/playbooks/yaml/argocd-apps/prometheus/prometheus-application.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.14.0"
+    targetRevision: "v1.15.0"
     path: playbooks/yaml/argocd-apps/prometheus
     kustomize:
       helm:

--- a/playbooks/yaml/argocd-apps/prowlarr/prowlarr-application.yaml
+++ b/playbooks/yaml/argocd-apps/prowlarr/prowlarr-application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "feature/readarr-prowlarr-integration"
+    targetRevision: "v1.15.0"
     path: playbooks/yaml/argocd-apps/prowlarr
   destination:
     server: "https://kubernetes.default.svc"

--- a/playbooks/yaml/argocd-apps/qbittorrent/qbittorrent-application.yaml
+++ b/playbooks/yaml/argocd-apps/qbittorrent/qbittorrent-application.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.14.0"
+    targetRevision: "v1.15.0"
     path: playbooks/yaml/argocd-apps/qbittorrent
   destination:
     server: https://kubernetes.default.svc

--- a/playbooks/yaml/argocd-apps/radarr/radarr-application.yaml
+++ b/playbooks/yaml/argocd-apps/radarr/radarr-application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.14.0"
+    targetRevision: "v1.15.0"
     path: playbooks/yaml/argocd-apps/radarr
   destination:
     server: https://kubernetes.default.svc

--- a/playbooks/yaml/argocd-apps/readarr/README.md
+++ b/playbooks/yaml/argocd-apps/readarr/README.md
@@ -1,11 +1,39 @@
 # Readarr
 
-Readarr manages books in a fashion similar to how Radarr manages movies.
+## Overview
+
+Readarr is a book/audiobook collection manager for Usenet and BitTorrent users. This directory deploys Readarr to the `media` namespace with:
+
+- A `Deployment` for linuxserver/readarr
+- A PVC for `/config` data
+- A LoadBalancer `Service` on `192.168.1.131:8787`
+- **Automated qBittorrent integration** via PostSync bootstrap
 
 ## Access
 
-- LoadBalancer service at `192.168.1.131:8787`
-- Or internally at `readarr.media.svc.cluster.local:8787`
+After ArgoCD sync:
+
+- Visit <http://192.168.1.131:8787/> to access Readarr
+- Or use the internal DNS: `readarr.media.svc.cluster.local:8787`
+
+## Bootstrap Integration
+
+The deployment includes a PostSync job that automatically configures:
+
+- **qBittorrent download client** with hardcoded credentials (admin/123)
+- Host: `qbittorrent.media.svc.cluster.local:8080`
+- Category: `readarr`
+
+The bootstrap script provides full debug output and handles idempotent configuration.
+
+## Manual Verification
+
+Check download clients via API:
+
+```bash
+curl -s -H "X-Api-Key: a85bb8f2ab19425f9c8c0bbc6f0aa29c" \
+  http://192.168.1.131:8787/api/v1/downloadclient | jq '.[] | {id: .id, name: .name, enable: .enable}'
+```
 
 ## Configuration
 

--- a/playbooks/yaml/argocd-apps/readarr/bootstrap-job.yaml
+++ b/playbooks/yaml/argocd-apps/readarr/bootstrap-job.yaml
@@ -1,0 +1,62 @@
+# playbooks/yaml/argocd-apps/readarr/bootstrap-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: readarr-bootstrap
+  namespace: media
+  labels:
+    app: readarr
+    component: bootstrap
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  ttlSecondsAfterFinished: 120
+  template:
+    metadata:
+      labels:
+        app: readarr
+        component: bootstrap
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: bootstrap
+        image: alpine/curl:latest
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -euo pipefail
+          apk add --no-cache jq
+          /scripts/bootstrap.sh
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          limits:
+            memory: "128Mi"
+            cpu: "200m"
+        volumeMounts:
+        - name: payloads
+          mountPath: /payloads
+          readOnly: true
+        - name: scripts
+          mountPath: /scripts
+          readOnly: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: false
+          runAsUser: 0
+          runAsGroup: 0
+          capabilities:
+            drop:
+            - ALL
+      volumes:
+      - name: payloads
+        configMap:
+          name: readarr-payloads
+          defaultMode: 0644
+      - name: scripts
+        configMap:
+          name: readarr-bootstrap-scripts
+          defaultMode: 0755

--- a/playbooks/yaml/argocd-apps/readarr/bootstrap-scripts-cm.yaml
+++ b/playbooks/yaml/argocd-apps/readarr/bootstrap-scripts-cm.yaml
@@ -1,0 +1,58 @@
+# playbooks/yaml/argocd-apps/readarr/bootstrap-scripts-cm.yaml
+# ConfigMap with a single, minimal shell bootstrap script that uses curl + jq
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: readarr-bootstrap-scripts
+  namespace: media
+  labels:
+    app: readarr
+data:
+  bootstrap.sh: |
+    #!/usr/bin/env sh
+    set -eu
+    API="http://readarr.media.svc.cluster.local:8787"
+    API_KEY="a85bb8f2ab19425f9c8c0bbc6f0aa29c"
+
+    echo "=== DEBUG: Readarr qBittorrent Bootstrap ==="
+    echo "API Endpoint: $API"
+    echo "API Key: $API_KEY"
+    echo "============================================="
+
+    echo "=== Processing qBittorrent Download Client ==="
+    echo "Checking if qBittorrent already exists..."
+
+    echo "Full curl command for checking existing clients:"
+    echo "curl -sS -H \"X-Api-Key: $API_KEY\" \"$API/api/v1/downloadclient\""
+    echo
+
+    EXISTING_CLIENTS=$(curl -sS -H "X-Api-Key: $API_KEY" "$API/api/v1/downloadclient")
+    echo "Existing download clients response:"
+    echo "$EXISTING_CLIENTS"
+    echo
+
+    if echo "$EXISTING_CLIENTS" | jq -e '.[] | select(.name == "qBittorrent")' > /dev/null 2>&1; then
+      echo "✓ qBittorrent already exists, skipping..."
+    else
+      echo "Adding qBittorrent download client..."
+      echo "Original payload:"
+      cat /payloads/qbittorrent.json
+      echo
+      echo "Full curl command for adding client:"
+      echo "curl -sS -H \"X-Api-Key: $API_KEY\" -H \"Content-Type: application/json\" -X POST \"$API/api/v1/downloadclient\" --data @/payloads/qbittorrent.json"
+      echo
+      echo "Making API call..."
+      RESPONSE=$(curl -sS -H "X-Api-Key: $API_KEY" -H "Content-Type: application/json" -X POST "$API/api/v1/downloadclient" --data @/payloads/qbittorrent.json)
+      echo "Response:"
+      echo "$RESPONSE"
+      echo
+    fi
+    echo "=============================================="
+
+    echo "=== Final verification ==="
+    echo "All download clients after bootstrap:"
+    curl -sS -H "X-Api-Key: $API_KEY" "$API/api/v1/downloadclient" | jq '.[] | {id: .id, name: .name, enable: .enable}'
+    echo
+
+    echo "=== Bootstrap completed ==="

--- a/playbooks/yaml/argocd-apps/readarr/deployment.yaml
+++ b/playbooks/yaml/argocd-apps/readarr/deployment.yaml
@@ -17,6 +17,7 @@ spec:
     metadata:
       labels:
         app: readarr
+        component: main
     spec:
       initContainers:
         - name: seed-config

--- a/playbooks/yaml/argocd-apps/readarr/kustomization.yaml
+++ b/playbooks/yaml/argocd-apps/readarr/kustomization.yaml
@@ -6,3 +6,13 @@ resources:
   - service.yaml
   - deployment.yaml
   - initial-config-configmap.yaml
+  - bootstrap-scripts-cm.yaml
+  - bootstrap-job.yaml
+
+configMapGenerator:
+  - name: readarr-payloads
+    namespace: media
+    files:
+      - qbittorrent.json=qbittorrent_payload.json
+    options:
+      disableNameSuffixHash: true

--- a/playbooks/yaml/argocd-apps/readarr/qbittorrent_payload.json
+++ b/playbooks/yaml/argocd-apps/readarr/qbittorrent_payload.json
@@ -1,0 +1,61 @@
+{
+  "enable": true,
+  "priority": 1,
+  "removeCompletedDownloads": false,
+  "removeFailedDownloads": true,
+  "name": "qBittorrent",
+  "fields": [
+    {
+      "name": "host",
+      "value": "qbittorrent.media.svc.cluster.local"
+    },
+    {
+      "name": "port",
+      "value": 8080
+    },
+    {
+      "name": "useSsl",
+      "value": false
+    },
+    {
+      "name": "urlBase"
+    },
+    {
+      "name": "username",
+      "value": "admin"
+    },
+    {
+      "name": "password",
+      "value": "123"
+    },
+    {
+      "name": "category",
+      "value": "readarr"
+    },
+    {
+      "name": "recentTvPriority",
+      "value": 0
+    },
+    {
+      "name": "olderTvPriority",
+      "value": 0
+    },
+    {
+      "name": "initialState",
+      "value": 0
+    },
+    {
+      "name": "sequentialOrder",
+      "value": false
+    },
+    {
+      "name": "firstAndLast",
+      "value": false
+    }
+  ],
+  "implementationName": "qBittorrent",
+  "implementation": "QBittorrent",
+  "configContract": "QBittorrentSettings",
+  "infoLink": "https://wiki.servarr.com/readarr/supported#qbittorrent",
+  "tags": []
+}

--- a/playbooks/yaml/argocd-apps/readarr/readarr-application.yaml
+++ b/playbooks/yaml/argocd-apps/readarr/readarr-application.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "feature/readarr-prowlarr-integration"
+    targetRevision: "feature/readarr-qbittorrent-integration"
     path: playbooks/yaml/argocd-apps/readarr
   destination:
     server: https://kubernetes.default.svc

--- a/playbooks/yaml/argocd-apps/readarr/readarr-application.yaml
+++ b/playbooks/yaml/argocd-apps/readarr/readarr-application.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "feature/readarr-qbittorrent-integration"
+    targetRevision: "v1.15.0"
     path: playbooks/yaml/argocd-apps/readarr
   destination:
     server: https://kubernetes.default.svc

--- a/playbooks/yaml/argocd-apps/readarr/service.yaml
+++ b/playbooks/yaml/argocd-apps/readarr/service.yaml
@@ -15,3 +15,4 @@ spec:
       name: http
   selector:
     app: readarr
+    component: main

--- a/playbooks/yaml/argocd-apps/redis/redis-application.yaml
+++ b/playbooks/yaml/argocd-apps/redis/redis-application.yaml
@@ -10,7 +10,7 @@ spec:
     namespace: redis
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.14.0"
+    targetRevision: "v1.15.0"
     path: playbooks/yaml/argocd-apps/redis
     kustomize:
   syncPolicy:


### PR DESCRIPTION
Implements automated qBittorrent download client configuration for Readarr using braindead bootstrap approach.

**Added:**
- qbittorrent_payload.json with hardcoded admin/123 creds  
- bootstrap-scripts-cm.yaml with full debug output, no loops
- bootstrap-job.yaml as PostSync hook
- Updated kustomization.yaml and README.md

**Fixed:**  
- Service selector to target only main pod (component: main)
- Fixes API connectivity issues during bootstrap

**Result:**
- Zero config automation ✅
- Full debug logging ✅  
- Idempotent bootstrap ✅
- GitOps ready ✅

Closes #35