### PR TITLE
OpenClaw runbook consolidation: single-command install/remove and tools entrypoints

### DIFF
--- a/playbooks/operations/README.md
+++ b/playbooks/operations/README.md
@@ -26,9 +26,18 @@ Storage initialization and management playbooks.
 - initialize-longhorn-storage.yml - Initialize Longhorn storage system
 
 ### security/
-Security and certificate management playbooks.
+Security playbooks.
 
 - sync-certificates.yml - Synchronize TLS certificates across namespaces
+
+### openclaw/
+OpenClaw install, runtime, and webhook automation runbooks.
+
+- openclaw-install.yml - one-command bootstrap for host, dependencies, baseline config, kubeconfig, and gateway autostart
+- openclaw-remove.yml - one-command teardown (autostart disabled, configs/kubeconfig/host removed)
+- openclaw-enable-tools.yml - enable optional tool capabilities (`file`, `exec`, `browser`) in one run
+- openclaw-disable-tools.yml - disable optional tool capabilities (`browser`, `exec`, `file`) in one run
+- (legacy single-purpose runbooks available under `openclaw/` for direct invocation)
 
 ### examples/
 Example and utility playbooks.
@@ -52,5 +61,3 @@ Playbooks use `verb-subject.yml` format:
 - restart-node.yml
 - set-node-labels.yml
 - initialize-longhorn-storage.yml
-
-

--- a/playbooks/operations/openclaw/README.md
+++ b/playbooks/operations/openclaw/README.md
@@ -1,0 +1,40 @@
+# OpenClaw Operations
+
+Runbooks for OpenClaw installation, runtime control, and Gmail/webhook integration.
+
+## Canonical entrypoints
+
+- `openclaw-install.yml` - one-command bootstrap: preflight → host/dependency install → baseline config → kubeconfig → enable gateway boot-start → final status
+- `openclaw-remove.yml` - one-command teardown: disable boot-start → remove install-mode config → remove kubeconfig → remove dependencies → remove host/user and service
+- `openclaw-enable-tools.yml` - enable optional tool capabilities in one pass (`file`, `exec`, `browser`)
+- `openclaw-disable-tools.yml` - disable optional tool capabilities in one pass (`browser`, `exec`, `file`)
+
+Use tags to narrow a tool pass:
+
+- `-t openclaw-tools-file` for `group:fs`
+- `-t openclaw-tools-exec` for `exec`
+- `-t openclaw-tools-browser` for `browser`/Playwright stack
+
+## Legacy one-purpose playbooks
+
+Kept for direct targeting and rollback scripting:
+
+- `audit-openclaw-security.yml`
+- `configure-openclaw-exec-tool.yml`
+- `configure-openclaw-file-tool.yml`
+- `configure-openclaw-full-web-browsing.yml`
+- `configure-openclaw-installation-mode.yml`
+- `configure-openclaw-kubeconfig.yml`
+- `disable-openclaw-exec-tool.yml`
+- `disable-openclaw-file-tool.yml`
+- `disable-openclaw-full-web-browsing.yml`
+- `disable-openclaw-gateway-autostart.yml`
+- `enable-openclaw-gateway-autostart.yml`
+- `install-openclaw-dependencies.yml`
+- `install-openclaw-host.yml`
+- `remove-openclaw-dependencies.yml`
+- `remove-openclaw-host.yml`
+- `remove-openclaw-installation-mode.yml`
+- `remove-openclaw-kubeconfig.yml`
+- `show-openclaw-installation-mode-status.yml`
+- `show-openclaw-preflight.yml`

--- a/playbooks/operations/openclaw/audit-openclaw-security.yml
+++ b/playbooks/operations/openclaw/audit-openclaw-security.yml
@@ -1,0 +1,59 @@
+---
+# Playbook to run OpenClaw security audit as the dedicated service account
+
+- name: Common tasks for every playbook
+  import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+
+- name: Run OpenClaw security audit
+  hosts: kube_control_plane[0]
+  become: true
+  vars:
+    openclaw_user: openclaw
+    openclaw_apply_fixes: false
+  pre_tasks:
+    - name: Check whether openclaw user exists
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ openclaw_user }}"
+        fail_key: false
+      register: openclaw_passwd
+
+    - name: Set user existence fact
+      ansible.builtin.set_fact:
+        openclaw_user_exists: >-
+          {{
+            openclaw_passwd.ansible_facts.getent_passwd is defined and
+            openclaw_user in openclaw_passwd.ansible_facts.getent_passwd
+          }}
+
+    - name: Fail when openclaw user is missing
+      ansible.builtin.fail:
+        msg: "openclaw user does not exist. Run install-openclaw-host.yml first."
+      when: not openclaw_user_exists
+  tasks:
+    - name: Run deep OpenClaw security audit
+      ansible.builtin.command: "runuser -l {{ openclaw_user }} -c 'openclaw security audit --deep'"
+      register: openclaw_audit_deep_before
+      changed_when: false
+      failed_when: false
+
+    - name: Apply OpenClaw security audit fixes
+      ansible.builtin.command: "runuser -l {{ openclaw_user }} -c 'openclaw security audit --fix'"
+      register: openclaw_audit_fix
+      changed_when: openclaw_audit_fix.rc == 0
+      failed_when: false
+      when: openclaw_apply_fixes | bool
+
+    - name: Run deep OpenClaw security audit after fixes
+      ansible.builtin.command: "runuser -l {{ openclaw_user }} -c 'openclaw security audit --deep'"
+      register: openclaw_audit_deep_after
+      changed_when: false
+      failed_when: false
+      when: openclaw_apply_fixes | bool
+
+    - name: Show audit command return codes
+      ansible.builtin.debug:
+        msg:
+          - "deep audit rc(before): {{ openclaw_audit_deep_before.rc }}"
+          - "fix rc: {{ (openclaw_audit_fix.rc if (openclaw_apply_fixes | bool) else 'skipped') }}"
+          - "deep audit rc(after): {{ (openclaw_audit_deep_after.rc if (openclaw_apply_fixes | bool) else 'skipped') }}"

--- a/playbooks/operations/openclaw/configure-openclaw-exec-tool.yml
+++ b/playbooks/operations/openclaw/configure-openclaw-exec-tool.yml
@@ -1,0 +1,148 @@
+---
+# Playbook to enable exec tooling for OpenClaw
+
+- name: Common tasks for every playbook
+  import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+
+- name: Enable OpenClaw exec tooling
+  hosts: kube_control_plane[0]
+  become: true
+  vars:
+    openclaw_user: openclaw
+    openclaw_home: "/home/{{ openclaw_user }}"
+    openclaw_config_file: "{{ openclaw_home }}/.openclaw/openclaw.json"
+    openclaw_service_name: openclaw-gateway
+    openclaw_service_unit_file: "/etc/systemd/system/{{ openclaw_service_name }}.service"
+    openclaw_agent_id: "main"
+    openclaw_exec_tool_name: "exec"
+  pre_tasks:
+    - name: Check whether openclaw user exists
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ openclaw_user }}"
+        fail_key: false
+      register: openclaw_passwd
+
+    - name: Set user existence fact
+      ansible.builtin.set_fact:
+        openclaw_user_exists: >-
+          {{
+            openclaw_passwd.ansible_facts.getent_passwd is defined and
+            openclaw_user in openclaw_passwd.ansible_facts.getent_passwd
+          }}
+
+    - name: Skip gracefully when openclaw user missing
+      ansible.builtin.fail:
+        msg: "openclaw user does not exist. No exec policy changes applied."
+      when: not openclaw_user_exists
+
+    - name: Check whether OpenClaw config exists
+      ansible.builtin.stat:
+        path: "{{ openclaw_config_file }}"
+      register: openclaw_config_stat
+
+    - name: Skip gracefully when config is missing
+      ansible.builtin.fail:
+        msg: "OpenClaw config not found at {{ openclaw_config_file }}. Run configure-openclaw-installation-mode.yml first."
+      when: not openclaw_config_stat.stat.exists
+  tasks:
+    - name: Read current OpenClaw config
+      ansible.builtin.slurp:
+        path: "{{ openclaw_config_file }}"
+      register: openclaw_config_raw
+
+    - name: Parse OpenClaw config
+      ansible.builtin.set_fact:
+        openclaw_config_json: "{{ openclaw_config_raw.content | b64decode | from_json }}"
+
+    - name: Remove exec from deny list
+      ansible.builtin.set_fact:
+        openclaw_tools: "{{ (openclaw_config_json.tools | default({})) | combine({
+          'deny': ((openclaw_config_json.tools.deny | default([]))
+            | reject('equalto', 'exec')
+            | list)
+        }, recursive=True) }}"
+
+    - name: Merge updated tool policy
+      ansible.builtin.set_fact:
+        openclaw_config_json_updated: "{{ openclaw_config_json | combine({
+          'tools': openclaw_tools
+        }, recursive=True) }}"
+
+    - name: Persist base tool policy
+      ansible.builtin.copy:
+        dest: "{{ openclaw_config_file }}"
+        owner: "{{ openclaw_user }}"
+        group: "{{ openclaw_user }}"
+        mode: "0600"
+        content: "{{ openclaw_config_json_updated | to_nice_json }}"
+
+    - name: Ensure exec is allowlisted for main agent
+      ansible.builtin.shell: |
+        python3 - <<'PY'
+        import json
+
+        config_path = '{{ openclaw_config_file }}'
+        agent_id = '{{ openclaw_agent_id }}'
+        tool_name = '{{ openclaw_exec_tool_name }}'
+
+        with open(config_path, 'r', encoding='utf-8') as f:
+            cfg = json.load(f)
+
+        agents_block = cfg.get('agents') or {}
+        agents = agents_block.get('list')
+        if not isinstance(agents, list):
+            agents = []
+
+        updated = False
+        for agent in agents:
+            if not isinstance(agent, dict) or agent.get('id') != agent_id:
+                continue
+            tools = agent.setdefault('tools', {})
+            allow = tools.get('allow')
+            if not isinstance(allow, list):
+                allow = []
+            if tool_name not in allow:
+                allow.append(tool_name)
+            tools['allow'] = sorted(dict.fromkeys(allow))
+            agent['tools'] = tools
+            updated = True
+            break
+
+        if not updated:
+            agents.append({'id': agent_id, 'tools': {'allow': [tool_name]}})
+
+        agents_block['list'] = agents
+        cfg['agents'] = agents_block
+
+        with open(config_path, 'w', encoding='utf-8') as f:
+            json.dump(cfg, f, indent=2)
+            f.write('\n')
+        PY
+      changed_when: true
+
+    - name: Check whether OpenClaw systemd unit exists
+      ansible.builtin.stat:
+        path: "{{ openclaw_service_unit_file }}"
+      register: openclaw_systemd_unit
+
+    - name: Restart OpenClaw gateway (systemd)
+      ansible.builtin.systemd:
+        name: "{{ openclaw_service_name }}.service"
+        state: restarted
+      when: openclaw_systemd_unit.stat.exists
+      failed_when: false
+
+    - name: Restart OpenClaw gateway (user service fallback)
+      ansible.builtin.command: "runuser -l {{ openclaw_user }} -c 'systemctl --user restart {{ openclaw_service_name }}'"
+      register: openclaw_gateway_restart_fallback
+      changed_when: openclaw_gateway_restart_fallback.rc == 0
+      failed_when: false
+      when: not openclaw_systemd_unit.stat.exists
+
+    - name: Show runbook summary
+      ansible.builtin.debug:
+        msg:
+          - "Removed 'exec' from tools.deny"
+          - "Added '{{ openclaw_exec_tool_name }}' to main agent allowlist"
+          - "OpenClaw gateway restart attempted"

