### PR TITLE
Fix CNPG Immich DB bootstrap configuration

### DIFF
--- a/playbooks/yaml/argocd-apps/cnpg/immich-db/overlays/initdb/bootstrap-initdb-patch.yaml
+++ b/playbooks/yaml/argocd-apps/cnpg/immich-db/overlays/initdb/bootstrap-initdb-patch.yaml
@@ -10,11 +10,10 @@ spec:
       owner: immich
       secret:
         name: immich-app-secret
-      postInitSQL:
-        - CREATE EXTENSION cube;
-        - CREATE EXTENSION earthdistance;
+      postInitApplicationSQL:
+        - CREATE EXTENSION IF NOT EXISTS cube;
+        - CREATE EXTENSION IF NOT EXISTS earthdistance;
         - CREATE EXTENSION IF NOT EXISTS vectors;
-        - ALTER DATABASE immich SET search_path TO "$user", public, vectors;
         - ALTER SCHEMA vectors OWNER TO immich;
-        - GRANT SELECT ON pg_vector_index_stat TO immich;
+        - ALTER DATABASE immich SET search_path TO "$user", public, vectors;
 


### PR DESCRIPTION
Fixes the CNPG Immich database bootstrap configuration to properly
create extensions in the application database context.

Changes:
- Move extension creation from postInitSQL to postInitApplicationSQL
  to ensure extensions are created in the immich database context
- Remove non-existent pg_vector_index_stat grant (pgvecto.rs doesn't
  have this view, it's specific to pgvector)
- Fix ALTER DATABASE command order to run after database creation
- Add IF NOT EXISTS to extension creation for idempotency

This resolves initialization errors where extensions were being
created in the wrong database context and non-existent views were
being referenced.