### PR TITLE
Add Prometheus alert for cert-manager certificate expiry (10 days)

### DIFF
--- a/playbooks/argocd/applications/observability/prometheus/alerts/cert-expiry.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/alerts/cert-expiry.yaml
@@ -1,0 +1,23 @@
+# playbooks/argocd/applications/observability/prometheus/alerts/cert-expiry.yaml
+# Alert when cert-manager certificates are within 10 days of expiry
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cert-expiry
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: cert-expiry
+      rules:
+        - alert: CertificateExpiringSoon
+          expr: |
+            (certmanager_certificate_expiration_timestamp_seconds - time())
+              < (10 * 24 * 60 * 60)
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Certificate expiring within 10 days"
+            description: "Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} expires in less than 10 days."

--- a/playbooks/argocd/applications/observability/prometheus/kustomization.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/kustomization.yaml
@@ -60,3 +60,4 @@ configMapGenerator:
 
 resources:
   - alerts/backups-essential.yaml
+  - alerts/cert-expiry.yaml


### PR DESCRIPTION
### Motivation
- Notify before TLS certificates expire by adding a Prometheus alert that fires when cert-manager-managed certificates are within 10 days of expiration, and no specialized skills were required to implement this change.

### Description
- Added `playbooks/argocd/applications/observability/prometheus/alerts/cert-expiry.yaml` which defines a `PrometheusRule` named `CertificateExpiringSoon` that uses `certmanager_certificate_expiration_timestamp_seconds - time() < (10 * 24 * 60 * 60)` with `for: 15m` and `severity: warning`, and updated `playbooks/argocd/applications/observability/prometheus/kustomization.yaml` to include the new alert in the resources.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d8f1faad0832db25cbc64182dec0b)