--- a/playbooks/operations/openclaw/configure-openclaw-file-tool.yml
+++ b/playbooks/operations/openclaw/configure-openclaw-file-tool.yml
@@ -1,0 +1,148 @@
+---
+# Playbook to enable file-system tools for OpenClaw
+
+- name: Common tasks for every playbook
+  import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+
+- name: Enable OpenClaw file-system tooling
+  hosts: kube_control_plane[0]
+  become: true
+  vars:
+    openclaw_user: openclaw
+    openclaw_home: "/home/{{ openclaw_user }}"
+    openclaw_config_file: "{{ openclaw_home }}/.openclaw/openclaw.json"
+    openclaw_service_name: openclaw-gateway
+    openclaw_service_unit_file: "/etc/systemd/system/{{ openclaw_service_name }}.service"
+    openclaw_agent_id: "main"
+    openclaw_file_tool_name: "group:fs"
+  pre_tasks:
+    - name: Check whether openclaw user exists
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ openclaw_user }}"
+        fail_key: false
+      register: openclaw_passwd
+
+    - name: Set user existence fact
+      ansible.builtin.set_fact:
+        openclaw_user_exists: >-
+          {{
+            openclaw_passwd.ansible_facts.getent_passwd is defined and
+            openclaw_user in openclaw_passwd.ansible_facts.getent_passwd
+          }}
+
+    - name: Skip gracefully when openclaw user missing
+      ansible.builtin.fail:
+        msg: "openclaw user does not exist. No file-tool policy changes applied."
+      when: not openclaw_user_exists
+
+    - name: Check whether OpenClaw config exists
+      ansible.builtin.stat:
+        path: "{{ openclaw_config_file }}"
+      register: openclaw_config_stat
+
+    - name: Skip gracefully when config is missing
+      ansible.builtin.fail:
+        msg: "OpenClaw config not found at {{ openclaw_config_file }}. Run configure-openclaw-installation-mode.yml first."
+      when: not openclaw_config_stat.stat.exists
+  tasks:
+    - name: Read current OpenClaw config
+      ansible.builtin.slurp:
+        path: "{{ openclaw_config_file }}"
+      register: openclaw_config_raw
+
+    - name: Parse OpenClaw config
+      ansible.builtin.set_fact:
+        openclaw_config_json: "{{ openclaw_config_raw.content | b64decode | from_json }}"
+
+    - name: Remove filesystem deny group
+      ansible.builtin.set_fact:
+        openclaw_tools: "{{ (openclaw_config_json.tools | default({})) | combine({
+          'deny': ((openclaw_config_json.tools.deny | default([]))
+            | reject('equalto', 'group:fs')
+            | list)
+        }, recursive=True) }}"
+
+    - name: Merge updated tool policy
+      ansible.builtin.set_fact:
+        openclaw_config_json_updated: "{{ openclaw_config_json | combine({
+          'tools': openclaw_tools
+        }, recursive=True) }}"
+
+    - name: Persist base tool policy
+      ansible.builtin.copy:
+        dest: "{{ openclaw_config_file }}"
+        owner: "{{ openclaw_user }}"
+        group: "{{ openclaw_user }}"
+        mode: "0600"
+        content: "{{ openclaw_config_json_updated | to_nice_json }}"
+
+    - name: Ensure file tool is allowlisted for main agent
+      ansible.builtin.shell: |
+        python3 - <<'PY'
+        import json
+
+        config_path = '{{ openclaw_config_file }}'
+        agent_id = '{{ openclaw_agent_id }}'
+        tool_name = '{{ openclaw_file_tool_name }}'
+
+        with open(config_path, 'r', encoding='utf-8') as f:
+            cfg = json.load(f)
+
+        agents_block = cfg.get('agents') or {}
+        agents = agents_block.get('list')
+        if not isinstance(agents, list):
+            agents = []
+
+        updated = False
+        for agent in agents:
+            if not isinstance(agent, dict) or agent.get('id') != agent_id:
+                continue
+            tools = agent.setdefault('tools', {})
+            allow = tools.get('allow')
+            if not isinstance(allow, list):
+                allow = []
+            if tool_name not in allow:
+                allow.append(tool_name)
+            tools['allow'] = sorted(dict.fromkeys(allow))
+            agent['tools'] = tools
+            updated = True
+            break
+
+        if not updated:
+            agents.append({'id': agent_id, 'tools': {'allow': [tool_name]}})
+
+        agents_block['list'] = agents
+        cfg['agents'] = agents_block
+
+        with open(config_path, 'w', encoding='utf-8') as f:
+            json.dump(cfg, f, indent=2)
+            f.write('\n')
+        PY
+      changed_when: true
+
+    - name: Check whether OpenClaw systemd unit exists
+      ansible.builtin.stat:
+        path: "{{ openclaw_service_unit_file }}"
+      register: openclaw_systemd_unit
+
+    - name: Restart OpenClaw gateway (systemd)
+      ansible.builtin.systemd:
+        name: "{{ openclaw_service_name }}.service"
+        state: restarted
+      when: openclaw_systemd_unit.stat.exists
+      failed_when: false
+
+    - name: Restart OpenClaw gateway (user service fallback)
+      ansible.builtin.command: "runuser -l {{ openclaw_user }} -c 'systemctl --user restart {{ openclaw_service_name }}'"
+      register: openclaw_gateway_restart_fallback
+      changed_when: openclaw_gateway_restart_fallback.rc == 0
+      failed_when: false
+      when: not openclaw_systemd_unit.stat.exists
+
+    - name: Show runbook summary
+      ansible.builtin.debug:
+        msg:
+          - "Removed 'group:fs' from tools.deny"
+          - "Added '{{ openclaw_file_tool_name }}' to main agent allowlist"
+          - "OpenClaw gateway restart attempted"

--- a/playbooks/operations/openclaw/configure-openclaw-full-web-browsing.yml
+++ b/playbooks/operations/openclaw/configure-openclaw-full-web-browsing.yml
@@ -1,0 +1,199 @@
+---
+# Playbook to enable full browser tooling for OpenClaw
+
+- name: Common tasks for every playbook
+  import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+
+- name: Enable OpenClaw full web browsing
+  hosts: kube_control_plane[0]
+  become: true
+  vars:
+    openclaw_user: openclaw
+    openclaw_home: "/home/{{ openclaw_user }}"
+    openclaw_config_file: "{{ openclaw_home }}/.openclaw/openclaw.json"
+    openclaw_service_name: openclaw-gateway
+    openclaw_service_unit_file: "/etc/systemd/system/{{ openclaw_service_name }}.service"
+    openclaw_browser_block:
+      enabled: true
+      defaultProfile: openclaw
+      headless: true
+    openclaw_browser_agent_id: "main"
+    openclaw_browser_tool_name: "browser"
+    openclaw_system_packages:
+      - chromium
+      - chromium-browser
+      - chromium-driver
+    openclaw_node_packages:
+      - playwright
+  pre_tasks:
+    - name: Check whether openclaw user exists
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ openclaw_user }}"
+        fail_key: false
+      register: openclaw_passwd
+
+    - name: Set user existence fact
+      ansible.builtin.set_fact:
+        openclaw_user_exists: >-
+          {{
+            openclaw_passwd.ansible_facts.getent_passwd is defined and
+            openclaw_user in openclaw_passwd.ansible_facts.getent_passwd
+          }}
+
+    - name: Fail when openclaw user is missing
+      ansible.builtin.fail:
+        msg: "openclaw user does not exist. Run install-openclaw-host.yml first."
+      when: not openclaw_user_exists
+
+    - name: Check whether OpenClaw config exists
+      ansible.builtin.stat:
+        path: "{{ openclaw_config_file }}"
+      register: openclaw_config_stat
+
+    - name: Fail when OpenClaw config is missing
+      ansible.builtin.fail:
+        msg: "OpenClaw config not found at {{ openclaw_config_file }}. Run configure-openclaw-installation-mode.yml first."
+      when: not openclaw_config_stat.stat.exists
+  tasks:
+    - name: Install browser package candidates for headless browsing
+      ansible.builtin.apt:
+        name: "{{ item }}"
+        state: present
+        update_cache: true
+      loop: "{{ openclaw_system_packages }}"
+      register: openclaw_browser_package_install
+      ignore_errors: true
+      failed_when: false
+
+    - name: Check whether any browser package installed
+      ansible.builtin.set_fact:
+        openclaw_browser_package_installed: >-
+          {{ openclaw_browser_package_install.results | map(attribute='failed') | select('equalto', false) | list | length > 0 }}
+
+    - name: Ensure npm global prefix is available
+      ansible.builtin.command: npm config get prefix
+      register: openclaw_npm_prefix
+      changed_when: false
+      failed_when: openclaw_npm_prefix.rc != 0
+
+    - name: Check whether full Playwright package is installed
+      ansible.builtin.stat:
+        path: "{{ (openclaw_npm_prefix.stdout | trim) }}/lib/node_modules/playwright/package.json"
+      register: openclaw_playwright_package
+
+    - name: Install full Playwright package
+      ansible.builtin.command: "{{ openclaw_npm_prefix.stdout | trim }}/bin/npm install -g {{ openclaw_node_packages | join(' ') }}"
+      register: openclaw_playwright_install
+      changed_when: openclaw_playwright_install.rc == 0
+      when: not openclaw_playwright_package.stat.exists
+
+    - name: Install Playwright Chromium browser binaries
+      ansible.builtin.command: "{{ openclaw_npm_prefix.stdout | trim }}/bin/playwright install chromium"
+      register: openclaw_playwright_browsers
+      changed_when: openclaw_playwright_browsers.rc == 0
+
+    - name: Read current OpenClaw config
+      ansible.builtin.slurp:
+        path: "{{ openclaw_config_file }}"
+      register: openclaw_config_raw
+
+    - name: Parse OpenClaw config
+      ansible.builtin.set_fact:
+        openclaw_config_json: "{{ openclaw_config_raw.content | b64decode | from_json }}"
+
+    - name: Enable browser tool and keep conservative non-browser deny settings
+      ansible.builtin.set_fact:
+        openclaw_tools: "{{ (openclaw_config_json.tools | default({})) | combine({
+          'deny': ((openclaw_config_json.tools.deny | default([]))
+            | reject('equalto', 'browser')
+            | list)
+        }, recursive=True) }}"
+
+    - name: Merge browser settings and tool policy
+      ansible.builtin.set_fact:
+        openclaw_config_json_updated: "{{ openclaw_config_json | combine({
+          'tools': openclaw_tools,
+          'browser': ((openclaw_config_json.browser | default({})) | combine(openclaw_browser_block, recursive=True))
+        }, recursive=True) }}"
+
+    - name: Persist OpenClaw config
+      ansible.builtin.copy:
+        dest: "{{ openclaw_config_file }}"
+        owner: "{{ openclaw_user }}"
+        group: "{{ openclaw_user }}"
+        mode: "0600"
+        content: "{{ openclaw_config_json_updated | to_nice_json }}"
+
+    - name: Ensure main agent has browser in tool allowlist
+      ansible.builtin.shell: |
+        python3 - <<'PY'
+        import json
+
+        config_path = '{{ openclaw_config_file }}'
+        agent_id = '{{ openclaw_browser_agent_id }}'
+        tool_name = '{{ openclaw_browser_tool_name }}'
+
+        with open(config_path, 'r', encoding='utf-8') as f:
+            cfg = json.load(f)
+
+        agents_block = cfg.get('agents') or {}
+        agents = agents_block.get('list')
+        if not isinstance(agents, list):
+            agents = []
+
+        updated = False
+        for agent in agents:
+            if not isinstance(agent, dict) or agent.get('id') != agent_id:
+                continue
+            tools = agent.setdefault('tools', {})
+            allow = tools.get('allow')
+            if not isinstance(allow, list):
+                allow = []
+            if tool_name not in allow:
+                allow.append(tool_name)
+            tools['allow'] = sorted(dict.fromkeys(allow))
+            agent['tools'] = tools
+            updated = True
+            break
+
+        if not updated:
+            agents.append({'id': agent_id, 'tools': {'allow': [tool_name]}})
+
+        agents_block['list'] = agents
+        cfg['agents'] = agents_block
+
+        with open(config_path, 'w', encoding='utf-8') as f:
+            json.dump(cfg, f, indent=2)
+            f.write('\n')
+        PY
+      changed_when: true
+
+    - name: Restart gateway (systemd service path)
+      ansible.builtin.stat:
+        path: "{{ openclaw_service_unit_file }}"
+      register: openclaw_systemd_unit
+
+    - name: Restart OpenClaw gateway (systemd)
+      ansible.builtin.systemd:
+        daemon_reload: true
+        name: "{{ openclaw_service_name }}.service"
+        state: restarted
+      when: openclaw_systemd_unit.stat.exists
+      failed_when: false
+
+    - name: Restart OpenClaw gateway (user service fallback)
+      ansible.builtin.command: "runuser -l {{ openclaw_user }} -c 'systemctl --user restart {{ openclaw_service_name }}'"
+      register: openclaw_gateway_restart_fallback
+      changed_when: openclaw_gateway_restart_fallback.rc == 0
+      failed_when: false
+      when: not openclaw_systemd_unit.stat.exists
+
+    - name: Show runbook summary
+      ansible.builtin.debug:
+        msg:
+          - "System browser package installed: {{ openclaw_browser_package_installed }}"
+          - "Playwright package install rc: {{ openclaw_playwright_install.rc | default('skipped') }}"
+          - "Playwright browsers install rc: {{ openclaw_playwright_browsers.rc | default('not run') }}"
+          - "Enabled browser tooling and host browser path in {{ openclaw_config_file }}"
+          - "Main agent browser allowlist entry ensured for {{ openclaw_browser_agent_id }}"

--- a/playbooks/operations/openclaw/configure-openclaw-installation-mode.yml
+++ b/playbooks/operations/openclaw/configure-openclaw-installation-mode.yml
@@ -1,0 +1,140 @@
+---
+# Playbook to configure OpenClaw hardened installation mode files
+
+- name: Common tasks for every playbook
+  import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+
+- name: Configure OpenClaw hardened installation mode
+  hosts: kube_control_plane[0]
+  become: true
+  vars:
+    openclaw_user: openclaw
+    openclaw_home: "/home/{{ openclaw_user }}"
+    openclaw_primary_model: openai-codex/gpt-5.3-codex
+    openclaw_config_dir: "{{ openclaw_home }}/.openclaw"
+    openclaw_config_file: "{{ openclaw_config_dir }}/openclaw.json"
+    openclaw_env_file: "{{ openclaw_config_dir }}/.env"
+    openclaw_gateway_unit_file: "{{ openclaw_home }}/.config/systemd/user/openclaw-gateway.service"
+    openclaw_telegram_bot_token: "{{ lookup('env', 'OPENCLAW_TELEGRAM_BOT_TOKEN') }}"
+    openclaw_require_telegram_token: false
+  pre_tasks:
+    - name: Check whether openclaw user exists
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ openclaw_user }}"
+        fail_key: false
+      register: openclaw_passwd
+
+    - name: Set user existence fact
+      ansible.builtin.set_fact:
+        openclaw_user_exists: >-
+          {{
+            openclaw_passwd.ansible_facts.getent_passwd is defined and
+            openclaw_user in openclaw_passwd.ansible_facts.getent_passwd
+          }}
+
+    - name: Fail when openclaw user is missing
+      ansible.builtin.fail:
+        msg: "openclaw user does not exist. Run install-openclaw-host.yml first."
+      when: not openclaw_user_exists
+
+    - name: Fail when token is required but not provided
+      ansible.builtin.fail:
+        msg: "OPENCLAW_TELEGRAM_BOT_TOKEN is required when openclaw_require_telegram_token=true."
+      when: openclaw_require_telegram_token | bool and (openclaw_telegram_bot_token | length == 0)
+
+  tasks:
+    - name: Ensure OpenClaw config directory exists
+      ansible.builtin.file:
+        path: "{{ openclaw_config_dir }}"
+        state: directory
+        owner: "{{ openclaw_user }}"
+        group: "{{ openclaw_user }}"
+        mode: "0700"
+
+    - name: Ensure OpenClaw kube directory exists
+      ansible.builtin.file:
+        path: "{{ openclaw_home }}/.kube"
+        state: directory
+        owner: "{{ openclaw_user }}"
+        group: "{{ openclaw_user }}"
+        mode: "0700"
+
+    - name: Write hardened OpenClaw configuration
+      ansible.builtin.copy:
+        dest: "{{ openclaw_config_file }}"
+        owner: "{{ openclaw_user }}"
+        group: "{{ openclaw_user }}"
+        mode: "0600"
+        content: |
+          {
+            "agents": {
+              "defaults": {
+                "model": {
+                  "primary": "{{ openclaw_primary_model }}"
+                },
+                "heartbeat": {
+                  "every": "0m"
+                }
+              }
+            },
+            "gateway": {
+              "mode": "local"
+            },
+            "channels": {
+              "telegram": {
+                "enabled": true,
+                "botToken": "${TELEGRAM_BOT_TOKEN}",
+                "dmPolicy": "pairing",
+                "groupPolicy": "disabled"
+              }
+            },
+            "tools": {
+              "deny": ["group:fs", "browser", "canvas", "nodes", "cron", "gateway"],
+              "elevated": {
+                "enabled": false
+              }
+            }
+          }
+
+    - name: Write Telegram token env file when token is provided
+      ansible.builtin.copy:
+        dest: "{{ openclaw_env_file }}"
+        owner: "{{ openclaw_user }}"
+        group: "{{ openclaw_user }}"
+        mode: "0600"
+        content: |
+          TELEGRAM_BOT_TOKEN={{ openclaw_telegram_bot_token }}
+      no_log: true
+      when: openclaw_telegram_bot_token | length > 0
+
+    - name: Warn when token file is skipped
+      ansible.builtin.debug:
+        msg: "OPENCLAW_TELEGRAM_BOT_TOKEN not set. Add {{ openclaw_env_file }} manually before Telegram pairing."
+      when: openclaw_telegram_bot_token | length == 0
+
+    - name: Check whether OpenClaw gateway user unit exists
+      ansible.builtin.stat:
+        path: "{{ openclaw_gateway_unit_file }}"
+      register: openclaw_gateway_unit
+
+    - name: Restart OpenClaw gateway user service when available
+      ansible.builtin.command: "runuser -l {{ openclaw_user }} -c 'systemctl --user restart openclaw-gateway'"
+      register: openclaw_gateway_restart
+      changed_when: openclaw_gateway_restart.rc == 0
+      failed_when: false
+      when: openclaw_gateway_unit.stat.exists
+
+    - name: Print remaining manual phases
+      ansible.builtin.debug:
+        msg:
+          - "Manual follow-up required:"
+          - "1) openclaw onboard --install-daemon --auth-choice openai-codex (as openclaw)"
+          - "2) openclaw pairing list telegram && openclaw pairing approve telegram <CODE>"
+          - "3) Enable gateway on boot via Ansible:"
+          - "   ansible-playbook .../operations/openclaw/enable-openclaw-gateway-autostart.yml"
+          - "4) If you want full browser automation later, run:"
+          - "   ansible-playbook .../operations/openclaw/configure-openclaw-full-web-browsing.yml"
+          - "5) If starting manually, force its working dir and HOME:"
+          - "   sudo -u openclaw sh -lc 'cd /home/openclaw && HOME=/home/openclaw openclaw gateway run'"
+          - "5) Configure Exec approvals allowlist in Control UI with /usr/local/bin/kubectl only"

