### PR TITLE
feat: deploy loki logging stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,17 @@ Run Soyspray Runbook
 ansible-playbook -i kubespray/inventory/soycluster/hosts.yml --become --become-user=root --user ubuntu main.yml --tags argocd,storage
 ansible-playbook -i kubespray/inventory/soycluster/hosts.yml --become --become-user=root --user ubuntu playbooks/hello-soy.yml
 ansible-playbook -i kubespray/inventory/soycluster/hosts.yml --become --become-user=root --user ubuntu playbooks/manage-argocd-apps.yml --tags pihole
+ansible-playbook -i kubespray/inventory/soycluster/hosts.yml --become --become-user=root --user ubuntu playbooks/manage-argocd-apps.yml --tags logging
 ```
+
+## Logging and Alerting
+
+The `logging` tag on `manage-argocd-apps.yml` provisions Grafana Loki backed by
+Longhorn and Grafana Alloy agents. The stack collects pod logs and Kubernetes
+events from every namespace, exposes them in Grafana Explore via an auto-created
+Loki datasource, enforces time-based retention (30 days by default), and ships
+LogQL alert rules to Alertmanager for spikes in error rate, total volume, and
+event storms.
 
 ## Bookmarks
 

--- a/playbooks/manage-argocd-apps.yml
+++ b/playbooks/manage-argocd-apps.yml
@@ -114,6 +114,14 @@
         definition: "{{ lookup('file', playbook_dir + '/yaml/argocd-apps/mysql/mysql-application.yaml') }}"
       tags: mysql
 
+    - name: Apply Logging Stack
+      kubernetes.core.k8s:
+        state: present
+        kubeconfig: "{{ kubeconfig_path }}"
+        namespace: argocd
+        definition: "{{ lookup('file', playbook_dir + '/yaml/argocd-apps/logging/logging-application.yaml') }}"
+      tags: logging
+
     - name: Verify and load Cloudflare token from .env
       block:
         - name: Load CLOUDFLARE_API_TOKEN from .env

--- a/playbooks/yaml/argocd-apps/logging/README.md
+++ b/playbooks/yaml/argocd-apps/logging/README.md
@@ -1,0 +1,3 @@
+# logging
+
+Grafana Loki and Grafana Alloy deployment for cluster-wide log aggregation, query, and alerting.

--- a/playbooks/yaml/argocd-apps/logging/alloy/clusterrole.yaml
+++ b/playbooks/yaml/argocd-apps/logging/alloy/clusterrole.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: grafana-alloy
+  labels:
+    app.kubernetes.io/name: grafana-alloy
+    app.kubernetes.io/part-of: soyspray-observability
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+      - nodes
+      - services
+      - endpoints
+      - events
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+      - cronjobs
+    verbs: ["get", "list", "watch"]

--- a/playbooks/yaml/argocd-apps/logging/alloy/clusterrolebinding.yaml
+++ b/playbooks/yaml/argocd-apps/logging/alloy/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-alloy
+  labels:
+    app.kubernetes.io/name: grafana-alloy
+    app.kubernetes.io/part-of: soyspray-observability
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: grafana-alloy
+subjects:
+  - kind: ServiceAccount
+    name: grafana-alloy
+    namespace: logging

--- a/playbooks/yaml/argocd-apps/logging/alloy/config-events.yaml
+++ b/playbooks/yaml/argocd-apps/logging/alloy/config-events.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-alloy-events
+  namespace: logging
+  labels:
+    app.kubernetes.io/name: grafana-alloy
+    app.kubernetes.io/component: events
+    app.kubernetes.io/part-of: soyspray-observability
+data:
+  config.alloy: |
+    logging {
+      level  = "info"
+      format = "logfmt"
+    }
+
+    kubernetes.events "cluster" {
+      namespaces = []
+    }
+
+    loki.write "cluster" {
+      endpoint {
+        url = "http://loki.logging.svc.cluster.local:3100/loki/api/v1/push"
+      }
+    }
+
+    loki.source.kubernetes_events "events" {
+      events     = kubernetes.events.cluster.receiver
+      job        = "kubernetes-events"
+      forward_to = [loki.process.events.receiver]
+    }
+
+    loki.process "events" {
+      forward_to = [loki.write.cluster.receiver]
+
+      stage.labels {
+        values = {
+          cluster  = "soycluster"
+          log_type = "event"
+        }
+      }
+
+      stage.labelmap {
+        source_labels = ["namespace"]
+        target_label  = "namespace"
+      }
+    }

--- a/playbooks/yaml/argocd-apps/logging/alloy/config-logs.yaml
+++ b/playbooks/yaml/argocd-apps/logging/alloy/config-logs.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-alloy-logs
+  namespace: logging
+  labels:
+    app.kubernetes.io/name: grafana-alloy
+    app.kubernetes.io/component: logs
+    app.kubernetes.io/part-of: soyspray-observability
+data:
+  config.alloy: |
+    logging {
+      level  = "info"
+      format = "logfmt"
+    }
+
+    discovery.kubernetes "pods" {
+      role = "pod"
+    }
+
+    loki.write "cluster" {
+      endpoint {
+        url = "http://loki.logging.svc.cluster.local:3100/loki/api/v1/push"
+      }
+    }
+
+    loki.process "pod_logs" {
+      forward_to = [loki.write.cluster.receiver]
+
+      stage.cri {}
+
+      stage.labels {
+        values = {
+          cluster  = "soycluster"
+          job      = "pod-logs"
+          log_type = "application"
+        }
+      }
+
+      stage.labelmap {
+        source_labels = ["__meta_kubernetes_pod_label_app", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app"
+      }
+
+      stage.labeldrop {
+        values = ["pod_template_hash"]
+      }
+    }
+
+    loki.source.kubernetes "pods" {
+      targets    = discovery.kubernetes.pods.targets
+      forward_to = [loki.process.pod_logs.receiver]
+
+      relabel_rules = <<-EOT
+        rule { action = "labelmap", regex = "__meta_kubernetes_pod_label_(.+)" }
+        rule { action = "labelmap", source_labels = ["__meta_kubernetes_namespace"], target_label = "namespace" }
+        rule { action = "labelmap", source_labels = ["__meta_kubernetes_pod_name"], target_label = "pod" }
+      EOT
+    }

--- a/playbooks/yaml/argocd-apps/logging/alloy/daemonset-logs.yaml
+++ b/playbooks/yaml/argocd-apps/logging/alloy/daemonset-logs.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: grafana-alloy-logs
+  namespace: logging
+  labels:
+    app.kubernetes.io/name: grafana-alloy
+    app.kubernetes.io/component: logs
+    app.kubernetes.io/part-of: soyspray-observability
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana-alloy
+      app.kubernetes.io/component: logs
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana-alloy
+        app.kubernetes.io/component: logs
+        app.kubernetes.io/part-of: soyspray-observability
+    spec:
+      serviceAccountName: grafana-alloy
+      hostPID: false
+      hostNetwork: false
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: grafana-alloy
+          image: grafana/alloy:1.3.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - "run"
+            - "/etc/alloy/config.alloy"
+          env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: varlibdocker
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: varlibcontainerd
+              mountPath: /var/lib/containerd
+              readOnly: true
+            - name: machineid
+              mountPath: /etc/machine-id
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: grafana-alloy-logs
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdocker
+          hostPath:
+            path: /var/lib/docker/containers
+            type: DirectoryOrCreate
+        - name: varlibcontainerd
+          hostPath:
+            path: /var/lib/containerd
+            type: DirectoryOrCreate
+        - name: machineid
+          hostPath:
+            path: /etc/machine-id
+            type: File

--- a/playbooks/yaml/argocd-apps/logging/alloy/deployment-events.yaml
+++ b/playbooks/yaml/argocd-apps/logging/alloy/deployment-events.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana-alloy-events
+  namespace: logging
+  labels:
+    app.kubernetes.io/name: grafana-alloy
+    app.kubernetes.io/component: events
+    app.kubernetes.io/part-of: soyspray-observability
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana-alloy
+      app.kubernetes.io/component: events
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana-alloy
+        app.kubernetes.io/component: events
+        app.kubernetes.io/part-of: soyspray-observability
+    spec:
+      serviceAccountName: grafana-alloy
+      containers:
+        - name: grafana-alloy
+          image: grafana/alloy:1.3.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - "run"
+            - "/etc/alloy/config.alloy"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+      volumes:
+        - name: config
+          configMap:
+            name: grafana-alloy-events
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: grafana-alloy
+                    app.kubernetes.io/component: logs

--- a/playbooks/yaml/argocd-apps/logging/alloy/serviceaccount.yaml
+++ b/playbooks/yaml/argocd-apps/logging/alloy/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana-alloy
+  namespace: logging
+  labels:
+    app.kubernetes.io/name: grafana-alloy
+    app.kubernetes.io/part-of: soyspray-observability

--- a/playbooks/yaml/argocd-apps/logging/kustomization.yaml
+++ b/playbooks/yaml/argocd-apps/logging/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: logging
+
+resources:
+  - namespace.yaml
+  - loki/serviceaccount.yaml
+  - loki/configmap.yaml
+  - loki/rules-configmap.yaml
+  - loki/service.yaml
+  - loki/statefulset.yaml
+  - alloy/serviceaccount.yaml
+  - alloy/clusterrole.yaml
+  - alloy/clusterrolebinding.yaml
+  - alloy/config-logs.yaml
+  - alloy/config-events.yaml
+  - alloy/daemonset-logs.yaml
+  - alloy/deployment-events.yaml

--- a/playbooks/yaml/argocd-apps/logging/logging-application.yaml
+++ b/playbooks/yaml/argocd-apps/logging/logging-application.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: logging
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: "https://github.com/kpoxo6op/soyspray.git"
+    targetRevision: "v1.6.0"
+    path: playbooks/yaml/argocd-apps/logging
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: logging
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - PruneLast=true

--- a/playbooks/yaml/argocd-apps/logging/loki/configmap.yaml
+++ b/playbooks/yaml/argocd-apps/logging/loki/configmap.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+  namespace: logging
+  labels:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: soyspray-observability
+    app.kubernetes.io/version: "3.0.0"
+data:
+  loki.yaml: |
+    auth_enabled: false
+    server:
+      http_listen_port: 3100
+      grpc_listen_port: 9095
+      log_level: info
+    common:
+      path_prefix: /var/loki
+      replication_factor: 1
+      ring:
+        kvstore:
+          store: inmemory
+    storage_config:
+      boltdb_shipper:
+        active_index_directory: /var/loki/index
+        cache_location: /var/loki/cache
+        shared_store: filesystem
+      filesystem:
+        directory: /var/loki/chunks
+    schema_config:
+      configs:
+        - from: 2024-01-01
+          store: boltdb-shipper
+          object_store: filesystem
+          schema: v13
+          index:
+            prefix: loki_index_
+            period: 24h
+    ruler:
+      alertmanager_url: http://prometheus-kube-prometheus-alertmanager.monitoring.svc:9093
+      evaluation_interval: 1m
+      poll_interval: 30s
+      ring:
+        kvstore:
+          store: inmemory
+      rule_path: /etc/loki/rules
+      storage:
+        type: local
+        local:
+          directory: /etc/loki/rules
+    compactor:
+      working_directory: /var/loki/compactor
+      shared_store: filesystem
+      retention_enabled: true
+    limits_config:
+      retention_period: 720h
+      reject_old_samples: true
+      reject_old_samples_max_age: 744h
+      max_cache_freshness_per_query: 10m
+      max_global_streams_per_user: 15000
+    chunk_store_config:
+      max_look_back_period: 720h
+    table_manager:
+      retention_deletes_enabled: true
+      retention_period: 720h
+    analytics:
+      reporting_enabled: false

--- a/playbooks/yaml/argocd-apps/logging/loki/rules-configmap.yaml
+++ b/playbooks/yaml/argocd-apps/logging/loki/rules-configmap.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-alert-rules
+  namespace: logging
+  labels:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/component: ruler
+    app.kubernetes.io/part-of: soyspray-observability
+data:
+  alerts.yaml: |
+    groups:
+      - name: loki-log-slo
+        rules:
+          - alert: LokiHighErrorRate
+            expr: |
+              sum by (namespace, app, job) (
+                rate({log_type="application"} |= "(?i)error" [5m])
+              ) > 0.5
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              summary: "High log error rate for {{ $labels.app | default $labels.job }} in {{ $labels.namespace }}"
+              description: |
+                Error log throughput has remained above 0.5 lines/sec for 10 minutes.
+                Inspect offending workload in namespace {{ $labels.namespace }}.
+          - alert: LokiExcessiveLogVolume
+            expr: |
+              sum by (namespace) (
+                rate({log_type="application"}[1m])
+              ) > 400
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "High log volume in namespace {{ $labels.namespace }}"
+              description: |
+                Namespace {{ $labels.namespace }} has sustained more than 400 log lines per second.
+                Check for noisy workloads to avoid saturating Loki.
+          - alert: KubernetesEventStorm
+            expr: |
+              sum by (namespace) (
+                rate({log_type="event"}[1m])
+              ) > 15
+            for: 3m
+            labels:
+              severity: critical
+            annotations:
+              summary: "Kubernetes event storm in namespace {{ $labels.namespace }}"
+              description: |
+                Kubernetes events for namespace {{ $labels.namespace }} exceeded 15 per second.
+                Investigate failing controllers or crash loops.

--- a/playbooks/yaml/argocd-apps/logging/loki/service.yaml
+++ b/playbooks/yaml/argocd-apps/logging/loki/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  namespace: logging
+  labels:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: soyspray-observability
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 3100
+      targetPort: 3100
+    - name: grpc
+      port: 9095
+      targetPort: 9095
+  selector:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/component: backend

--- a/playbooks/yaml/argocd-apps/logging/loki/serviceaccount.yaml
+++ b/playbooks/yaml/argocd-apps/logging/loki/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loki
+  namespace: logging
+  labels:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: soyspray-observability

--- a/playbooks/yaml/argocd-apps/logging/loki/statefulset.yaml
+++ b/playbooks/yaml/argocd-apps/logging/loki/statefulset.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: loki
+  namespace: logging
+  labels:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: soyspray-observability
+spec:
+  serviceName: loki
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/component: backend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/component: backend
+        app.kubernetes.io/part-of: soyspray-observability
+    spec:
+      serviceAccountName: loki
+      securityContext:
+        fsGroup: 10001
+      containers:
+        - name: loki
+          image: grafana/loki:3.0.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-config.file=/etc/loki/config/loki.yaml"
+            - "-target=all"
+          ports:
+            - name: http
+              containerPort: 3100
+            - name: grpc
+              containerPort: 9095
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 2000m
+              memory: 4Gi
+          volumeMounts:
+            - name: loki-config
+              mountPath: /etc/loki/config
+            - name: loki-rules
+              mountPath: /etc/loki/rules
+            - name: data
+              mountPath: /var/loki
+      volumes:
+        - name: loki-config
+          configMap:
+            name: loki-config
+            items:
+              - key: loki.yaml
+                path: loki.yaml
+        - name: loki-rules
+          configMap:
+            name: loki-alert-rules
+            items:
+              - key: alerts.yaml
+                path: alerts.yaml
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          app.kubernetes.io/name: loki
+          app.kubernetes.io/component: backend
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: longhorn
+        resources:
+          requests:
+            storage: 50Gi

--- a/playbooks/yaml/argocd-apps/logging/namespace.yaml
+++ b/playbooks/yaml/argocd-apps/logging/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: logging
+  labels:
+    app.kubernetes.io/part-of: soyspray-observability
+    pod-security.kubernetes.io/enforce: privileged

--- a/playbooks/yaml/argocd-apps/prometheus/values.yaml
+++ b/playbooks/yaml/argocd-apps/prometheus/values.yaml
@@ -37,6 +37,13 @@ grafana:
     date_formats:
       default_timezone: "Pacific/Auckland"
   defaultDashboardsTimezone: "Pacific/Auckland"
+  additionalDataSources:
+    - name: Loki
+      type: loki
+      access: proxy
+      url: http://loki.logging.svc.cluster.local:3100
+      jsonData:
+        maxLines: 2000
   sidecar:
     dashboards:
       enabled: true


### PR DESCRIPTION
## Summary
- add an Argo CD application that deploys Grafana Loki with persistent storage, retention, and LogQL alert rules routed to Alertmanager
- ship Grafana Alloy agents and RBAC to gather pod logs and Kubernetes events across the cluster
- register a Loki data source in Grafana and document the new logging tag in the runbook

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ed6af831f4832da2cd0467085b273f