### PR TITLE
qbittorrent: expose fixed peer port 49160, grow downloads PVC to 20 Gi, bump kubespray

### DIFF
--- a/playbooks/yaml/argocd-apps/cert-manager/cert-manager-application.yaml
+++ b/playbooks/yaml/argocd-apps/cert-manager/cert-manager-application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.16.0"
+    targetRevision: "v1.16.1"
     path: playbooks/yaml/argocd-apps/cert-manager
     kustomize:
   destination:

--- a/playbooks/yaml/argocd-apps/dingu/dingu-application.yaml
+++ b/playbooks/yaml/argocd-apps/dingu/dingu-application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "dingu"
+    targetRevision: "v1.16.1"
     path: playbooks/yaml/argocd-apps/dingu
   destination:
     server: https://kubernetes.default.svc

--- a/playbooks/yaml/argocd-apps/external-dns/external-dns-application.yaml
+++ b/playbooks/yaml/argocd-apps/external-dns/external-dns-application.yaml
@@ -15,7 +15,7 @@ spec:
         valueFiles:
           - $values/playbooks/yaml/argocd-apps/external-dns/values.yaml
     - repoURL: https://github.com/kpoxo6op/soyspray.git
-      targetRevision: "v1.16.0"
+      targetRevision: "v1.16.1"
       ref: values
   destination:
     server: https://kubernetes.default.svc

--- a/playbooks/yaml/argocd-apps/immich/immich-application.yaml
+++ b/playbooks/yaml/argocd-apps/immich/immich-application.yaml
@@ -13,7 +13,7 @@ spec:
     namespace: immich
   sources:
     - repoURL: https://github.com/kpoxo6op/soyspray.git
-      targetRevision: "v1.16.0"
+      targetRevision: "v1.16.1"
       path: playbooks/yaml/argocd-apps/immich
       kustomize:
   syncPolicy:

--- a/playbooks/yaml/argocd-apps/longhorn/longhorn-application.yaml
+++ b/playbooks/yaml/argocd-apps/longhorn/longhorn-application.yaml
@@ -10,7 +10,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.16.0"
+    targetRevision: "v1.16.1"
     path: playbooks/yaml/argocd-apps/longhorn
     kustomize:
   destination:

--- a/playbooks/yaml/argocd-apps/pihole-exporter/pihole-exporter-application.yaml
+++ b/playbooks/yaml/argocd-apps/pihole-exporter/pihole-exporter-application.yaml
@@ -10,7 +10,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.16.0"
+    targetRevision: "v1.16.1"
     path: playbooks/yaml/argocd-apps/pihole-exporter
     kustomize:
   destination:

--- a/playbooks/yaml/argocd-apps/pihole/pihole-application.yaml
+++ b/playbooks/yaml/argocd-apps/pihole/pihole-application.yaml
@@ -13,7 +13,7 @@ spec:
     namespace: pihole
   sources:
     - repoURL: "https://github.com/kpoxo6op/soyspray.git"
-      targetRevision: "v1.16.0"
+      targetRevision: "v1.16.1"
       path: playbooks/yaml/argocd-apps/pihole
       kustomize:
   syncPolicy:

--- a/playbooks/yaml/argocd-apps/postgresql/postgresql-application.yaml
+++ b/playbooks/yaml/argocd-apps/postgresql/postgresql-application.yaml
@@ -16,7 +16,7 @@ spec:
     namespace: postgresql
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.16.0"
+    targetRevision: "v1.16.1"
     path: playbooks/yaml/argocd-apps/postgresql
     kustomize:
   syncPolicy:

--- a/playbooks/yaml/argocd-apps/prometheus/prometheus-application.yaml
+++ b/playbooks/yaml/argocd-apps/prometheus/prometheus-application.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.16.0"
+    targetRevision: "v1.16.1"
     path: playbooks/yaml/argocd-apps/prometheus
     kustomize:
       helm:

--- a/playbooks/yaml/argocd-apps/prowlarr/prowlarr-application.yaml
+++ b/playbooks/yaml/argocd-apps/prowlarr/prowlarr-application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.16.0"
+    targetRevision: "v1.16.1"
     path: playbooks/yaml/argocd-apps/prowlarr
   destination:
     server: "https://kubernetes.default.svc"

--- a/playbooks/yaml/argocd-apps/qbittorrent/README.md
+++ b/playbooks/yaml/argocd-apps/qbittorrent/README.md
@@ -1,5 +1,7 @@
 # qBittorrent (Raw K8s Manifests)
 