--- a/playbooks/operations/openclaw/configure-openclaw-kubeconfig.yml
+++ b/playbooks/operations/openclaw/configure-openclaw-kubeconfig.yml
@@ -1,0 +1,85 @@
+---
+# Playbook to provision OpenClaw kubeconfig from the host admin kubeconfig
+
+- name: Common tasks for every playbook
+  import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+
+- name: Configure OpenClaw kubeconfig with host admin credentials
+  hosts: kube_control_plane[0]
+  become: true
+  vars:
+    kubeconfig_admin_path: /etc/kubernetes/admin.conf
+    openclaw_user: openclaw
+    openclaw_home: "/home/{{ openclaw_user }}"
+    openclaw_kubeconfig_path: "{{ openclaw_home }}/.kube/config"
+  pre_tasks:
+    - name: Check whether openclaw user exists
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ openclaw_user }}"
+        fail_key: false
+      register: openclaw_passwd
+
+    - name: Set user existence fact
+      ansible.builtin.set_fact:
+        openclaw_user_exists: >-
+          {{
+            openclaw_passwd.ansible_facts.getent_passwd is defined and
+            openclaw_user in openclaw_passwd.ansible_facts.getent_passwd
+          }}
+
+    - name: Fail when openclaw user is missing
+      ansible.builtin.fail:
+        msg: "openclaw user does not exist. Run install-openclaw-host.yml first."
+      when: not openclaw_user_exists
+
+    - name: Check host admin kubeconfig exists
+      ansible.builtin.stat:
+        path: "{{ kubeconfig_admin_path }}"
+      register: kubeconfig_admin
+
+    - name: Fail when admin kubeconfig is missing
+      ansible.builtin.fail:
+        msg: "Admin kubeconfig not found at {{ kubeconfig_admin_path }}. Cannot provision OpenClaw kubeconfig."
+      when: not kubeconfig_admin.stat.exists
+  tasks:
+    - name: Ensure OpenClaw kube directory exists
+      ansible.builtin.file:
+        path: "{{ openclaw_home }}/.kube"
+        state: directory
+        owner: "{{ openclaw_user }}"
+        group: "{{ openclaw_user }}"
+        mode: "0700"
+
+    - name: Copy host admin kubeconfig for OpenClaw
+      ansible.builtin.copy:
+        src: "{{ kubeconfig_admin_path }}"
+        dest: "{{ openclaw_kubeconfig_path }}"
+        owner: "{{ openclaw_user }}"
+        group: "{{ openclaw_user }}"
+        mode: "0600"
+        remote_src: true
+
+    - name: Validate OpenClaw can read pods with kubeconfig
+      ansible.builtin.command: >-
+        runuser -l {{ openclaw_user }} -c
+        "kubectl --kubeconfig={{ openclaw_kubeconfig_path }} auth can-i get pods --all-namespaces"
+      register: openclaw_can_get_pods
+      changed_when: false
+      failed_when: (openclaw_can_get_pods.stdout | trim) != "yes"
+
+    - name: Validate OpenClaw has delete privilege (same as node admin context)
+      ansible.builtin.command: >-
+        runuser -l {{ openclaw_user }} -c
+        "kubectl --kubeconfig={{ openclaw_kubeconfig_path }} auth can-i delete pods --all-namespaces"
+      register: openclaw_can_delete_pods
+      changed_when: false
+      failed_when: (openclaw_can_delete_pods.stdout | trim) != "yes"
+
+    - name: Show kubeconfig validation summary
+      ansible.builtin.debug:
+        msg:
+          - "OpenClaw kubeconfig written to {{ openclaw_kubeconfig_path }}"
+          - "Source: {{ kubeconfig_admin_path }}"
+          - "can-i get pods --all-namespaces: {{ openclaw_can_get_pods.stdout | trim }}"
+          - "can-i delete pods --all-namespaces: {{ openclaw_can_delete_pods.stdout | trim }}"

--- a/playbooks/operations/openclaw/disable-openclaw-exec-tool.yml
+++ b/playbooks/operations/openclaw/disable-openclaw-exec-tool.yml
@@ -1,0 +1,145 @@
+---
+# Playbook to disable exec tooling for OpenClaw
+
+- name: Common tasks for every playbook
+  import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+
+- name: Disable OpenClaw exec tooling
+  hosts: kube_control_plane[0]
+  become: true
+  vars:
+    openclaw_user: openclaw
+    openclaw_home: "/home/{{ openclaw_user }}"
+    openclaw_config_file: "{{ openclaw_home }}/.openclaw/openclaw.json"
+    openclaw_service_name: openclaw-gateway
+    openclaw_service_unit_file: "/etc/systemd/system/{{ openclaw_service_name }}.service"
+    openclaw_agent_id: "main"
+    openclaw_exec_tool_name: "exec"
+  pre_tasks:
+    - name: Check whether openclaw user exists
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ openclaw_user }}"
+        fail_key: false
+      register: openclaw_passwd
+
+    - name: Set user existence fact
+      ansible.builtin.set_fact:
+        openclaw_user_exists: >-
+          {{
+            openclaw_passwd.ansible_facts.getent_passwd is defined and
+            openclaw_user in openclaw_passwd.ansible_facts.getent_passwd
+          }}
+
+    - name: Skip gracefully when openclaw user missing
+      ansible.builtin.fail:
+        msg: "openclaw user does not exist. No exec policy changes applied."
+      when: not openclaw_user_exists
+
+    - name: Check whether OpenClaw config exists
+      ansible.builtin.stat:
+        path: "{{ openclaw_config_file }}"
+      register: openclaw_config_stat
+
+    - name: Skip gracefully when config is missing
+      ansible.builtin.fail:
+        msg: "OpenClaw config not found at {{ openclaw_config_file }}. Nothing to disable."
+      when: not openclaw_config_stat.stat.exists
+  tasks:
+    - name: Read current OpenClaw config
+      ansible.builtin.slurp:
+        path: "{{ openclaw_config_file }}"
+      register: openclaw_config_raw
+
+    - name: Parse OpenClaw config
+      ansible.builtin.set_fact:
+        openclaw_config_json: "{{ openclaw_config_raw.content | b64decode | from_json }}"
+
+    - name: Re-enable exec deny in tool policy
+      ansible.builtin.set_fact:
+        openclaw_tools: "{{ (openclaw_config_json.tools | default({})) | combine({
+          'deny': (((openclaw_config_json.tools.deny | default([])) + ['exec']) | unique)
+        }, recursive=True) }}"
+
+    - name: Merge updated tool policy
+      ansible.builtin.set_fact:
+        openclaw_config_json_updated: "{{ openclaw_config_json | combine({
+          'tools': openclaw_tools
+        }, recursive=True) }}"
+
+    - name: Persist base tool policy
+      ansible.builtin.copy:
+        dest: "{{ openclaw_config_file }}"
+        owner: "{{ openclaw_user }}"
+        group: "{{ openclaw_user }}"
+        mode: "0600"
+        content: "{{ openclaw_config_json_updated | to_nice_json }}"
+
+    - name: Remove exec from main agent allowlist
+      ansible.builtin.shell: |
+        python3 - <<'PY'
+        import json
+
+        config_path = '{{ openclaw_config_file }}'
+        agent_id = '{{ openclaw_agent_id }}'
+        tool_name = '{{ openclaw_exec_tool_name }}'
+
+        with open(config_path, 'r', encoding='utf-8') as f:
+            cfg = json.load(f)
+
+        agents_block = cfg.get('agents') or {}
+        agents = agents_block.get('list')
+        if not isinstance(agents, list):
+            agents = []
+
+        for agent in agents:
+            if not isinstance(agent, dict) or agent.get('id') != agent_id:
+                continue
+            tools = agent.get('tools')
+            if not isinstance(tools, dict):
+                continue
+            allow = tools.get('allow')
+            if not isinstance(allow, list):
+                continue
+            allow = [entry for entry in allow if entry != tool_name]
+            if allow:
+                tools['allow'] = allow
+            else:
+                tools.pop('allow', None)
+                if not tools:
+                    agent.pop('tools', None)
+
+        agents_block['list'] = agents
+        cfg['agents'] = agents_block
+
+        with open(config_path, 'w', encoding='utf-8') as f:
+            json.dump(cfg, f, indent=2)
+            f.write('\n')
+        PY
+      changed_when: true
+
+    - name: Check whether OpenClaw systemd unit exists
+      ansible.builtin.stat:
+        path: "{{ openclaw_service_unit_file }}"
+      register: openclaw_systemd_unit
+
+    - name: Restart OpenClaw gateway (systemd)
+      ansible.builtin.systemd:
+        name: "{{ openclaw_service_name }}.service"
+        state: restarted
+      when: openclaw_systemd_unit.stat.exists
+      failed_when: false
+
+    - name: Restart OpenClaw gateway (user service fallback)
+      ansible.builtin.command: "runuser -l {{ openclaw_user }} -c 'systemctl --user restart {{ openclaw_service_name }}'"
+      register: openclaw_gateway_restart_fallback
+      changed_when: openclaw_gateway_restart_fallback.rc == 0
+      failed_when: false
+      when: not openclaw_systemd_unit.stat.exists
+
+    - name: Show runbook summary
+      ansible.builtin.debug:
+        msg:
+          - "Added 'exec' to tools.deny"
+          - "Removed '{{ openclaw_exec_tool_name }}' from main agent allowlist when present"
+          - "OpenClaw gateway restart attempted"

