### PR TITLE
Add ingresses for media apps

### DIFF
--- a/playbooks/yaml/argocd-apps/calibre-web/calibre-web-application.yaml
+++ b/playbooks/yaml/argocd-apps/calibre-web/calibre-web-application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.15.1"
+    targetRevision: "v1.15.2"
     path: playbooks/yaml/argocd-apps/calibre-web
   destination:
     server: "https://kubernetes.default.svc"

--- a/playbooks/yaml/argocd-apps/calibre-web/ingress.yaml
+++ b/playbooks/yaml/argocd-apps/calibre-web/ingress.yaml
@@ -1,0 +1,30 @@
+# playbooks/yaml/argocd-apps/calibre-web/ingress.yaml
+# Ingress for Calibre-Web
+# Exposes Calibre-Web UI at https://calibre-web.soyspray.vip
+# Uses the nginx ingress class and prod-cert-tls secret
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: calibre-web-ingress
+  namespace: media
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - calibre-web.soyspray.vip
+      secretName: prod-cert-tls
+  rules:
+    - host: calibre-web.soyspray.vip
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: calibre-web
+                port:
+                  number: 8083
+

--- a/playbooks/yaml/argocd-apps/calibre-web/kustomization.yaml
+++ b/playbooks/yaml/argocd-apps/calibre-web/kustomization.yaml
@@ -6,6 +6,7 @@ kind: Kustomization
 resources:
   - pvc-config.yaml
   - service.yaml
+  - ingress.yaml
   - deployment.yaml
   - job-calibre-web-poststart.yaml
 

--- a/playbooks/yaml/argocd-apps/cert-manager/cert-manager-application.yaml
+++ b/playbooks/yaml/argocd-apps/cert-manager/cert-manager-application.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.15.1"
+    targetRevision: "v1.15.2"
     path: playbooks/yaml/argocd-apps/cert-manager
     kustomize:
   destination:

--- a/playbooks/yaml/argocd-apps/external-dns/external-dns-application.yaml
+++ b/playbooks/yaml/argocd-apps/external-dns/external-dns-application.yaml
@@ -13,7 +13,7 @@ spec:
         valueFiles:
           - $values/playbooks/yaml/argocd-apps/external-dns/values.yaml
     - repoURL: https://github.com/kpoxo6op/soyspray.git
-      targetRevision: "v1.15.1"
+      targetRevision: "v1.15.2"
       ref: values
   destination:
     server: https://kubernetes.default.svc

--- a/playbooks/yaml/argocd-apps/immich/immich-application.yaml
+++ b/playbooks/yaml/argocd-apps/immich/immich-application.yaml
@@ -13,7 +13,7 @@ spec:
     namespace: immich
   sources:
     - repoURL: https://github.com/kpoxo6op/soyspray.git
-      targetRevision: "v1.15.1"readarr-calibre-integration"
+      targetRevision: "v1.15.2"
       path: playbooks/yaml/argocd-apps/immich
       kustomize:
   syncPolicy:

--- a/playbooks/yaml/argocd-apps/longhorn/longhorn-application.yaml
+++ b/playbooks/yaml/argocd-apps/longhorn/longhorn-application.yaml
@@ -8,7 +8,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.15.1"
+    targetRevision: "v1.15.2"
     path: playbooks/yaml/argocd-apps/longhorn
     kustomize:
   destination:

--- a/playbooks/yaml/argocd-apps/pihole-exporter/pihole-exporter-application.yaml
+++ b/playbooks/yaml/argocd-apps/pihole-exporter/pihole-exporter-application.yaml
@@ -8,7 +8,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.15.1"
+    targetRevision: "v1.15.2"
     path: playbooks/yaml/argocd-apps/pihole-exporter
     kustomize:
   destination:

--- a/playbooks/yaml/argocd-apps/pihole/pihole-application.yaml
+++ b/playbooks/yaml/argocd-apps/pihole/pihole-application.yaml
@@ -11,7 +11,7 @@ spec:
     namespace: pihole
   sources:
     - repoURL: "https://github.com/kpoxo6op/soyspray.git"
-      targetRevision: "v1.15.1"
+      targetRevision: "v1.15.2"
       path: playbooks/yaml/argocd-apps/pihole
       kustomize:
   syncPolicy:

--- a/playbooks/yaml/argocd-apps/postgresql/postgresql-application.yaml
+++ b/playbooks/yaml/argocd-apps/postgresql/postgresql-application.yaml
@@ -14,7 +14,7 @@ spec:
     namespace: postgresql
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.15.1"
+    targetRevision: "v1.15.2"
     path: playbooks/yaml/argocd-apps/postgresql
     kustomize:
   syncPolicy:

