### PR TITLE
Fix secret-reflector RBAC configmaps; raise observability CPU limits

### DIFF
--- a/playbooks/argocd/applications/infrastructure/cert-manager/reflector.yaml
+++ b/playbooks/argocd/applications/infrastructure/cert-manager/reflector.yaml
@@ -12,6 +12,7 @@ rules:
   - apiGroups: [""]
     resources:
       - secrets
+      - configmaps
       - namespaces
     verbs:
       - get
@@ -20,6 +21,7 @@ rules:
   - apiGroups: [""]
     resources:
       - secrets
+      - configmaps
     verbs:
       - create
       - update

--- a/playbooks/argocd/applications/observability/alloy-loki-manual/alloy-daemonset.yaml
+++ b/playbooks/argocd/applications/observability/alloy-loki-manual/alloy-daemonset.yaml
@@ -58,7 +58,7 @@ spec:
               cpu: 75m
               memory: 128Mi
             limits:
-              cpu: 250m
+              cpu: 500m
               memory: 256Mi
           volumeMounts:
             - name: config

--- a/playbooks/argocd/applications/observability/prometheus/values.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/values.yaml
@@ -228,7 +228,7 @@ prometheus-node-exporter:
       cpu: 50m
       memory: 64Mi
     limits:
-      cpu: 100m
+      cpu: 200m
       memory: 128Mi
 
 kube-state-metrics:


### PR DESCRIPTION
### Why

We got new CPU throttling alerts for `monitoring/alloy` and `monitoring/node-exporter`.
Investigation shows `cert-manager/secret-reflector` is in a tight error loop with repeated `403 Forbidden` while trying to watch cluster-scoped ConfigMaps (missing RBAC).
This drives high CPU (~1.3 cores) and log spam, which in turn pushes Alloy to its CPU limit (250m) and triggers throttling.

### Changes

- Grant `secret-reflector` RBAC for ConfigMaps (get/list/watch + create/update/patch) so it stops faulting on ConfigMap watches.
- Increase Alloy CPU limit from 250m -> 500m to give headroom when log volume spikes.
- Increase node-exporter CPU limit from 100m -> 200m to reduce burst throttling alerts.