--- a/playbooks/operations/openclaw/disable-openclaw-file-tool.yml
+++ b/playbooks/operations/openclaw/disable-openclaw-file-tool.yml
@@ -1,0 +1,145 @@
+---
+# Playbook to disable file-system tools for OpenClaw
+
+- name: Common tasks for every playbook
+  import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+
+- name: Disable OpenClaw file-system tooling
+  hosts: kube_control_plane[0]
+  become: true
+  vars:
+    openclaw_user: openclaw
+    openclaw_home: "/home/{{ openclaw_user }}"
+    openclaw_config_file: "{{ openclaw_home }}/.openclaw/openclaw.json"
+    openclaw_service_name: openclaw-gateway
+    openclaw_service_unit_file: "/etc/systemd/system/{{ openclaw_service_name }}.service"
+    openclaw_agent_id: "main"
+    openclaw_file_tool_name: "group:fs"
+  pre_tasks:
+    - name: Check whether openclaw user exists
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ openclaw_user }}"
+        fail_key: false
+      register: openclaw_passwd
+
+    - name: Set user existence fact
+      ansible.builtin.set_fact:
+        openclaw_user_exists: >-
+          {{
+            openclaw_passwd.ansible_facts.getent_passwd is defined and
+            openclaw_user in openclaw_passwd.ansible_facts.getent_passwd
+          }}
+
+    - name: Skip gracefully when openclaw user missing
+      ansible.builtin.fail:
+        msg: "openclaw user does not exist. No file-tool policy changes applied."
+      when: not openclaw_user_exists
+
+    - name: Check whether OpenClaw config exists
+      ansible.builtin.stat:
+        path: "{{ openclaw_config_file }}"
+      register: openclaw_config_stat
+
+    - name: Skip gracefully when config is missing
+      ansible.builtin.fail:
+        msg: "OpenClaw config not found at {{ openclaw_config_file }}. Nothing to disable."
+      when: not openclaw_config_stat.stat.exists
+  tasks:
+    - name: Read current OpenClaw config
+      ansible.builtin.slurp:
+        path: "{{ openclaw_config_file }}"
+      register: openclaw_config_raw
+
+    - name: Parse OpenClaw config
+      ansible.builtin.set_fact:
+        openclaw_config_json: "{{ openclaw_config_raw.content | b64decode | from_json }}"
+
+    - name: Re-enable filesystem deny group
+      ansible.builtin.set_fact:
+        openclaw_tools: "{{ (openclaw_config_json.tools | default({})) | combine({
+          'deny': (((openclaw_config_json.tools.deny | default([])) + ['group:fs']) | unique)
+        }, recursive=True) }}"
+
+    - name: Merge updated tool policy
+      ansible.builtin.set_fact:
+        openclaw_config_json_updated: "{{ openclaw_config_json | combine({
+          'tools': openclaw_tools
+        }, recursive=True) }}"
+
+    - name: Persist base tool policy
+      ansible.builtin.copy:
+        dest: "{{ openclaw_config_file }}"
+        owner: "{{ openclaw_user }}"
+        group: "{{ openclaw_user }}"
+        mode: "0600"
+        content: "{{ openclaw_config_json_updated | to_nice_json }}"
+
+    - name: Remove file tool from main agent allowlist
+      ansible.builtin.shell: |
+        python3 - <<'PY'
+        import json
+
+        config_path = '{{ openclaw_config_file }}'
+        agent_id = '{{ openclaw_agent_id }}'
+        tool_name = '{{ openclaw_file_tool_name }}'
+
+        with open(config_path, 'r', encoding='utf-8') as f:
+            cfg = json.load(f)
+
+        agents_block = cfg.get('agents') or {}
+        agents = agents_block.get('list')
+        if not isinstance(agents, list):
+            agents = []
+
+        for agent in agents:
+            if not isinstance(agent, dict) or agent.get('id') != agent_id:
+                continue
+            tools = agent.get('tools')
+            if not isinstance(tools, dict):
+                continue
+            allow = tools.get('allow')
+            if not isinstance(allow, list):
+                continue
+            allow = [entry for entry in allow if entry != tool_name]
+            if allow:
+                tools['allow'] = allow
+            else:
+                tools.pop('allow', None)
+                if not tools:
+                    agent.pop('tools', None)
+
+        agents_block['list'] = agents
+        cfg['agents'] = agents_block
+
+        with open(config_path, 'w', encoding='utf-8') as f:
+            json.dump(cfg, f, indent=2)
+            f.write('\n')
+        PY
+      changed_when: true
+
+    - name: Check whether OpenClaw systemd unit exists
+      ansible.builtin.stat:
+        path: "{{ openclaw_service_unit_file }}"
+      register: openclaw_systemd_unit
+
+    - name: Restart OpenClaw gateway (systemd)
+      ansible.builtin.systemd:
+        name: "{{ openclaw_service_name }}.service"
+        state: restarted
+      when: openclaw_systemd_unit.stat.exists
+      failed_when: false
+
+    - name: Restart OpenClaw gateway (user service fallback)
+      ansible.builtin.command: "runuser -l {{ openclaw_user }} -c 'systemctl --user restart {{ openclaw_service_name }}'"
+      register: openclaw_gateway_restart_fallback
+      changed_when: openclaw_gateway_restart_fallback.rc == 0
+      failed_when: false
+      when: not openclaw_systemd_unit.stat.exists
+
+    - name: Show runbook summary
+      ansible.builtin.debug:
+        msg:
+          - "Added 'group:fs' to tools.deny"
+          - "Removed '{{ openclaw_file_tool_name }}' from main agent allowlist when present"
+          - "OpenClaw gateway restart attempted"

--- a/playbooks/operations/openclaw/disable-openclaw-full-web-browsing.yml
+++ b/playbooks/operations/openclaw/disable-openclaw-full-web-browsing.yml
@@ -1,0 +1,146 @@
+---
+# Playbook to disable full browser tooling for OpenClaw
+
+- name: Common tasks for every playbook
+  import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+
+- name: Disable OpenClaw full web browsing
+  hosts: kube_control_plane[0]
+  become: true
+  vars:
+    openclaw_user: openclaw
+    openclaw_home: "/home/{{ openclaw_user }}"
+    openclaw_config_file: "{{ openclaw_home }}/.openclaw/openclaw.json"
+    openclaw_service_name: openclaw-gateway
+    openclaw_service_unit_file: "/etc/systemd/system/{{ openclaw_service_name }}.service"
+    openclaw_browser_agent_id: "main"
+    openclaw_browser_tool_name: "browser"
+  pre_tasks:
+    - name: Check whether openclaw user exists
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ openclaw_user }}"
+        fail_key: false
+      register: openclaw_passwd
+
+    - name: Set user existence fact
+      ansible.builtin.set_fact:
+        openclaw_user_exists: >-
+          {{
+            openclaw_passwd.ansible_facts.getent_passwd is defined and
+            openclaw_user in openclaw_passwd.ansible_facts.getent_passwd
+          }}
+
+    - name: Skip gracefully when openclaw user missing
+      ansible.builtin.fail:
+        msg: "openclaw user does not exist. No browser policy changes applied."
+      when: not openclaw_user_exists
+
+    - name: Check whether OpenClaw config exists
+      ansible.builtin.stat:
+        path: "{{ openclaw_config_file }}"
+      register: openclaw_config_stat
+
+    - name: Skip gracefully when config is missing
+      ansible.builtin.fail:
+        msg: "OpenClaw config not found at {{ openclaw_config_file }}. Nothing to disable."
+      when: not openclaw_config_stat.stat.exists
+  tasks:
+    - name: Read current OpenClaw config
+      ansible.builtin.slurp:
+        path: "{{ openclaw_config_file }}"
+      register: openclaw_config_raw
+
+    - name: Parse OpenClaw config
+      ansible.builtin.set_fact:
+        openclaw_config_json: "{{ openclaw_config_raw.content | b64decode | from_json }}"
+
+    - name: Revoke browser tool access
+      ansible.builtin.set_fact:
+        openclaw_tools: "{{ (openclaw_config_json.tools | default({})) | combine({
+          'deny': (((openclaw_config_json.tools.deny | default([])) + ['browser']) | unique)
+        }, recursive=True) }}"
+
+    - name: Disable browser in config
+      ansible.builtin.set_fact:
+        openclaw_config_json_updated: "{{ openclaw_config_json | combine({
+          'tools': openclaw_tools,
+          'browser': ((openclaw_config_json.browser | default({})) | combine({'enabled': false}, recursive=True))
+        }, recursive=True) }}"
+
+    - name: Persist OpenClaw config base browser policy
+      ansible.builtin.copy:
+        dest: "{{ openclaw_config_file }}"
+        owner: "{{ openclaw_user }}"
+        group: "{{ openclaw_user }}"
+        mode: "0600"
+        content: "{{ openclaw_config_json_updated | to_nice_json }}"
+
+    - name: Remove main agent browser allowlist override
+      ansible.builtin.shell: |
+        python3 - <<'PY'
+        import json
+
+        config_path = '{{ openclaw_config_file }}'
+        agent_id = '{{ openclaw_browser_agent_id }}'
+        tool_name = '{{ openclaw_browser_tool_name }}'
+
+        with open(config_path, 'r', encoding='utf-8') as f:
+            cfg = json.load(f)
+
+        agents_block = cfg.get('agents') or {}
+        agents = agents_block.get('list')
+        if not isinstance(agents, list):
+            agents = []
+
+        for agent in agents:
+            if not isinstance(agent, dict) or agent.get('id') != agent_id:
+                continue
+            tools = agent.get('tools')
+            if not isinstance(tools, dict):
+                continue
+            allow = tools.get('allow')
+            if not isinstance(allow, list):
+                continue
+            allow = [entry for entry in allow if entry != tool_name]
+            if allow:
+                tools['allow'] = allow
+            else:
+                tools.pop('allow', None)
+                if not tools:
+                    agent.pop('tools', None)
+
+        agents_block['list'] = agents
+        cfg['agents'] = agents_block
+
+        with open(config_path, 'w', encoding='utf-8') as f:
+            json.dump(cfg, f, indent=2)
+            f.write('\n')
+        PY
+      changed_when: true
+
+    - name: Check whether OpenClaw systemd unit exists
+      ansible.builtin.stat:
+        path: "{{ openclaw_service_unit_file }}"
+      register: openclaw_systemd_unit
+
+    - name: Restart OpenClaw gateway (systemd)
+      ansible.builtin.systemd:
+        name: "{{ openclaw_service_name }}.service"
+        state: restarted
+      when: openclaw_systemd_unit.stat.exists
+      failed_when: false
+
+    - name: Restart OpenClaw gateway (user service fallback)
+      ansible.builtin.command: "runuser -l {{ openclaw_user }} -c 'systemctl --user restart {{ openclaw_service_name }}'"
+      register: openclaw_gateway_restart_fallback
+      changed_when: openclaw_gateway_restart_fallback.rc == 0
+      failed_when: false
+      when: not openclaw_systemd_unit.stat.exists
+
+    - name: Show runbook summary
+      ansible.builtin.debug:
+        msg:
+          - "browser tool is now denied"
+          - "browser.enabled: false"
+          - "OpenClaw gateway restart attempted"

--- a/playbooks/operations/openclaw/disable-openclaw-gateway-autostart.yml
+++ b/playbooks/operations/openclaw/disable-openclaw-gateway-autostart.yml
@@ -1,0 +1,35 @@
+---
+# Playbook to disable and remove OpenClaw gateway autostart systemd service
+
+- name: Common tasks for every playbook
+  import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+
+- name: Disable OpenClaw gateway autostart service
+  hosts: kube_control_plane[0]
+  become: true
+  vars:
+    openclaw_service_name: openclaw-gateway
+    openclaw_service_unit: "/etc/systemd/system/{{ openclaw_service_name }}.service"
+  tasks:
+    - name: Stop OpenClaw gateway system service
+      ansible.builtin.systemd:
+        name: "{{ openclaw_service_name }}.service"
+        enabled: false
+        state: stopped
+      failed_when: false
+
+    - name: Remove OpenClaw gateway system service file
+      ansible.builtin.file:
+        path: "{{ openclaw_service_unit }}"
+        state: absent
+
+    - name: Reload systemd manager configuration
+      ansible.builtin.command: systemctl daemon-reload
+      changed_when: false
+      failed_when: false
+
+    - name: Report autostart status
+      ansible.builtin.debug:
+        msg:
+          - "Removed systemd service: {{ openclaw_service_unit }}"
+          - "Autostart disabled: yes"

--- a/playbooks/operations/openclaw/enable-openclaw-gateway-autostart.yml
+++ b/playbooks/operations/openclaw/enable-openclaw-gateway-autostart.yml
@@ -1,0 +1,125 @@
+---
+# Playbook to install and enable a systemd service for OpenClaw gateway autostart
+
+- name: Common tasks for every playbook
+  import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+
+- name: Enable OpenClaw gateway autostart service
+  hosts: kube_control_plane[0]
+  become: true
+  vars:
+    openclaw_user: openclaw
+    openclaw_home: "/home/{{ openclaw_user }}"
+    openclaw_service_name: openclaw-gateway
+    openclaw_service_unit: "/etc/systemd/system/{{ openclaw_service_name }}.service"
+    openclaw_user_service_unit: "{{ openclaw_home }}/.config/systemd/user/{{ openclaw_service_name }}.service"
+    openclaw_gateway_binary_candidates:
+      - /usr/local/bin/openclaw
+      - /usr/bin/openclaw
+      - /usr/local/sbin/openclaw
+      - /usr/sbin/openclaw
+  pre_tasks:
+    - name: Check whether openclaw user exists
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ openclaw_user }}"
+        fail_key: false
+      register: openclaw_passwd
+
+    - name: Set user existence fact
+      ansible.builtin.set_fact:
+        openclaw_user_exists: >-
+          {{
+            openclaw_passwd.ansible_facts.getent_passwd is defined and
+            openclaw_user in openclaw_passwd.ansible_facts.getent_passwd
+          }}
+
+    - name: Fail when openclaw user does not exist
+      ansible.builtin.fail:
+        msg: "openclaw user does not exist. Run install-openclaw-host.yml first."
+      when: not openclaw_user_exists
+
+    - name: Check known OpenClaw binary locations
+      ansible.builtin.stat:
+        path: "{{ item }}"
+      loop: "{{ openclaw_gateway_binary_candidates }}"
+      register: openclaw_binary_checks
+
+    - name: Resolve OpenClaw CLI binary path
+      ansible.builtin.set_fact:
+        openclaw_gateway_binary: >-
+          {{
+            (openclaw_binary_checks.results
+            | selectattr('stat.exists', 'equalto', true)
+            | map(attribute='item')
+            | list
+            | first | default(''))
+          }}
+
+    - name: Verify OpenClaw CLI binary
+      ansible.builtin.fail:
+        msg: "OpenClaw binary was not found in {{ openclaw_gateway_binary_candidates | join(', ') }}. Run install-openclaw-host.yml first."
+      when: openclaw_gateway_binary | length == 0
+  tasks:
+    - name: Check whether legacy user service exists
+      ansible.builtin.stat:
+        path: "{{ openclaw_user_service_unit }}"
+      register: openclaw_user_service_unit_stat
+
+    - name: Stop and disable legacy user service if present
+      ansible.builtin.command: "runuser -l {{ openclaw_user }} -c 'systemctl --user stop {{ openclaw_service_name }} && systemctl --user disable {{ openclaw_service_name }}'"
+      register: openclaw_user_service_disable
+      changed_when: openclaw_user_service_disable.rc == 0
+      failed_when: false
+      when: openclaw_user_service_unit_stat.stat.exists
+
+    - name: Install systemd service for OpenClaw gateway
+      ansible.builtin.copy:
+        dest: "{{ openclaw_service_unit }}"
+        owner: root
+        group: root
+        mode: "0644"
+        content: |
+          [Unit]
+          Description=OpenClaw Gateway
+          After=network-online.target
+          Wants=network-online.target
+
+          [Service]
+          Type=simple
+          User={{ openclaw_user }}
+          Group={{ openclaw_user }}
+          WorkingDirectory={{ openclaw_home }}
+          Environment=HOME={{ openclaw_home }}
+          EnvironmentFile=-{{ openclaw_home }}/.openclaw/.env
+          ExecStart={{ openclaw_gateway_binary }} gateway run
+          Restart=on-failure
+          RestartSec=5
+          TimeoutStartSec=120
+          LimitNOFILE=65535
+
+          [Install]
+          WantedBy=multi-user.target
+
+    - name: Enable and start OpenClaw gateway system service
+      ansible.builtin.systemd:
+        daemon_reload: true
+        name: "{{ openclaw_service_name }}.service"
+        enabled: true
+        state: started
+
+    - name: Verify gateway is reachable on the loopback bind
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: 18789
+        timeout: 20
+        state: started
+      register: openclaw_gateway_loopback_check
+
+    - name: Report autostart status
+      ansible.builtin.debug:
+        msg:
+          - "Installed systemd service: {{ openclaw_service_unit }}"
+          - "Autostart enabled: yes"
+          - "Gateway listening on: 127.0.0.1:18789"
+          - "Loopback check: {{ openclaw_gateway_loopback_check.state }}"