--- a/playbooks/yaml/argocd-apps/prometheus/prometheus-application.yaml
+++ b/playbooks/yaml/argocd-apps/prometheus/prometheus-application.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.15.1"
+    targetRevision: "v1.15.2"
     path: playbooks/yaml/argocd-apps/prometheus
     kustomize:
       helm:

--- a/playbooks/yaml/argocd-apps/prowlarr/ingress.yaml
+++ b/playbooks/yaml/argocd-apps/prowlarr/ingress.yaml
@@ -1,0 +1,30 @@
+# playbooks/yaml/argocd-apps/prowlarr/ingress.yaml
+# Ingress for Prowlarr
+# Exposes Prowlarr UI at https://prowlarr.soyspray.vip
+# Uses the nginx ingress class and prod-cert-tls secret
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prowlarr-ingress
+  namespace: media
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - prowlarr.soyspray.vip
+      secretName: prod-cert-tls
+  rules:
+    - host: prowlarr.soyspray.vip
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: prowlarr
+                port:
+                  number: 9696
+

--- a/playbooks/yaml/argocd-apps/prowlarr/kustomization.yaml
+++ b/playbooks/yaml/argocd-apps/prowlarr/kustomization.yaml
@@ -6,6 +6,7 @@ kind: Kustomization
 resources:
   - pvc-config.yaml
   - service.yaml
+  - ingress.yaml
   - deployment.yaml
   - initial-config-configmap.yaml
   - bootstrap-scripts-cm.yaml

--- a/playbooks/yaml/argocd-apps/prowlarr/prowlarr-application.yaml
+++ b/playbooks/yaml/argocd-apps/prowlarr/prowlarr-application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.15.1"
+    targetRevision: "v1.15.2"
     path: playbooks/yaml/argocd-apps/prowlarr
   destination:
     server: "https://kubernetes.default.svc"

--- a/playbooks/yaml/argocd-apps/qbittorrent/qbittorrent-application.yaml
+++ b/playbooks/yaml/argocd-apps/qbittorrent/qbittorrent-application.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.15.1"
+    targetRevision: "v1.15.2"
     path: playbooks/yaml/argocd-apps/qbittorrent
   destination:
     server: https://kubernetes.default.svc

--- a/playbooks/yaml/argocd-apps/radarr/radarr-application.yaml
+++ b/playbooks/yaml/argocd-apps/radarr/radarr-application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.15.1"
+    targetRevision: "v1.15.2"
     path: playbooks/yaml/argocd-apps/radarr
   destination:
     server: https://kubernetes.default.svc

--- a/playbooks/yaml/argocd-apps/readarr/ingress.yaml
+++ b/playbooks/yaml/argocd-apps/readarr/ingress.yaml
@@ -1,0 +1,30 @@
+# playbooks/yaml/argocd-apps/readarr/ingress.yaml
+# Ingress for Readarr
+# Exposes Readarr UI at https://readarr.soyspray.vip
+# Uses the nginx ingress class and prod-cert-tls secret
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: readarr-ingress
+  namespace: media
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - readarr.soyspray.vip
+      secretName: prod-cert-tls
+  rules:
+    - host: readarr.soyspray.vip
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: readarr
+                port:
+                  number: 8787
+

--- a/playbooks/yaml/argocd-apps/readarr/kustomization.yaml
+++ b/playbooks/yaml/argocd-apps/readarr/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - pvc-config.yaml
   - service.yaml
+  - ingress.yaml
   - deployment.yaml
   - initial-config-configmap.yaml
   - bootstrap-scripts-cm.yaml

--- a/playbooks/yaml/argocd-apps/readarr/readarr-application.yaml
+++ b/playbooks/yaml/argocd-apps/readarr/readarr-application.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.15.1"
+    targetRevision: "v1.15.2"
     path: playbooks/yaml/argocd-apps/readarr
   destination:
     server: https://kubernetes.default.svc

--- a/playbooks/yaml/argocd-apps/redis/redis-application.yaml
+++ b/playbooks/yaml/argocd-apps/redis/redis-application.yaml
@@ -10,7 +10,7 @@ spec:
     namespace: redis
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.15.1"
+    targetRevision: "v1.15.2"
     path: playbooks/yaml/argocd-apps/redis
     kustomize:
   syncPolicy:


### PR DESCRIPTION
## Summary
- expose calibre-web, prowlarr and readarr via Ingress
- include new ingress resources in their kustomizations
- bump all argocd Application targetRevision to v1.15.2
- fix typo in immich application manifest

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d0ecb4cb8832d80b763da3e92be26