+Port forwarding was added in the router to the new qBittorrent port.
+
 admin / 123
 
 This folder contains a minimal raw Kubernetes definition of qBittorrent,

--- a/playbooks/yaml/argocd-apps/qbittorrent/configmap.yaml
+++ b/playbooks/yaml/argocd-apps/qbittorrent/configmap.yaml
@@ -13,6 +13,9 @@ data:
     program=
 
     [BitTorrent]
+    Session\AnnounceIP=210.54.32.219
+    Session\AnnounceToAllTrackers=true
+    Session\ReannounceWhenAddressChanged=true
     Session\AddTorrentStopped=false
     Session\DefaultSavePath=/downloads/incoming/books
     Session\Port=49160

--- a/playbooks/yaml/argocd-apps/qbittorrent/pvc-downloads.yaml
+++ b/playbooks/yaml/argocd-apps/qbittorrent/pvc-downloads.yaml
@@ -10,4 +10,4 @@ spec:
   storageClassName: longhorn-rwx
   resources:
     requests:
-      storage: 10Gi
+      storage: 20Gi

--- a/playbooks/yaml/argocd-apps/qbittorrent/qbittorrent-application.yaml
+++ b/playbooks/yaml/argocd-apps/qbittorrent/qbittorrent-application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "qbittorrent-peer-connectivity"
+    targetRevision: "v1.16.1"
     path: playbooks/yaml/argocd-apps/qbittorrent
   destination:
     server: https://kubernetes.default.svc

--- a/playbooks/yaml/argocd-apps/qbittorrent/qbittorrent-application.yaml
+++ b/playbooks/yaml/argocd-apps/qbittorrent/qbittorrent-application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.16.0"
+    targetRevision: "qbittorrent-peer-connectivity"
     path: playbooks/yaml/argocd-apps/qbittorrent
   destination:
     server: https://kubernetes.default.svc

--- a/playbooks/yaml/argocd-apps/qbittorrent/service-peers.yaml
+++ b/playbooks/yaml/argocd-apps/qbittorrent/service-peers.yaml
@@ -1,0 +1,21 @@
+# Dedicated LoadBalancer Service for BitTorrent peer traffic
+apiVersion: v1
+kind: Service
+metadata:
+  name: qbittorrent-peers
+  namespace: media
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 192.168.1.240
+  externalTrafficPolicy: Local
+  ports:
+    - name: peers-tcp
+      port: 49160
+      protocol: TCP
+      targetPort: 49160
+    - name: peers-udp
+      port: 49160
+      protocol: UDP
+      targetPort: 49160
+  selector:
+    app: qbittorrent

--- a/playbooks/yaml/argocd-apps/readarr/readarr-application.yaml
+++ b/playbooks/yaml/argocd-apps/readarr/readarr-application.yaml
@@ -10,7 +10,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/kpoxo6op/soyspray.git
-    targetRevision: "v1.16.0"
+    targetRevision: "v1.16.1"
     path: playbooks/yaml/argocd-apps/readarr
   destination:
     server: https://kubernetes.default.svc

--- a/playbooks/yaml/argocd-apps/redis/redis-application.yaml
+++ b/playbooks/yaml/argocd-apps/redis/redis-application.yaml
@@ -12,7 +12,7 @@ spec:
     namespace: redis
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "v1.16.0"
+    targetRevision: "v1.16.1"
     path: playbooks/yaml/argocd-apps/redis
     kustomize:
   syncPolicy:


### PR DESCRIPTION
This PR completes the “peer-connectivity” rollout for qBittorrent.
Validated end-to-end (router → MetalLB → pod) with live uploads.

What’s inside

- New MetalLB IP pool (in kubespray sub-module)
  - Adds /32 pool torrent → 192.168.1.240
  - ➜ sub-module pointer moves from 8b24951 → 13574a3.
- Dedicated Service qbittorrent-peers
  - LoadBalancer 192.168.1.240, TCP+UDP 49160.
- ConfigMap tweaks
  - Hard-code external announce keys so the tracker always sees
    210.54.32.219:49160.
- PVC resize
  - qbittorrent-downloads RWX volume grows from 10 Gi → 20 Gi.
- ArgoCD app tracks branch qbittorrent-peer-connectivity.
- README note about matching router forward rule.

Why

- Keeps Web-UI on old IP/port while giving peers a stable, routed endpoint.
- Upload path confirmed by tracker (connectable) and by live Ubuntu ISO swarm.
- Extra 10 Gi ensures space for future tests / larger torrents.