--- a/playbooks/operations/openclaw/install-openclaw-dependencies.yml
+++ b/playbooks/operations/openclaw/install-openclaw-dependencies.yml
@@ -1,0 +1,187 @@
+---
+# Install optional dependencies used by OpenClaw integrations (Gmail/webhooks workflows)
+
+- name: Common tasks for every playbook
+  import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+
+- name: Install OpenClaw integration dependencies
+  hosts: kube_control_plane[0]
+  become: true
+  vars:
+    openclaw_tailscale_gpg_keyring: /usr/share/keyrings/tailscale-archive-keyring.gpg
+    openclaw_tailscale_version: "1.86.2"
+    openclaw_apt_release: "{{ ansible_distribution_release | default('jammy') }}"
+    openclaw_tailscale_repo: "deb [signed-by={{ openclaw_tailscale_gpg_keyring }}] https://pkgs.tailscale.com/stable/ubuntu {{ openclaw_apt_release }} main"
+
+    openclaw_google_cloud_cli_gpg_keyring: /usr/share/keyrings/google-cloud-sdk-archive-keyring.gpg
+    openclaw_google_cloud_cli_apt_repo: "deb [signed-by={{ openclaw_google_cloud_cli_gpg_keyring }}] https://packages.cloud.google.com/apt cloud-sdk main"
+    openclaw_gog_cli_arch: "{{ 'amd64' if ansible_architecture in ['x86_64', 'amd64'] else 'arm64' }}"
+    openclaw_gog_cli_version: "v0.11.0"
+    openclaw_gog_cli_tmp_archive: /tmp/gogcli_{{ openclaw_gog_cli_version }}_linux_{{ openclaw_gog_cli_arch }}.tar.gz
+    openclaw_gog_cli_url: "https://github.com/steipete/gogcli/releases/download/{{ openclaw_gog_cli_version }}/gogcli_{{ openclaw_gog_cli_version | regex_replace('^v', '') }}_linux_{{ openclaw_gog_cli_arch }}.tar.gz"
+    openclaw_gog_binary: /usr/local/bin/gog
+  tasks:
+    - name: Check existing gcloud installation
+      ansible.builtin.command: gcloud --version
+      register: openclaw_gcloud_version_before
+      changed_when: false
+      failed_when: false
+
+    - name: Check existing gog installation
+      ansible.builtin.command: gog --version
+      register: openclaw_gog_version_before
+      changed_when: false
+      failed_when: false
+
+    - name: Check existing tailscale installation
+      ansible.builtin.command: tailscale version
+      register: openclaw_tailscale_before
+      changed_when: false
+      failed_when: false
+
+    - name: Install Google Cloud CLI
+      block:
+        - name: Install Google Cloud apt prerequisites
+          ansible.builtin.apt:
+            name:
+              - apt-transport-https
+              - ca-certificates
+              - curl
+              - gnupg
+            state: present
+            update_cache: true
+
+        - name: Install Google Cloud signing key
+          ansible.builtin.shell: |
+            curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+              | gpg --dearmor -o {{ openclaw_google_cloud_cli_gpg_keyring }}
+          args:
+            creates: "{{ openclaw_google_cloud_cli_gpg_keyring }}"
+
+        - name: Configure Google Cloud apt repository
+          ansible.builtin.apt_repository:
+            repo: "{{ openclaw_google_cloud_cli_apt_repo }}"
+            filename: google-cloud-sdk
+
+        - name: Install google-cloud-cli package
+          ansible.builtin.apt:
+            name: google-cloud-cli
+            state: present
+            update_cache: true
+
+        - name: Report installed gcloud version
+          ansible.builtin.command: gcloud --version
+          register: openclaw_gcloud_version_after
+          changed_when: false
+          failed_when: false
+
+        - name: Show gcloud version
+          ansible.builtin.debug:
+            msg: "gcloud installed: {{ openclaw_gcloud_version_after.stdout_lines[0] | default('n/a') }}"
+      when: openclaw_gcloud_version_before.rc != 0
+
+    - name: Skip gcloud install
+      ansible.builtin.debug:
+        msg: "gcloud already available: {{ openclaw_gcloud_version_before.stdout_lines[0] | default('unknown') }}"
+      when: openclaw_gcloud_version_before.rc == 0
+
+    - name: Install gog CLI
+      block:
+        - name: Ensure prerequisite packages for gog are present
+          ansible.builtin.apt:
+            name:
+              - curl
+            state: present
+            update_cache: true
+
+        - name: Download gog Linux archive
+          ansible.builtin.get_url:
+            url: "{{ openclaw_gog_cli_url }}"
+            dest: "{{ openclaw_gog_cli_tmp_archive }}"
+            mode: "0644"
+
+        - name: Install gog binary
+          ansible.builtin.unarchive:
+            src: "{{ openclaw_gog_cli_tmp_archive }}"
+            dest: /usr/local/bin
+            remote_src: true
+
+        - name: Set gog executable bit
+          ansible.builtin.file:
+            path: "{{ openclaw_gog_binary }}"
+            mode: "0755"
+
+        - name: Verify gog installation
+          ansible.builtin.command: gog --version
+          register: openclaw_gog_version_after
+          changed_when: false
+          failed_when: false
+
+        - name: Show gog version
+          ansible.builtin.debug:
+            msg: "gog installed: {{ openclaw_gog_version_after.stdout_lines[0] | default(openclaw_gog_version_after.stderr_lines[0] | default('n/a')) }}"
+
+        - name: Remove temporary gog archive
+          ansible.builtin.file:
+            path: "{{ openclaw_gog_cli_tmp_archive }}"
+            state: absent
+      when: openclaw_gog_version_before.rc != 0
+
+    - name: Skip gog install
+      ansible.builtin.debug:
+        msg: >-
+          gog already available: {{
+            openclaw_gog_version_before.stdout_lines[0] |
+            default(openclaw_gog_version_before.stderr_lines[0] | default('unknown'))
+          }}
+      when: openclaw_gog_version_before.rc == 0
+
+    - name: Install tailscale
+      block:
+        - name: Ensure prerequisite packages for tailscale are installed
+          ansible.builtin.apt:
+            name:
+              - curl
+              - gnupg
+            state: present
+            update_cache: true
+
+        - name: Install tailscale signing key
+          ansible.builtin.shell: |
+            curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/{{ openclaw_apt_release }}.gpg \
+              | gpg --dearmor -o {{ openclaw_tailscale_gpg_keyring }}
+          args:
+            creates: "{{ openclaw_tailscale_gpg_keyring }}"
+
+        - name: Configure tailscale apt repository
+          ansible.builtin.apt_repository:
+            repo: "{{ openclaw_tailscale_repo }}"
+            filename: tailscale
+
+        - name: Install tailscale package
+          ansible.builtin.apt:
+            name: "tailscale={{ openclaw_tailscale_version }}"
+            state: present
+            update_cache: true
+
+        - name: Ensure tailscaled is started
+          ansible.builtin.service:
+            name: tailscaled
+            state: started
+            enabled: true
+
+        - name: Verify tailscale installation
+          ansible.builtin.command: tailscale version
+          register: openclaw_tailscale_after
+          changed_when: false
+          failed_when: false
+
+        - name: Show tailscale version
+          ansible.builtin.debug:
+            msg: "tailscale installed: {{ openclaw_tailscale_after.stdout_lines[0] | default('n/a') }}"
+      when: openclaw_tailscale_before.rc != 0
+
+    - name: Skip tailscale install
+      ansible.builtin.debug:
+        msg: "tailscale already available: {{ openclaw_tailscale_before.stdout_lines[0] | default('unknown') }}"
+      when: openclaw_tailscale_before.rc == 0

--- a/playbooks/operations/openclaw/install-openclaw-host.yml
+++ b/playbooks/operations/openclaw/install-openclaw-host.yml
@@ -1,0 +1,90 @@
+---
+# Playbook to prepare host prerequisites and install OpenClaw CLI
+
+- name: Common tasks for every playbook
+  import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+
+- name: Install OpenClaw host prerequisites
+  hosts: kube_control_plane[0]
+  become: true
+  vars:
+    openclaw_user: openclaw
+    openclaw_expected_kubectl_path: /usr/local/bin/kubectl
+    openclaw_install_script_url: https://openclaw.ai/install.sh
+    openclaw_prerequisite_packages:
+      - curl
+      - ca-certificates
+      - gnupg
+      - jq
+      - git
+      - openssl
+  pre_tasks:
+    - name: Check expected kubectl path exists
+      ansible.builtin.stat:
+        path: "{{ openclaw_expected_kubectl_path }}"
+      register: kubectl_path_check
+
+    - name: Fail if kubectl path does not match plan
+      ansible.builtin.fail:
+        msg: "Expected kubectl at {{ openclaw_expected_kubectl_path }} but it is missing on target node."
+      when: not kubectl_path_check.stat.exists
+
+    - name: Check whether reboot is pending
+      ansible.builtin.stat:
+        path: /var/run/reboot-required
+      register: reboot_required
+
+    - name: Warn when node reboot is still pending
+      ansible.builtin.debug:
+        msg: "Maintenance warning: /var/run/reboot-required is present. Schedule downtime before rollout."
+      when: reboot_required.stat.exists
+  tasks:
+    - name: Upgrade apt packages
+      ansible.builtin.apt:
+        update_cache: true
+        upgrade: dist
+
+    - name: Ensure OpenClaw prerequisite packages are installed
+      ansible.builtin.apt:
+        name: "{{ openclaw_prerequisite_packages }}"
+        state: present
+        update_cache: true
+
+    - name: Ensure openclaw service account exists
+      ansible.builtin.user:
+        name: "{{ openclaw_user }}"
+        create_home: true
+        shell: /bin/bash
+        state: present
+
+    - name: Check linger marker for openclaw
+      ansible.builtin.stat:
+        path: "/var/lib/systemd/linger/{{ openclaw_user }}"
+      register: openclaw_linger
+
+    - name: Enable linger for openclaw
+      ansible.builtin.command: "loginctl enable-linger {{ openclaw_user }}"
+      when: not openclaw_linger.stat.exists
+
+    - name: Check existing OpenClaw installation
+      ansible.builtin.command: openclaw --version
+      register: openclaw_version_before
+      changed_when: false
+      failed_when: false
+
+    - name: Install OpenClaw CLI without onboarding
+      ansible.builtin.shell: |
+        curl -fsSL {{ openclaw_install_script_url }} | bash -s -- --no-onboard
+      args:
+        executable: /bin/bash
+      when: openclaw_version_before.rc != 0
+      changed_when: true
+
+    - name: Validate OpenClaw CLI can be executed after install
+      ansible.builtin.command: openclaw --version
+      register: openclaw_version_after
+      changed_when: false
+
+    - name: Show installed OpenClaw version
+      ansible.builtin.debug:
+        msg: "{{ openclaw_version_after.stdout }}"

--- a/playbooks/operations/openclaw/openclaw-disable-tools.yml
+++ b/playbooks/operations/openclaw/openclaw-disable-tools.yml
@@ -1,0 +1,19 @@
+---
+# Canonical one-command disablement for optional OpenClaw tool capabilities
+
+- import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+- import_playbook: ./disable-openclaw-full-web-browsing.yml
+  tags:
+    - openclaw
+    - openclaw-tools
+    - openclaw-tools-browser
+- import_playbook: ./disable-openclaw-exec-tool.yml
+  tags:
+    - openclaw
+    - openclaw-tools
+    - openclaw-tools-exec
+- import_playbook: ./disable-openclaw-file-tool.yml
+  tags:
+    - openclaw
+    - openclaw-tools
+    - openclaw-tools-file

--- a/playbooks/operations/openclaw/openclaw-enable-tools.yml
+++ b/playbooks/operations/openclaw/openclaw-enable-tools.yml
@@ -1,0 +1,19 @@
+---
+# Canonical one-command enablement for optional OpenClaw tool capabilities
+
+- import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+- import_playbook: ./configure-openclaw-file-tool.yml
+  tags:
+    - openclaw
+    - openclaw-tools
+    - openclaw-tools-file
+- import_playbook: ./configure-openclaw-exec-tool.yml
+  tags:
+    - openclaw
+    - openclaw-tools
+    - openclaw-tools-exec
+- import_playbook: ./configure-openclaw-full-web-browsing.yml
+  tags:
+    - openclaw
+    - openclaw-tools
+    - openclaw-tools-browser

--- a/playbooks/operations/openclaw/openclaw-install.yml
+++ b/playbooks/operations/openclaw/openclaw-install.yml
@@ -1,0 +1,37 @@
+---
+# Canonical one-command OpenClaw platform bootstrap
+
+- import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+- import_playbook: ./show-openclaw-preflight.yml
+  tags:
+    - openclaw
+    - openclaw-preflight
+- import_playbook: ./install-openclaw-host.yml
+  tags:
+    - openclaw
+    - openclaw-bootstrap
+    - openclaw-host
+- import_playbook: ./install-openclaw-dependencies.yml
+  tags:
+    - openclaw
+    - openclaw-bootstrap
+    - openclaw-deps
+- import_playbook: ./configure-openclaw-installation-mode.yml
+  tags:
+    - openclaw
+    - openclaw-bootstrap
+    - openclaw-config
+- import_playbook: ./configure-openclaw-kubeconfig.yml
+  tags:
+    - openclaw
+    - openclaw-bootstrap
+    - openclaw-config
+- import_playbook: ./enable-openclaw-gateway-autostart.yml
+  tags:
+    - openclaw
+    - openclaw-bootstrap
+    - openclaw-service
+- import_playbook: ./show-openclaw-installation-mode-status.yml
+  tags:
+    - openclaw
+    - openclaw-postcheck

--- a/playbooks/operations/openclaw/openclaw-remove.yml
+++ b/playbooks/operations/openclaw/openclaw-remove.yml
@@ -1,0 +1,33 @@
+---
+# Canonical one-command OpenClaw platform teardown (runtime + host cleanup)
+
+- import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+- import_playbook: ./disable-openclaw-gateway-autostart.yml
+  tags:
+    - openclaw
+    - openclaw-teardown
+    - openclaw-service
+- import_playbook: ./remove-openclaw-installation-mode.yml
+  tags:
+    - openclaw
+    - openclaw-teardown
+    - openclaw-config
+- import_playbook: ./remove-openclaw-kubeconfig.yml
+  tags:
+    - openclaw
+    - openclaw-teardown
+    - openclaw-config
+- import_playbook: ./remove-openclaw-dependencies.yml
+  tags:
+    - openclaw
+    - openclaw-teardown
+    - openclaw-deps
+- import_playbook: ./remove-openclaw-host.yml
+  tags:
+    - openclaw
+    - openclaw-teardown
+    - openclaw-host
+- import_playbook: ./show-openclaw-preflight.yml
+  tags:
+    - openclaw
+    - openclaw-postcheck

--- a/playbooks/operations/openclaw/remove-openclaw-dependencies.yml
+++ b/playbooks/operations/openclaw/remove-openclaw-dependencies.yml
@@ -1,0 +1,76 @@
+---
+# Remove optional dependencies used by OpenClaw integrations (Gmail/webhooks workflows)
+
+- name: Common tasks for every playbook
+  import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+
+- name: Remove OpenClaw integration dependencies
+  hosts: kube_control_plane[0]
+  become: true
+  vars:
+    openclaw_tailscale_gpg_keyring: /usr/share/keyrings/tailscale-archive-keyring.gpg
+    openclaw_google_cloud_cli_gpg_keyring: /usr/share/keyrings/google-cloud-sdk-archive-keyring.gpg
+    openclaw_gog_binary: /usr/local/bin/gog
+    openclaw_google_cloud_repo_file: /etc/apt/sources.list.d/google-cloud-sdk.list
+    openclaw_tailscale_repo_file: /etc/apt/sources.list.d/tailscale.list
+
+  tasks:
+    - name: Check gog installation
+      ansible.builtin.stat:
+        path: "{{ openclaw_gog_binary }}"
+      register: openclaw_gog_binary_check
+
+    - name: Remove gog binary
+      ansible.builtin.file:
+        path: "{{ openclaw_gog_binary }}"
+        state: absent
+      when: openclaw_gog_binary_check.stat.exists
+
+    - name: Remove gcloud apt repository package
+      ansible.builtin.apt:
+        name: google-cloud-cli
+        state: absent
+        purge: true
+      register: openclaw_gcloud_apt_removed
+      failed_when: false
+
+    - name: Remove tailscale package
+      ansible.builtin.apt:
+        name: tailscale
+        state: absent
+        purge: true
+      register: openclaw_tailscale_apt_removed
+      failed_when: false
+
+    - name: Stop and disable tailscaled service
+      ansible.builtin.service:
+        name: tailscaled
+        state: stopped
+        enabled: false
+      failed_when: false
+
+    - name: Remove google cloud apt sources and keyring
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ openclaw_google_cloud_repo_file }}"
+        - "{{ openclaw_google_cloud_cli_gpg_keyring }}"
+
+    - name: Remove tailscale apt sources and keyring
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ openclaw_tailscale_repo_file }}"
+        - "{{ openclaw_tailscale_gpg_keyring }}"
+
+    - name: Refresh apt package cache
+      ansible.builtin.apt:
+        update_cache: true
+
+    - name: Verify gcloud and tailscale removals
+      ansible.builtin.debug:
+        msg: >-
+          google-cloud-cli removed: {{ openclaw_gcloud_apt_removed.changed | default(false) }};
+          tailscale removed: {{ openclaw_tailscale_apt_removed.changed | default(false) }}

--- a/playbooks/operations/openclaw/remove-openclaw-host.yml
+++ b/playbooks/operations/openclaw/remove-openclaw-host.yml
@@ -1,0 +1,85 @@
+---
+# Playbook to remove OpenClaw host installation and service account
+
+- name: Common tasks for every playbook
+  import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+
+- name: Remove OpenClaw host prerequisites
+  hosts: kube_control_plane[0]
+  become: true
+  vars:
+    openclaw_user: openclaw
+    openclaw_service_name: openclaw-gateway
+    openclaw_service_unit: "/etc/systemd/system/{{ openclaw_service_name }}.service"
+    openclaw_binary_paths:
+      - /usr/local/bin/openclaw
+      - /usr/bin/openclaw
+  pre_tasks:
+    - name: Check whether openclaw user exists
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ openclaw_user }}"
+        fail_key: false
+      register: openclaw_passwd
+
+    - name: Set user existence fact
+      ansible.builtin.set_fact:
+        openclaw_user_exists: >-
+          {{
+            openclaw_passwd.ansible_facts.getent_passwd is defined and
+            openclaw_user in openclaw_passwd.ansible_facts.getent_passwd
+          }}
+  tasks:
+    - name: Stop and disable OpenClaw gateway system service
+      ansible.builtin.systemd:
+        name: "{{ openclaw_service_name }}.service"
+        enabled: false
+        state: stopped
+      failed_when: false
+
+    - name: Remove OpenClaw gateway system service file
+      ansible.builtin.file:
+        path: "{{ openclaw_service_unit }}"
+        state: absent
+
+    - name: Stop OpenClaw gateway user service if present
+      ansible.builtin.command: "runuser -l {{ openclaw_user }} -c 'systemctl --user stop openclaw-gateway'"
+      register: openclaw_gateway_stop
+      changed_when: openclaw_gateway_stop.rc == 0
+      failed_when: false
+      when: openclaw_user_exists
+
+    - name: Reload systemd manager configuration
+      ansible.builtin.command: systemctl daemon-reload
+      changed_when: false
+
+    - name: Disable linger for openclaw
+      ansible.builtin.command: "loginctl disable-linger {{ openclaw_user }}"
+      register: openclaw_linger_disable
+      changed_when: openclaw_linger_disable.rc == 0
+      failed_when: false
+      when: openclaw_user_exists
+
+    - name: Remove openclaw user and home directory
+      ansible.builtin.user:
+        name: "{{ openclaw_user }}"
+        state: absent
+        remove: true
+        force: true
+      when: openclaw_user_exists
+
+    - name: Remove lingering marker
+      ansible.builtin.file:
+        path: "/var/lib/systemd/linger/{{ openclaw_user }}"
+        state: absent
+
+    - name: Remove OpenClaw binaries from common locations
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop: "{{ openclaw_binary_paths }}"
+
+    - name: Remove legacy openclaw auto-update cron entry
+      ansible.builtin.cron:
+        name: "openclaw auto-update"
+        state: absent

--- a/playbooks/operations/openclaw/remove-openclaw-installation-mode.yml
+++ b/playbooks/operations/openclaw/remove-openclaw-installation-mode.yml
@@ -1,0 +1,56 @@
+---
+# Playbook to remove OpenClaw hardened installation mode files
+
+- name: Common tasks for every playbook
+  import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+
+- name: Remove OpenClaw hardened installation mode files
+  hosts: kube_control_plane[0]
+  become: true
+  vars:
+    openclaw_user: openclaw
+    openclaw_home: "/home/{{ openclaw_user }}"
+    openclaw_config_dir: "{{ openclaw_home }}/.openclaw"
+    openclaw_config_file: "{{ openclaw_config_dir }}/openclaw.json"
+    openclaw_env_file: "{{ openclaw_config_dir }}/.env"
+    openclaw_purge_config_dir: false
+  pre_tasks:
+    - name: Check whether openclaw user exists
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ openclaw_user }}"
+        fail_key: false
+      register: openclaw_passwd
+
+    - name: Set user existence fact
+      ansible.builtin.set_fact:
+        openclaw_user_exists: >-
+          {{
+            openclaw_passwd.ansible_facts.getent_passwd is defined and
+            openclaw_user in openclaw_passwd.ansible_facts.getent_passwd
+          }}
+  tasks:
+    - name: Stop OpenClaw gateway user service if present
+      ansible.builtin.command: "runuser -l {{ openclaw_user }} -c 'systemctl --user stop openclaw-gateway'"
+      register: openclaw_gateway_stop
+      changed_when: openclaw_gateway_stop.rc == 0
+      failed_when: false
+      when: openclaw_user_exists
+
+    - name: Remove OpenClaw hardened config
+      ansible.builtin.file:
+        path: "{{ openclaw_config_file }}"
+        state: absent
+      when: openclaw_user_exists
+
+    - name: Remove OpenClaw Telegram token env file
+      ansible.builtin.file:
+        path: "{{ openclaw_env_file }}"
+        state: absent
+      when: openclaw_user_exists
+
+    - name: Optionally remove entire OpenClaw config directory
+      ansible.builtin.file:
+        path: "{{ openclaw_config_dir }}"
+        state: absent
+      when: openclaw_user_exists and (openclaw_purge_config_dir | bool)

--- a/playbooks/operations/openclaw/remove-openclaw-kubeconfig.yml
+++ b/playbooks/operations/openclaw/remove-openclaw-kubeconfig.yml
@@ -1,0 +1,42 @@
+---
+# Playbook to remove the dedicated kubeconfig used by OpenClaw
+
+- name: Common tasks for every playbook
+  import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+
+- name: Remove OpenClaw kubeconfig
+  hosts: kube_control_plane[0]
+  become: true
+  vars:
+    openclaw_user: openclaw
+    openclaw_home: "/home/{{ openclaw_user }}"
+    openclaw_kubeconfig_path: "{{ openclaw_home }}/.kube/config"
+    openclaw_kube_dir: "{{ openclaw_home }}/.kube"
+    openclaw_purge_kube_dir: false
+  pre_tasks:
+    - name: Check whether openclaw user exists
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ openclaw_user }}"
+        fail_key: false
+      register: openclaw_passwd
+
+    - name: Set user existence fact
+      ansible.builtin.set_fact:
+        openclaw_user_exists: >-
+          {{
+            openclaw_passwd.ansible_facts.getent_passwd is defined and
+            openclaw_user in openclaw_passwd.ansible_facts.getent_passwd
+          }}
+  tasks:
+    - name: Remove OpenClaw kubeconfig file
+      ansible.builtin.file:
+        path: "{{ openclaw_kubeconfig_path }}"
+        state: absent
+      when: openclaw_user_exists
+
+    - name: Optionally remove OpenClaw kube directory
+      ansible.builtin.file:
+        path: "{{ openclaw_kube_dir }}"
+        state: absent
+      when: openclaw_user_exists and (openclaw_purge_kube_dir | bool)

--- a/playbooks/operations/openclaw/show-openclaw-installation-mode-status.yml
+++ b/playbooks/operations/openclaw/show-openclaw-installation-mode-status.yml
@@ -1,0 +1,132 @@
+---
+# Status checks after OpenClaw installation mode rollout
+
+- name: Common tasks for every playbook
+  import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+
+- name: Show OpenClaw installation mode status
+  hosts: kube_control_plane[0]
+  become: true
+  vars:
+    openclaw_user: openclaw
+    openclaw_home: "/home/{{ openclaw_user }}"
+    openclaw_config_file: "{{ openclaw_home }}/.openclaw/openclaw.json"
+    openclaw_env_file: "{{ openclaw_home }}/.openclaw/.env"
+    openclaw_kubeconfig_path: "{{ openclaw_home }}/.kube/config"
+    openclaw_service_name: openclaw-gateway
+    openclaw_service_unit_file: "/etc/systemd/system/{{ openclaw_service_name }}.service"
+  tasks:
+    - name: Check OpenClaw CLI version
+      ansible.builtin.command: "runuser -l {{ openclaw_user }} -c 'openclaw --version'"
+      register: openclaw_version
+      changed_when: false
+      failed_when: false
+
+    - name: Check openclaw user existence
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ openclaw_user }}"
+        fail_key: false
+      register: openclaw_passwd
+
+    - name: Check linger marker
+      ansible.builtin.stat:
+        path: "/var/lib/systemd/linger/{{ openclaw_user }}"
+      register: openclaw_linger
+
+    - name: Check OpenClaw config file
+      ansible.builtin.stat:
+        path: "{{ openclaw_config_file }}"
+      register: openclaw_config_stat
+
+    - name: Check OpenClaw env file
+      ansible.builtin.stat:
+        path: "{{ openclaw_env_file }}"
+      register: openclaw_env_stat
+
+    - name: Check OpenClaw kubeconfig file
+      ansible.builtin.stat:
+        path: "{{ openclaw_kubeconfig_path }}"
+      register: openclaw_kubeconfig_stat
+
+    - name: Check OpenClaw systemd service file
+      ansible.builtin.stat:
+        path: "{{ openclaw_service_unit_file }}"
+      register: openclaw_service_unit
+
+    - name: Read OpenClaw config for browser policy
+      ansible.builtin.slurp:
+        path: "{{ openclaw_config_file }}"
+      register: openclaw_config_raw
+      when: openclaw_config_stat.stat.exists
+
+    - name: Parse OpenClaw config
+      ansible.builtin.set_fact:
+        openclaw_config_json: "{{ openclaw_config_raw.content | b64decode | from_json }}"
+      when: openclaw_config_stat.stat.exists
+
+    - name: Read main agent tool allowlist for session-level diagnostics
+      ansible.builtin.set_fact:
+        openclaw_main_agent_tools_allow: >-
+          {{
+            (
+              openclaw_config_json.agents.list | default([])
+              | selectattr("id", "equalto", "main")
+              | map(attribute="tools")
+              | map(attribute="allow", default=[])
+              | list
+            )[0] | default([])
+          }}
+      when: openclaw_config_stat.stat.exists
+
+    - name: Check if OpenClaw gateway service is enabled
+      ansible.builtin.command: "systemctl is-enabled {{ openclaw_service_name }}.service"
+      register: openclaw_service_enabled
+      changed_when: false
+      failed_when: false
+
+    - name: Check if OpenClaw gateway service is active
+      ansible.builtin.command: "systemctl is-active {{ openclaw_service_name }}.service"
+      register: openclaw_service_active
+      changed_when: false
+      failed_when: false
+
+    - name: Check read access with OpenClaw kubeconfig
+      ansible.builtin.command: >-
+        runuser -l {{ openclaw_user }} -c
+        "kubectl --kubeconfig={{ openclaw_kubeconfig_path }} auth can-i get pods --all-namespaces"
+      register: openclaw_can_get_pods
+      changed_when: false
+      failed_when: false
+      when: openclaw_kubeconfig_stat.stat.exists
+
+    - name: Check delete access with OpenClaw kubeconfig
+      ansible.builtin.command: >-
+        runuser -l {{ openclaw_user }} -c
+        "kubectl --kubeconfig={{ openclaw_kubeconfig_path }} auth can-i delete pods --all-namespaces"
+      register: openclaw_can_delete_pods
+      changed_when: false
+      failed_when: false
+      when: openclaw_kubeconfig_stat.stat.exists
+
+    - name: Show status summary
+      ansible.builtin.debug:
+        msg:
+          - "openclaw version command rc: {{ openclaw_version.rc }}"
+          - "openclaw version: {{ openclaw_version.stdout | default('not installed') }}"
+          - "openclaw user present: {{ (openclaw_passwd.ansible_facts.getent_passwd is defined) and (openclaw_user in openclaw_passwd.ansible_facts.getent_passwd) }}"
+          - "linger enabled: {{ openclaw_linger.stat.exists }}"
+          - "config file present: {{ openclaw_config_stat.stat.exists }}"
+          - "env file present: {{ openclaw_env_stat.stat.exists }}"
+          - "kubeconfig present: {{ openclaw_kubeconfig_stat.stat.exists }}"
+          - "systemd unit present: {{ openclaw_service_unit.stat.exists }}"
+          - "systemd enabled: {{ (openclaw_service_enabled.stdout | trim) if openclaw_service_enabled.rc == 0 else 'disabled' }}"
+          - "systemd active: {{ (openclaw_service_active.stdout | trim) if openclaw_service_active.rc == 0 else 'inactive' }}"
+          - "browser tool denied: {{ 'browser' in (openclaw_config_json.tools.deny | default([])) if openclaw_config_stat.stat.exists else 'unknown' }}"
+          - "browser enabled: {{ (openclaw_config_json.browser.enabled | default(false)) if openclaw_config_stat.stat.exists else 'unknown' }}"
+          - "main agent browser allowlist: {{ openclaw_main_agent_tools_allow | default([]) if openclaw_config_stat.stat.exists else 'unknown' }}"
+          - "filesystem tools denied: {{ 'group:fs' in (openclaw_config_json.tools.deny | default([])) if openclaw_config_stat.stat.exists else 'unknown' }}"
+          - "exec tool denied: {{ 'exec' in (openclaw_config_json.tools.deny | default([])) if openclaw_config_stat.stat.exists else 'unknown' }}"
+          - "main agent exec allowlisted: {{ 'exec' in (openclaw_main_agent_tools_allow | default([])) if openclaw_config_stat.stat.exists else 'unknown' }}"
+          - "kube can-i get pods -A: {{ (openclaw_can_get_pods.stdout | trim) if openclaw_kubeconfig_stat.stat.exists else 'not checked' }}"
+          - "kube can-i delete pods -A: {{ (openclaw_can_delete_pods.stdout | trim) if openclaw_kubeconfig_stat.stat.exists else 'not checked' }}"

--- a/playbooks/operations/openclaw/show-openclaw-preflight.yml
+++ b/playbooks/operations/openclaw/show-openclaw-preflight.yml
@@ -1,0 +1,62 @@
+---
+# Read-only preflight checks before OpenClaw installation mode rollout
+
+- name: Common tasks for every playbook
+  import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+
+- name: Show OpenClaw preflight status
+  hosts: kube_control_plane[0]
+  become: true
+  vars:
+    openclaw_user: openclaw
+    kubectl_expected_path: /usr/local/bin/kubectl
+    kubeconfig_admin_path: /etc/kubernetes/admin.conf
+  tasks:
+    - name: Check OpenClaw CLI path
+      ansible.builtin.shell: command -v openclaw
+      args:
+        executable: /bin/bash
+      register: openclaw_path
+      changed_when: false
+      failed_when: false
+
+    - name: Check openclaw user existence
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ openclaw_user }}"
+        fail_key: false
+      register: openclaw_passwd
+
+    - name: Check expected kubectl path exists
+      ansible.builtin.stat:
+        path: "{{ kubectl_expected_path }}"
+      register: kubectl_expected_stat
+
+    - name: Check admin kubeconfig exists
+      ansible.builtin.stat:
+        path: "{{ kubeconfig_admin_path }}"
+      register: admin_kubeconfig_stat
+
+    - name: Check reboot-required marker
+      ansible.builtin.stat:
+        path: /var/run/reboot-required
+      register: reboot_required
+
+    - name: Check admin kubeconfig delete privileges
+      ansible.builtin.command: >-
+        kubectl --kubeconfig={{ kubeconfig_admin_path }}
+        auth can-i delete pods --all-namespaces
+      register: admin_can_delete_pods
+      changed_when: false
+      failed_when: false
+      when: admin_kubeconfig_stat.stat.exists
+
+    - name: Show preflight summary
+      ansible.builtin.debug:
+        msg:
+          - "openclaw binary present: {{ openclaw_path.rc == 0 }}"
+          - "openclaw user present: {{ (openclaw_passwd.ansible_facts.getent_passwd is defined) and (openclaw_user in openclaw_passwd.ansible_facts.getent_passwd) }}"
+          - "kubectl path {{ kubectl_expected_path }} present: {{ kubectl_expected_stat.stat.exists }}"
+          - "admin kubeconfig present: {{ admin_kubeconfig_stat.stat.exists }}"
+          - "reboot required: {{ reboot_required.stat.exists }}"
+          - "admin can delete pods -A: {{ (admin_can_delete_pods.stdout | trim) if admin_kubeconfig_stat.stat.exists else 'unknown (admin kubeconfig missing)' }}"

--- a/playbooks/operations/security/README.md
+++ b/playbooks/operations/security/README.md
@@ -1,0 +1,5 @@
+# Security Operations
+
+Cluster security playbooks for maintenance tasks.
+
+- `sync-certificates.yml` - Synchronize TLS certificates across namespaces

--- a/soydocs/openclaw-installation-mode-plan.md
+++ b/soydocs/openclaw-installation-mode-plan.md
@@ -1,0 +1,583 @@
+# OpenClaw Installation Mode Plan
+
+## Goal
+
+Install OpenClaw on the Ubuntu mini PC in a hardened mode for:
+
+- Telegram DM control (pairing-only)
+- Public web research, with optional full browser automation when explicitly enabled
+- `kubectl` execution, matching host SSH admin permissions
+- ChatGPT Codex subscription auth (no OpenAI API key)
+
+## Scope and guardrails
+
+- Host-level setup is done on the mini PC (`192.168.1.10`).
+- OpenClaw runs as dedicated user `openclaw`, not `root`.
+- Gateway UI stays on localhost and is accessed only via SSH tunnel.
+- OpenClaw Kubernetes access is provisioned using host admin kubeconfig, matching SSH admin context.
+
+## Runbook Mapping
+
+Primary flow is now consolidated into these two entrypoints:
+
+- `openclaw-install.yml` - bootstrap install + deps + hardened config + kubeconfig + gateway autostart + status checks
+- `openclaw-remove.yml` - teardown of gateway autostart, install-mode configs, kubeconfig, dependencies, and host identity
+
+Legacy direct-run playbooks still exist for granular control:
+
+- `configure-openclaw-full-web-browsing.yml` - install Chromium/Playwright and enable browser tool access
+- `configure-openclaw-file-tool.yml` - remove filesystem deny block (`group:fs`) and enable file tooling
+- `configure-openclaw-exec-tool.yml` - remove exec deny block and enable command execution tooling
+- `configure-openclaw-installation-mode.yml` - write hardened runtime config and service settings
+- `configure-openclaw-kubeconfig.yml` - copy `/etc/kubernetes/admin.conf` for matching Kubernetes privileges
+- `disable-openclaw-exec-tool.yml` - re-add exec denial and remove exec from agent allowlist
+- `disable-openclaw-file-tool.yml` - re-add `group:fs` deny and remove file tool from allowlist
+- `disable-openclaw-full-web-browsing.yml` - disable browser tool and browser automation in OpenClaw config
+- `disable-openclaw-gateway-autostart.yml` - stop and remove boot-start service
+- `enable-openclaw-gateway-autostart.yml` - create and enable systemd service so OpenClaw starts after reboot
+- `install-openclaw-dependencies.yml` - install Google Cloud CLI, `gog`, tailscale
+- `install-openclaw-host.yml` - install host prerequisites and CLI
+- `remove-openclaw-host.yml` - remove install, service user, and lingering state
+- `remove-openclaw-installation-mode.yml` - remove hardened config only
+- `remove-openclaw-kubeconfig.yml` - remove OpenClaw kubeconfig
+- `remove-openclaw-dependencies.yml` - remove integration dependencies
+- `show-openclaw-installation-mode-status.yml` - post-change verification
+- `show-openclaw-preflight.yml` - initial readiness check before rollout
+- `audit-openclaw-security.yml` - security review
+
+## Current-state scouting (2026-02-15)
+
+Read-only checks on `node-0` found:
+
+- OpenClaw is not installed yet (`openclaw` binary absent).
+- `openclaw` user/home do not exist yet.
+- `kubectl` is installed at `/usr/local/bin/kubectl` (not `/usr/bin` or `/snap/bin`).
+- `/etc/kubernetes/admin.conf` exists and maps to `kubernetes-admin@cluster.local`.
+- With that admin kubeconfig, `kubectl auth can-i delete pods -A` returns `yes` (full admin).
+- Node is single `control-plane,worker` and currently reports `reboot-required`.
+
+## Phase 0: Preflight for single-node downtime risk
+
+- Because this is a single-node control-plane + worker cluster, any reboot is full cluster downtime.
+- A reboot is already pending on the host, so schedule a maintenance window before starting OpenClaw rollout.
+- Confirm `kubectl` allowlist target path as `/usr/local/bin/kubectl`.
+
+## Phase 1: Prepare host and service account
+
+Run as `root`:
+
+```bash
+apt update
+apt -y upgrade
+apt -y install curl ca-certificates gnupg jq git openssl
+useradd -m -s /bin/bash openclaw
+loginctl enable-linger openclaw
+```
+
+Security note:
+
+- Do not add `openclaw` to `sudo` by default. Keep it as an unprivileged service account.
+- If temporary sudo is ever required for break-glass troubleshooting, grant and remove it explicitly.
+
+Validation:
+
+```bash
+id openclaw
+loginctl show-user openclaw | grep Linger
+```
+
+## Phase 2: Install OpenClaw CLI without root onboarding
+
+Run as `root`:
+
+```bash
+curl -fsSL https://openclaw.ai/install.sh | bash -s -- --no-onboard
+```
+
+Implementation detail used by this repo:
+
+- `install-openclaw-host.yml` runs `https://openclaw.ai/install.sh` during initial provisioning only.
+- OpenClaw itself is expected to self-manage updates after install.
+
+Validation:
+
+```bash
+openclaw --version
+```
+
+## Phase 3: Onboard as `openclaw` with Codex OAuth
+
+Switch user:
+
+```bash
+sudo -iu openclaw
+```
+
+Run onboarding:
+
+```bash
+openclaw onboard --install-daemon --auth-choice openai-codex
+```
+
+Wizard targets:
+
+- Auth choice: `openai-codex`
+- Primary model: `openai-codex/gpt-5.3-codex`
+- Complete headless OAuth flow if callback cannot bind
+
+Validation:
+
+```bash
+systemctl --user status openclaw-gateway
+journalctl --user -u openclaw-gateway --no-pager -n 200
+```
+
+## Phase 4: Configure Telegram securely
+
+1. Create bot token with `@BotFather` (human step).
+2. Save token as `openclaw`:
+
+```bash
+umask 077
+mkdir -p ~/.openclaw
+cat > ~/.openclaw/.env <<'EOF'
+TELEGRAM_BOT_TOKEN=PASTE_TOKEN_HERE
+EOF
+```
+
+3. Set minimal hardened config in `~/.openclaw/openclaw.json`:
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "openai-codex/gpt-5.3-codex" },
+      heartbeat: { every: "0m" },
+    },
+  },
+
+  channels: {
+    telegram: {
+      enabled: true,
+      botToken: "${TELEGRAM_BOT_TOKEN}",
+      dmPolicy: "pairing",
+      groupPolicy: "disabled",
+    },
+  },
+
+  tools: {
+    deny: ["group:fs", "browser", "canvas", "nodes", "cron", "gateway"],
+    elevated: { enabled: false },
+  },
+}
+```
+
+4. Restart and verify:
+
+```bash
+systemctl --user restart openclaw-gateway || true
+journalctl --user -u openclaw-gateway --no-pager -n 200 || true
+# Fallback when systemd --user is unavailable:
+sudo -u openclaw sh -lc 'cd /home/openclaw && HOME=/home/openclaw openclaw gateway run'
+openclaw logs --follow
+```
+
+## Phase 4a: Enable gateway on boot
+
+Run on host:
+
+```bash
+ansible-playbook -i kubespray/inventory/soycluster/hosts.yml \
+  --become --become-user=root --user ubuntu \
+  playbooks/operations/openclaw/enable-openclaw-gateway-autostart.yml
+```
+
+Validation:
+
+```bash
+sudo systemctl status openclaw-gateway
+sudo systemctl is-enabled openclaw-gateway
+sudo systemctl is-active openclaw-gateway
+curl --silent --max-time 2 http://127.0.0.1:18789/ | head
+```
+
+Expected:
+
+- Unit installed at `/etc/systemd/system/openclaw-gateway.service`.
+- `enabled = enabled` and `active = active`.
+- Dashboard still binds loopback-only (`127.0.0.1:18789`).
+
+## Phase 5: Pair Telegram account
+
+From phone, DM bot once. Then as `openclaw`:
+
+```bash
+openclaw pairing list telegram
+openclaw pairing approve telegram CODE_FROM_THE_LIST
+```
+
+Expected result:
+
+- Only approved DM can control the agent.
+- Groups remain disabled.
+
+## Phase 6: Enable safe web access mode
+
+- Keep `browser` denied.
+- Use OpenClaw web tools (`web_fetch`) for public internet research.
+- Keep filesystem tools denied (`group:fs`) to reduce secret exposure risk.
+- Keep command execution intentionally off until phase 6b.
+
+### Phase 6a: Optional file tool enablement
+
+Run when you explicitly want filesystem access inside OpenClaw sessions:
+
+```bash
+ansible-playbook -i kubespray/inventory/soycluster/hosts.yml \
+  --become --become-user=root --user ubuntu \
+  playbooks/operations/openclaw/configure-openclaw-file-tool.yml
+```
+
+What this changes:
+
+- Removes `group:fs` from `tools.deny`.
+- Adds `group:fs` to `agents.main.tools.allow`.
+- Restarts gateway so the session tool manifest is rebuilt.
+
+Validation:
+
+- `openclaw config get tools.deny` does not include `group:fs`.
+- `openclaw config get agents` includes `main -> tools -> allow` with `group:fs`.
+
+Rollback:
+
+```bash
+ansible-playbook -i kubespray/inventory/soycluster/hosts.yml \
+  --become --become-user=root --user ubuntu \
+  playbooks/operations/openclaw/disable-openclaw-file-tool.yml
+```
+
+### Phase 6b: Optional exec tooling enablement
+
+Run when you want OpenClaw to run shell commands (`gog`, `kubectl`, etc.):
+
+```bash
+ansible-playbook -i kubespray/inventory/soycluster/hosts.yml \
+  --become --become-user=root --user ubuntu \
+  playbooks/operations/openclaw/configure-openclaw-exec-tool.yml
+```
+
+What this changes:
+
+- Removes `exec` from `tools.deny`.
+- Adds `exec` to `agents.main.tools.allow`.
+- Restarts gateway so the session tool manifest is rebuilt.
+
+Validation:
+
+- `openclaw config get tools.deny` does not include `exec`.
+- `openclaw config get agents` includes `main -> tools -> allow` with `exec`.
+- Ask OpenClaw to execute a harmless command and confirm output.
+
+Rollback:
+
+```bash
+ansible-playbook -i kubespray/inventory/soycluster/hosts.yml \
+  --become --become-user=root --user ubuntu \
+  playbooks/operations/openclaw/disable-openclaw-exec-tool.yml
+```
+
+## Phase 6c: Enable full browser automation (explicit gate)
+
+Run:
+
+```bash
+ansible-playbook -i kubespray/inventory/soycluster/hosts.yml \
+  --become --become-user=root --user ubuntu \
+  playbooks/operations/openclaw/configure-openclaw-full-web-browsing.yml
+```
+
+Validation:
+
+- `openclaw config get tools.deny` should no longer include `browser`.
+- `openclaw config get browser` returns enabled settings with `defaultProfile` set (typically `openclaw`).
+- `openclaw browser --browser-profile openclaw status` returns a reachable status.
+- OpenClaw logs should show browser control service availability.
+
+Rollback:
+
+```bash
+ansible-playbook -i kubespray/inventory/soycluster/hosts.yml \
+  --become --become-user=root --user ubuntu \
+  playbooks/operations/openclaw/disable-openclaw-full-web-browsing.yml
+```
+
+## Phase 7: Restrict exec command allowlist for safety
+
+Open Control UI over SSH tunnel from laptop:
+
+```bash
+ssh -L 18789:127.0.0.1:18789 openclaw@YOUR_SERVER
+```
+
+Then browse locally to `http://127.0.0.1:18789/` and configure Exec approvals:
+
+- target: Gateway
+- agent: `main`
+- `security: allowlist`
+- `ask: off`
+- `askFallback: deny`
+- `autoAllowSkills: false`
+- allowlist entries: full binary path only.
+  - minimum baseline: `/usr/local/bin/kubectl`
+  - add `/usr/local/bin/gog` only when you want OpenClaw to run gmail CLI commands.
+
+Validation:
+
+- `kubectl` commands are allowed.
+- `bash`, `cat`, `curl`, `env`, etc. are denied.
+
+## Phase 8: Match OpenClaw Kubernetes permissions to node admin
+
+Use the host admin kubeconfig as the OpenClaw identity source:
+
+1. Ensure `openclaw` OS user exists and linger is enabled.
+2. Copy `/etc/kubernetes/admin.conf` to:
+
+```bash
+/home/openclaw/.kube/config
+```
+
+Permissions:
+
+```bash
+chmod 600 /home/openclaw/.kube/config
+chown openclaw:openclaw /home/openclaw/.kube/config
+```
+
+Validation:
+
+- `KUBECONFIG=/home/openclaw/.kube/config kubectl auth can-i get pods --all-namespaces` returns yes.
+- `KUBECONFIG=/home/openclaw/.kube/config kubectl auth can-i delete pods --all-namespaces` returns yes.
+
+## Phase 9: Run security audit and apply fixes
+
+As `openclaw`:
+
+```bash
+openclaw security audit --deep
+openclaw security audit --fix
+```
+
+Post-check:
+
+- Re-run deep audit and confirm remaining findings are understood/accepted.
+
+## Phase 11: Rollback for autostart
+
+- To disable boot start while keeping config and binary:
+
+```bash
+ansible-playbook -i kubespray/inventory/soycluster/hosts.yml \
+  --become --become-user=root --user ubuntu \
+  playbooks/operations/openclaw/disable-openclaw-gateway-autostart.yml
+```
+
+- To fully remove OpenClaw installation:
+
+```bash
+ansible-playbook -i kubespray/inventory/soycluster/hosts.yml \
+  --become --become-user=root --user ubuntu \
+  playbooks/operations/openclaw/remove-openclaw-host.yml
+```
+
+## Phase 10: Progressive capability expansion (one-by-one + review)
+
+Use this when current limits are too strict and you want to add power safely.
+
+Change-control loop (repeat for every new capability):
+
+1. Pick exactly one capability to add.
+2. Define success criteria and a rollback trigger before deployment.
+3. Implement via code/config in a branch and push first.
+4. Deploy only that single change.
+5. Run validation checks and real-user test prompts.
+6. Review logs/audit output for at least one observation window.
+7. Keep or revert, then document the decision/date.
+
+Default observation window:
+
+- Low risk: 24 hours
+- Medium/high risk: 72 hours
+
+Rollback rule:
+
+- If unexpected behavior appears, revert the last single capability change only.
+
+### Expansion ladder (recommended order)
+
+#### Step 10.1: Reduce Kubernetes permissions later (if desired)
+
+- Keep exec restricted to `/usr/local/bin/kubectl`.
+- Add only required new verbs/resources for one namespace/app at a time.
+- Validate both allow and deny behavior:
+  - `KUBECONFIG=/home/openclaw/.kube/config kubectl auth can-i <verb> <resource> -n <allowed-ns>`
+  - `KUBECONFIG=/home/openclaw/.kube/config kubectl auth can-i <verb> <resource> -n kube-system`
+
+#### Step 10.2: Add one more host binary (if needed)
+
+- Add one explicit binary path in Exec approvals allowlist (for example `helm`), not a wildcard.
+- Verify that only the new binary is added and all other binaries remain denied.
+
+#### Step 10.3: Relax Telegram policy incrementally
+
+- Keep DMs in `pairing`.
+- If group support is needed later, enable only for explicit approved chats and test with a non-approved chat first.
+
+#### Step 10.4: Relax tool denies incrementally
+
+- Remove one denied tool at a time from `tools.deny`.
+- Test that the new tool works and that previous guardrails still hold.
+- Keep `tools.elevated.enabled: false` unless there is a strict break-glass need.
+
+#### Step 10.5: Enable heartbeat last
+
+- Change from `0m` to a conservative interval only after prior steps are stable.
+- Review behavior for noisy/unexpected proactive actions before reducing interval further.
+
+### Review checklist per step
+
+- No new secrets exposed in logs or chat.
+- No unapproved command paths executed.
+- Kubernetes actions match intended cluster access profile.
+- Telegram access scope matches intended policy.
+- `openclaw security audit --deep` remains clean or deviations are accepted and documented.
+
+## Phase 12: Gmail webhooks saga (post-installation)
+
+This is the exact saga from the current cluster install. Keep this as the reference
+when re-running Gmail webhooks on the same node.
+
+### What happened (in order)
+
+- Initial `openclaw webhooks gmail setup` worked only after:
+  - installing `gcloud`
+  - selecting a project with Mail/PubSub enabled
+  - passing `--project <PROJECT_ID>` consistently.
+- OAuth setup initially failed with:
+  - missing OAuth credentials JSON
+  - malformed/unfinished redirect URL handling from the terminal
+  - “access_denied” on Google verification/testing state.
+- Final successful run required:
+  - keyring passphrase supplied on each run
+  - clean redirect URL passed to `gog auth add ... --remote --step 2`
+  - `tailscale` DNS/funnel enabled for a reachable push endpoint.
+
+Observed values in this deployment:
+
+- account: `kpoxo6op@gmail.com`
+- project: `kpoxo6op`
+- OAuth client: Desktop app JSON at `~/.config/gogcli/credentials.json` for `openclaw` user
+- hooks topic: `projects/kpoxo6op/topics/gog-gmail-watch`
+- hooks subscription: `gog-gmail-watch-push`
+
+### What worked for this deployment
+
+Use this pattern for rerun or audits (replace placeholders only):
+
+1. Configure project and API enablement once:
+
+```bash
+gcloud config set project <PROJECT_ID>
+gcloud --project=<PROJECT_ID> services enable gmail.googleapis.com pubsub.googleapis.com
+```
+
+2. Ensure OAuth creds file exists for gog:
+
+```bash
+sudo -u openclaw mkdir -p /home/openclaw/.config/gogcli
+sudo -u openclaw test -f /home/openclaw/.config/gogcli/credentials.json
+```
+
+3. Start auth step 1 (as openclaw with keyring passphrase):
+
+```bash
+sudo -u openclaw GOG_KEYRING_PASSWORD='<KEYRING_PASS>' \
+  bash -lc 'gog auth add <user@gmail.com> --services gmail --remote --step 1'
+```
+
+4. Open the returned URL, authenticate, then pass the full redirect URL exactly once:
+
+```bash
+AUTH_URL='<FULL_REDIRECT_URL>'
+AUTH_URL=$(printf "%s" "$AUTH_URL" | tr -d "\r\n")
+sudo -u openclaw GOG_KEYRING_PASSWORD='<KEYRING_PASS>' \
+  bash -lc 'gog auth add <user@gmail.com> --services gmail --remote --step 2 --auth-url "$AUTH_URL"'
+```
+
+5. Verify token record exists:
+
+```bash
+sudo -u openclaw GOG_KEYRING_PASSWORD='<KEYRING_PASS>' bash -lc 'gog auth list'
+```
+
+6. Setup OpenClaw Gmail webhooks:
+
+```bash
+sudo -u openclaw GOG_KEYRING_PASSWORD='<KEYRING_PASS>' \
+  openclaw webhooks gmail setup --account <user@gmail.com> --project <PROJECT_ID>
+```
+
+7. Start watch loop:
+
+```bash
+sudo -u openclaw GOG_KEYRING_PASSWORD='<KEYRING_PASS>' openclaw webhooks gmail run
+```
+
+### Post-checks to confirm final health
+
+- `openclaw config get hooks`
+  - `hooks.enabled: true`
+  - `hooks.presets` contains `"gmail"`
+  - `hooks.gmail.account` matches `<user@gmail.com>`
+  - `hooks.gmail.topic` and `hooks.gmail.subscription` are set.
+- `gog gmail watch serve` reports local listener on `127.0.0.1:8788`.
+- `gog gmail watch status --account <user@gmail.com> --json` returns valid history data.
+- `gcloud --project=<PROJECT_ID> pubsub subscriptions describe <subscription>` returns `state: ACTIVE`.
+- `openclaw webhooks gmail status` (if available in your installed version) returns configured state.
+
+### What to do if it fails again
+
+- `Error: No tokens stored`: rerun step 1/2 with correct keyring passphrase.
+- `Error: GCP project id required`: add `--project` and verify `gcloud config set project`.
+- `Error: push endpoint required` or `tailscale DNS name missing`: confirm node is on tailscale and funnel/DNS route is reachable.
+- Webhook auth URL looks broken by terminal wrapping: copy/paste with no newlines, then run `tr -d "\r\n"`.
+
+## Operational checklist
+
+- Gateway runs as `openclaw` with linger enabled.
+- OAuth, pairing, and credential files in `~/.openclaw/` treated as secrets.
+- `~/.openclaw/` and `.env` are never committed to git.
+- Telegram remains `dmPolicy: pairing` and `groupPolicy: disabled`.
+- Heartbeat remains disabled (`0m`) until trust level increases.
+- Gateway UI is not exposed publicly.
+- Exec approvals remain allowlist-only.
+
+## References
+
+- [Gateway runbook](https://docs.openclaw.ai/gateway)
+- [Installer](https://docs.openclaw.ai/install/installer)
+- [OpenAI provider](https://docs.openclaw.ai/providers/openai)
+- [OAuth](https://docs.openclaw.ai/concepts/oauth)
+- [Telegram channel](https://docs.openclaw.ai/channels/telegram)
+- [Gateway configuration](https://docs.openclaw.ai/gateway/configuration)
+- [Tools overview](https://docs.openclaw.ai/tools)
+- [Heartbeat](https://docs.openclaw.ai/gateway/heartbeat)
+- [Logging](https://docs.openclaw.ai/logging)
+- [Pairing](https://docs.openclaw.ai/pairing)
+- [Web tools](https://docs.openclaw.ai/tools/web)
+- [Exec approvals](https://docs.openclaw.ai/tools/exec-approvals)
+- [Control UI](https://docs.openclaw.ai/index)
+- [Security audit](https://docs.openclaw.ai/gateway/security)
+- [Agent workspace guidance](https://docs.openclaw.ai/agent-workspace)
+- `soydocs/openclaw-node0-ops-checklist.md` — node-0 one-page operational checklist for Gmail/webhooks/browser health.


### PR DESCRIPTION
## Summary
- Move OpenClaw runbooks into their own operations area with dedicated README and security section cleanup.
- Add canonical one-command entrypoints:
  - `openclaw-install.yml`
  - `openclaw-remove.yml`
  - `openclaw-enable-tools.yml`
  - `openclaw-disable-tools.yml`
- Keep legacy granular playbooks for rollback and explicit control.
- Update operation indexes and installation-mode documentation to reference new entrypoints and explain legacy vs canonical usage.

## Validation
- `ansible-playbook --syntax-check playbooks/operations/openclaw/openclaw-install.yml`
- `ansible-playbook --syntax-check playbooks/operations/openclaw/openclaw-remove.yml`
- `ansible-playbook --syntax-check playbooks/operations/openclaw/openclaw-enable-tools.yml`
- `ansible-playbook --syntax-check playbooks/operations/openclaw/openclaw-disable-tools.yml`
