### PR TITLE
Add domain expiry and DNS health alerting for soyspray.vip

### DIFF
--- a/playbooks/argocd/applications/observability/domain-health/README.md
+++ b/playbooks/argocd/applications/observability/domain-health/README.md
@@ -1,0 +1,28 @@
+# Domain Health Exporter
+
+This app runs an in-cluster exporter that checks `soyspray.vip` health on a fixed
+interval and exposes Prometheus metrics.
+
+Current checks:
+
+- RDAP expiry date for `soyspray.vip`
+- Cloudflare zone exists
+- Cloudflare zone status is `active`
+- Cloudflare nameservers match the expected values
+- Public DNS NS records match the expected values
+- Healthchecks ping on successful / failed runs
+
+Required `.env` variables before deploy:
+
+- `CLOUDFLARE_API_TOKEN`
+- `DOMAIN_HEALTHCHECKS_PING_URL`
+- `SOYSPRAY_VIP_EXPECTED_NAMESERVERS`
+
+`SOYSPRAY_VIP_EXPECTED_NAMESERVERS` should be a comma-separated list, for
+example:
+
+```dotenv
+SOYSPRAY_VIP_EXPECTED_NAMESERVERS=ada.ns.cloudflare.com,bob.ns.cloudflare.com
+```
+
+The Cloudflare token only needs read access to the zone metadata.

--- a/playbooks/argocd/applications/observability/domain-health/deployment.yaml
+++ b/playbooks/argocd/applications/observability/domain-health/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: domain-health
+  namespace: domain-health
+  labels:
+    app.kubernetes.io/name: domain-health
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: domain-health
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: domain-health
+    spec:
+      containers:
+        - name: exporter
+          image: python:3.12-slim
+          imagePullPolicy: IfNotPresent
+          command:
+            - python3
+            - /app/domain-health-exporter.py
+          ports:
+            - name: metrics
+              containerPort: 8080
+          env:
+            - name: DOMAIN_NAME
+              value: soyspray.vip
+            - name: CHECK_INTERVAL_SECONDS
+              value: "21600"
+            - name: HTTP_PORT
+              value: "8080"
+            - name: CLOUDFLARE_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflare-api-token
+                  key: api-token
+            - name: HEALTHCHECKS_PING_URL
+              valueFrom:
+                secretKeyRef:
+                  name: domain-health-config
+                  key: healthchecks-ping-url
+            - name: EXPECTED_NAMESERVERS
+              valueFrom:
+                secretKeyRef:
+                  name: domain-health-config
+                  key: expected-nameservers
+          volumeMounts:
+            - name: exporter-script
+              mountPath: /app
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 60
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+      volumes:
+        - name: exporter-script
+          configMap:
+            name: domain-health-exporter
+            defaultMode: 0555

--- a/playbooks/argocd/applications/observability/domain-health/domain-health-application.yaml
+++ b/playbooks/argocd/applications/observability/domain-health/domain-health-application.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: domain-health
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: "https://github.com/kpoxo6op/soyspray.git"
+    targetRevision: "HEAD"
+    path: playbooks/argocd/applications/observability/domain-health
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: domain-health
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      retry:
+        limit: 5
+        backoff:
+          duration: "10s"
+          factor: 2
+          maxDuration: "5m"
+    syncOptions:
+      - CreateNamespace=true
+      - PruneLast=true

--- a/playbooks/argocd/applications/observability/domain-health/domain-health-application.yaml
+++ b/playbooks/argocd/applications/observability/domain-health/domain-health-application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "HEAD"
+    targetRevision: "issue-122-add-domain-expiry-and-dns-health-alerting-for-soyspray-vip"
     path: playbooks/argocd/applications/observability/domain-health
   destination:
     server: "https://kubernetes.default.svc"

--- a/playbooks/argocd/applications/observability/domain-health/domain-health-application.yaml
+++ b/playbooks/argocd/applications/observability/domain-health/domain-health-application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "issue-122-add-domain-expiry-and-dns-health-alerting-for-soyspray-vip"
+    targetRevision: "HEAD"
     path: playbooks/argocd/applications/observability/domain-health
   destination:
     server: "https://kubernetes.default.svc"

--- a/playbooks/argocd/applications/observability/domain-health/domain-health-exporter.py
+++ b/playbooks/argocd/applications/observability/domain-health/domain-health-exporter.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+import json
+import logging
+import math
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+logging.basicConfig(
+    level=os.getenv("LOG_LEVEL", "INFO").upper(),
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+
+DOMAIN_NAME = os.environ["DOMAIN_NAME"]
+CHECK_INTERVAL_SECONDS = int(os.getenv("CHECK_INTERVAL_SECONDS", "21600"))
+HTTP_PORT = int(os.getenv("HTTP_PORT", "8080"))
+CLOUDFLARE_API_TOKEN = os.environ["CLOUDFLARE_API_TOKEN"]
+HEALTHCHECKS_PING_URL = os.environ["HEALTHCHECKS_PING_URL"]
+EXPECTED_NAMESERVERS = sorted(
+    ns.strip().rstrip(".").lower()
+    for ns in os.environ["EXPECTED_NAMESERVERS"].split(",")
+    if ns.strip()
+)
+USER_AGENT = "soyspray-domain-health/1.0"
+
+if not EXPECTED_NAMESERVERS:
+    raise RuntimeError("EXPECTED_NAMESERVERS must not be empty")
+
+
+METRIC_HELP = {
+    "domain_health_check_success": "Whether the named check completed successfully.",
+    "domain_health_last_check_timestamp_seconds": "Unix timestamp of the most recent check attempt.",
+    "domain_health_last_success_timestamp_seconds": "Unix timestamp of the most recent successful check.",
+    "domain_health_rdap_expiry_timestamp_seconds": "Unix timestamp of the domain RDAP expiry date.",
+    "domain_health_rdap_expiry_days": "Remaining whole days until domain expiry.",
+    "domain_health_cloudflare_zone_exists": "Whether the Cloudflare zone exists.",
+    "domain_health_cloudflare_zone_active": "Whether the Cloudflare zone status is active.",
+    "domain_health_cloudflare_nameservers_match": "Whether Cloudflare nameservers match the expected values.",
+    "domain_health_public_dns_nameservers_match": "Whether public DNS NS answers match the expected values.",
+}
+
+
+class MetricsState:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._samples = {}
+        self._last_run_ok = False
+        self._last_run_finished = 0.0
+
+    def set_metric(self, name, labels, value):
+        key = (name, tuple(sorted(labels.items())))
+        with self._lock:
+            self._samples[key] = float(value)
+
+    def get_health(self):
+        with self._lock:
+            if self._last_run_finished == 0:
+                return False
+            return self._last_run_ok and (time.time() - self._last_run_finished) < (CHECK_INTERVAL_SECONDS * 2)
+
+    def finish_run(self, ok):
+        with self._lock:
+            self._last_run_ok = ok
+            self._last_run_finished = time.time()
+
+    def render_prometheus(self):
+        with self._lock:
+            grouped = {}
+            for (name, labels), value in self._samples.items():
+                grouped.setdefault(name, []).append((labels, value))
+
+        lines = []
+        for name in sorted(grouped):
+            lines.append(f"# HELP {name} {METRIC_HELP.get(name, name)}")
+            lines.append(f"# TYPE {name} gauge")
+            for labels, value in sorted(grouped[name]):
+                rendered_labels = ",".join(
+                    f'{k}="{str(v).replace(chr(92), chr(92) * 2).replace(chr(34), chr(92) + chr(34))}"'
+                    for k, v in labels
+                )
+                metric = f"{name}{{{rendered_labels}}}" if rendered_labels else name
+                if math.isnan(value) or math.isinf(value):
+                    continue
+                lines.append(f"{metric} {value}")
+        lines.append("")
+        return "\n".join(lines).encode("utf-8")
+
+
+STATE = MetricsState()
+
+
+def request_json(url, headers=None):
+    req = Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": USER_AGENT,
+            **(headers or {}),
+        },
+    )
+    with urlopen(req, timeout=20) as response:
+        return json.load(response)
+
+
+def parse_timestamp(value):
+    cleaned = value.strip()
+    if cleaned.endswith("Z"):
+        cleaned = cleaned[:-1] + "+00:00"
+    return datetime.fromisoformat(cleaned).astimezone(timezone.utc).timestamp()
+
+
+def extract_rdap_expiry_timestamp(payload):
+    direct_keys = [
+        "expirationDate",
+        "expiryDate",
+        "expires",
+        "registryExpiryDate",
+        "paid_till",
+    ]
+    for key in direct_keys:
+        value = payload.get(key)
+        if isinstance(value, str):
+            return parse_timestamp(value)
+
+    for event in payload.get("events", []):
+        action = str(event.get("eventAction", "")).strip().lower()
+        when = event.get("eventDate")
+        if not isinstance(when, str):
+            continue
+        if action in {"expiration", "expiry", "expiration date", "registered until"}:
+            return parse_timestamp(when)
+
+    raise RuntimeError("Unable to find RDAP expiry timestamp")
+
+
+def normalize_nameservers(values):
+    return sorted(str(value).strip().rstrip(".").lower() for value in values if str(value).strip())
+
+
+def update_check_status(check_name, ok, now_ts):
+    labels = {"domain": DOMAIN_NAME, "check": check_name}
+    STATE.set_metric("domain_health_check_success", labels, 1 if ok else 0)
+    STATE.set_metric("domain_health_last_check_timestamp_seconds", labels, now_ts)
+    if ok:
+        STATE.set_metric("domain_health_last_success_timestamp_seconds", labels, now_ts)
+
+
+def check_rdap(now_ts):
+    payload = request_json(f"https://rdap.org/domain/{quote(DOMAIN_NAME)}")
+    expiry_ts = extract_rdap_expiry_timestamp(payload)
+    expiry_days = math.floor((expiry_ts - now_ts) / 86400)
+    labels = {"domain": DOMAIN_NAME}
+    STATE.set_metric("domain_health_rdap_expiry_timestamp_seconds", labels, expiry_ts)
+    STATE.set_metric("domain_health_rdap_expiry_days", labels, expiry_days)
+
+
+def check_cloudflare(now_ts):
+    headers = {"Authorization": f"Bearer {CLOUDFLARE_API_TOKEN}"}
+    payload = request_json(
+        f"https://api.cloudflare.com/client/v4/zones?name={quote(DOMAIN_NAME)}",
+        headers=headers,
+    )
+    if not payload.get("success", False):
+        raise RuntimeError(f"Cloudflare API error: {payload}")
+
+    zone = None
+    for candidate in payload.get("result", []):
+        if str(candidate.get("name", "")).lower() == DOMAIN_NAME.lower():
+            zone = candidate
+            break
+
+    labels = {"domain": DOMAIN_NAME}
+    STATE.set_metric("domain_health_cloudflare_zone_exists", labels, 1 if zone else 0)
+    if not zone:
+        return
+
+    STATE.set_metric(
+        "domain_health_cloudflare_zone_active",
+        labels,
+        1 if str(zone.get("status", "")).lower() == "active" else 0,
+    )
+    nameservers = normalize_nameservers(zone.get("name_servers", []))
+    STATE.set_metric(
+        "domain_health_cloudflare_nameservers_match",
+        labels,
+        1 if nameservers == EXPECTED_NAMESERVERS else 0,
+    )
+
+
+def check_public_dns(now_ts):
+    payload = request_json(f"https://dns.google/resolve?name={quote(DOMAIN_NAME)}&type=NS")
+    answers = payload.get("Answer", [])
+    nameservers = normalize_nameservers(answer.get("data", "") for answer in answers)
+    labels = {"domain": DOMAIN_NAME}
+    STATE.set_metric(
+        "domain_health_public_dns_nameservers_match",
+        labels,
+        1 if nameservers == EXPECTED_NAMESERVERS else 0,
+    )
+
+
+def ping_healthchecks(suffix=""):
+    url = HEALTHCHECKS_PING_URL.rstrip("/") + suffix
+    req = Request(url, headers={"User-Agent": USER_AGENT})
+    with urlopen(req, timeout=10) as response:
+        response.read()
+
+
+def run_checks_forever():
+    while True:
+        now_ts = time.time()
+        overall_ok = True
+        checks = {
+            "rdap": check_rdap,
+            "cloudflare_zone": check_cloudflare,
+            "cloudflare_nameservers": check_cloudflare,
+            "public_dns_nameservers": check_public_dns,
+        }
+
+        for check_name, check_fn in checks.items():
+            try:
+                check_fn(now_ts)
+                update_check_status(check_name, True, now_ts)
+                logging.info("check succeeded: %s", check_name)
+            except Exception as exc:  # noqa: BLE001
+                overall_ok = False
+                update_check_status(check_name, False, now_ts)
+                logging.exception("check failed: %s: %s", check_name, exc)
+
+        update_check_status("overall", overall_ok, now_ts)
+        try:
+            ping_healthchecks("" if overall_ok else "/fail")
+        except (HTTPError, URLError) as exc:
+            logging.warning("healthchecks ping failed: %s", exc)
+
+        STATE.finish_run(overall_ok)
+        time.sleep(CHECK_INTERVAL_SECONDS)
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/metrics":
+            payload = STATE.render_prometheus()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+
+        if self.path == "/healthz":
+            status = 200 if STATE.get_health() else 503
+            payload = b"ok\n" if status == 200 else b"stale\n"
+            self.send_response(status)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+    def log_message(self, fmt, *args):
+        logging.debug("http %s", fmt % args)
+
+
+def main():
+    worker = threading.Thread(target=run_checks_forever, daemon=True)
+    worker.start()
+    server = ThreadingHTTPServer(("0.0.0.0", HTTP_PORT), Handler)
+    logging.info("starting exporter on :%s for domain %s", HTTP_PORT, DOMAIN_NAME)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/playbooks/argocd/applications/observability/domain-health/kustomization.yaml
+++ b/playbooks/argocd/applications/observability/domain-health/kustomization.yaml
@@ -5,6 +5,8 @@ configMapGenerator:
   - name: domain-health-exporter
     files:
       - domain-health-exporter.py
+    options:
+      disableNameSuffixHash: true
 
 resources:
   - deployment.yaml

--- a/playbooks/argocd/applications/observability/domain-health/kustomization.yaml
+++ b/playbooks/argocd/applications/observability/domain-health/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+configMapGenerator:
+  - name: domain-health-exporter
+    files:
+      - domain-health-exporter.py
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/playbooks/argocd/applications/observability/domain-health/service.yaml
+++ b/playbooks/argocd/applications/observability/domain-health/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: domain-health
+  namespace: domain-health
+  labels:
+    app.kubernetes.io/name: domain-health
+spec:
+  selector:
+    app.kubernetes.io/name: domain-health
+  ports:
+    - name: metrics
+      port: 8080
+      targetPort: metrics

--- a/playbooks/argocd/applications/observability/prometheus/alerts/domain-health.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/alerts/domain-health.yaml
@@ -1,0 +1,93 @@
+# Domain health alerts for soyspray.vip RDAP and Cloudflare DNS state
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: domain-health
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: domain-health
+      rules:
+        - alert: DomainExpiryWarning
+          expr: |
+            domain_health_rdap_expiry_days{domain="soyspray.vip"} < 30
+            and domain_health_rdap_expiry_days{domain="soyspray.vip"} >= 14
+            and on (domain) domain_health_check_success{domain="soyspray.vip", check="rdap"} == 1
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Domain expiry approaching for soyspray.vip"
+            description: "RDAP reports soyspray.vip expires in less than 30 days."
+        - alert: DomainExpiryCritical
+          expr: |
+            domain_health_rdap_expiry_days{domain="soyspray.vip"} < 14
+            and on (domain) domain_health_check_success{domain="soyspray.vip", check="rdap"} == 1
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Domain expiry is critical for soyspray.vip"
+            description: "RDAP reports soyspray.vip expires in less than 14 days."
+        - alert: CloudflareZoneMissing
+          expr: |
+            domain_health_cloudflare_zone_exists{domain="soyspray.vip"} == 0
+            and on (domain) domain_health_check_success{domain="soyspray.vip", check="cloudflare_zone"} == 1
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Cloudflare zone missing for soyspray.vip"
+            description: "The Cloudflare API no longer returns a zone for soyspray.vip."
+        - alert: CloudflareZoneInactive
+          expr: |
+            domain_health_cloudflare_zone_active{domain="soyspray.vip"} == 0
+            and on (domain) domain_health_check_success{domain="soyspray.vip", check="cloudflare_zone"} == 1
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Cloudflare zone inactive for soyspray.vip"
+            description: "The Cloudflare zone exists but is not active."
+        - alert: CloudflareNameserversMismatch
+          expr: |
+            domain_health_cloudflare_nameservers_match{domain="soyspray.vip"} == 0
+            and on (domain) domain_health_check_success{domain="soyspray.vip", check="cloudflare_nameservers"} == 1
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Cloudflare nameservers mismatch for soyspray.vip"
+            description: "Cloudflare-reported zone nameservers do not match the expected values."
+        - alert: PublicDNSNameserversMismatch
+          expr: |
+            domain_health_public_dns_nameservers_match{domain="soyspray.vip"} == 0
+            and on (domain) domain_health_check_success{domain="soyspray.vip", check="public_dns_nameservers"} == 1
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Public DNS nameservers mismatch for soyspray.vip"
+            description: "Public DNS NS answers do not match the expected Cloudflare nameservers."
+        - alert: DomainHealthCheckFailing
+          expr: |
+            domain_health_check_success{domain="soyspray.vip", check=~"rdap|cloudflare_zone|cloudflare_nameservers|public_dns_nameservers"} == 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Domain health checker is failing"
+            description: "At least one domain-health check has failed for soyspray.vip."
+        - alert: DomainHealthNoRecentSuccess
+          expr: |
+            time() - max by (domain) (
+              domain_health_last_success_timestamp_seconds{domain="soyspray.vip", check="overall"}
+            ) > 12 * 60 * 60
+          for: 30m
+          labels:
+            severity: critical
+          annotations:
+            summary: "No recent successful domain-health run"
+            description: "The in-cluster domain-health exporter has not completed a successful overall run in the last 12 hours."

--- a/playbooks/argocd/applications/observability/prometheus/dashboards/domain-health.json
+++ b/playbooks/argocd/applications/observability/prometheus/dashboards/domain-health.json
@@ -1,0 +1,1000 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": true,
+              "tooltip": true,
+              "viz": false
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "content": "This dashboard tracks the in-cluster `domain-health` exporter for `soyspray.vip`.\n\nCommon checks:\n- RDAP expiry date and days remaining\n- Cloudflare zone exists and is `active`\n- Cloudflare nameservers match expected values\n- Public DNS NS answers match expected values\n- Exporter heartbeat succeeded recently\n\nAlert thresholds:\n- Expiry warning: `< 30 days`\n- Expiry critical: `< 14 days`\n- No recent successful run: `> 12 hours`\n",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "vector(1)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "What This Covers",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 2,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 14
+              },
+              {
+                "color": "green",
+                "value": 30
+              }
+            ]
+          },
+          "unit": "d"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 6
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "domain_health_rdap_expiry_days{domain=\"soyspray.vip\"}",
+          "instant": true,
+          "legendFormat": "days",
+          "refId": "A"
+        }
+      ],
+      "title": "Expiry Days Remaining",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeAsIso"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 6
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "domain_health_rdap_expiry_timestamp_seconds{domain=\"soyspray.vip\"}",
+          "instant": true,
+          "legendFormat": "expiry",
+          "refId": "A"
+        }
+      ],
+      "title": "RDAP Expiry Date",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 6
+              },
+              {
+                "color": "red",
+                "value": 12
+              }
+            ]
+          },
+          "unit": "h"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 6
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(time() - domain_health_last_success_timestamp_seconds{domain=\"soyspray.vip\", check=\"overall\"}) / 3600",
+          "instant": true,
+          "legendFormat": "hours",
+          "refId": "A"
+        }
+      ],
+      "title": "Last Successful Run Age",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "text": "Failing"
+                },
+                "1": {
+                  "color": "green",
+                  "text": "Healthy"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 6
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "domain_health_check_success{domain=\"soyspray.vip\", check=\"overall\"}",
+          "instant": true,
+          "legendFormat": "overall",
+          "refId": "A"
+        }
+      ],
+      "title": "Overall Status",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 7,
+      "panels": [],
+      "title": "Common Checks",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "text": "Failing"
+                },
+                "1": {
+                  "color": "green",
+                  "text": "OK"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 12
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "domain_health_check_success{domain=\"soyspray.vip\", check=\"rdap\"}",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "RDAP Check",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "text": "Missing"
+                },
+                "1": {
+                  "color": "green",
+                  "text": "Present"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 4,
+        "y": 12
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "domain_health_cloudflare_zone_exists{domain=\"soyspray.vip\"}",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cloudflare Zone Exists",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "text": "Inactive"
+                },
+                "1": {
+                  "color": "green",
+                  "text": "Active"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 9,
+        "y": 12
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "domain_health_cloudflare_zone_active{domain=\"soyspray.vip\"}",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cloudflare Zone Active",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "text": "Mismatch"
+                },
+                "1": {
+                  "color": "green",
+                  "text": "Match"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 14,
+        "y": 12
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "domain_health_cloudflare_nameservers_match{domain=\"soyspray.vip\"}",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cloudflare Nameservers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "text": "Mismatch"
+                },
+                "1": {
+                  "color": "green",
+                  "text": "Match"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 19,
+        "y": 12
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "domain_health_public_dns_nameservers_match{domain=\"soyspray.vip\"}",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Public DNS Nameservers",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 13,
+      "panels": [],
+      "title": "Trends",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 14
+              },
+              {
+                "color": "green",
+                "value": 30
+              }
+            ]
+          },
+          "unit": "d"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "domain_health_rdap_expiry_days{domain=\"soyspray.vip\"}",
+          "legendFormat": "days remaining",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Expiry Days Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": true,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "domain_health_check_success{domain=\"soyspray.vip\", check=~\"overall|rdap|cloudflare_zone|cloudflare_nameservers|public_dns_nameservers\"}",
+          "legendFormat": "{{check}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Check Status Signals",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10m",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "soyspray",
+    "domain",
+    "dns"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "includeAll": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Domain Health",
+  "uid": "domain-health",
+  "version": 1,
+  "weekStart": ""
+}

--- a/playbooks/argocd/applications/observability/prometheus/dashboards/domain-health.json
+++ b/playbooks/argocd/applications/observability/prometheus/dashboards/domain-health.json
@@ -48,6 +48,7 @@
         "y": 0
       },
       "id": 1,
+      "description": "Summary of what the exporter validates and which alert thresholds back this dashboard.",
       "options": {
         "content": "This dashboard tracks the in-cluster `domain-health` exporter for `soyspray.vip`.\n\nCommon checks:\n- RDAP expiry date and days remaining\n- Cloudflare zone exists and is `active`\n- Cloudflare nameservers match expected values\n- Public DNS NS answers match expected values\n- Exporter heartbeat succeeded recently\n\nAlert thresholds:\n- Expiry warning: `< 30 days`\n- Expiry critical: `< 14 days`\n- No recent successful run: `> 12 hours`\n",
         "mode": "markdown"
@@ -76,6 +77,7 @@
         "y": 5
       },
       "id": 2,
+      "description": "High-level current state for domain registration expiry and exporter freshness.",
       "panels": [],
       "title": "Overview",
       "type": "row"
@@ -119,6 +121,7 @@
         "y": 6
       },
       "id": 3,
+      "description": "Whole days remaining until the RDAP-reported expiry date for soyspray.vip.",
       "options": {
         "colorMode": "background",
         "graphMode": "none",
@@ -180,6 +183,7 @@
         "y": 6
       },
       "id": 4,
+      "description": "Absolute expiry date from RDAP. Prometheus stores timestamps in seconds, so this panel converts to milliseconds for Grafana date rendering.",
       "options": {
         "colorMode": "none",
         "graphMode": "none",
@@ -202,7 +206,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "domain_health_rdap_expiry_timestamp_seconds{domain=\"soyspray.vip\"}",
+          "expr": "domain_health_rdap_expiry_timestamp_seconds{domain=\"soyspray.vip\"} * 1000",
           "instant": true,
           "legendFormat": "expiry",
           "refId": "A"
@@ -250,6 +254,7 @@
         "y": 6
       },
       "id": 5,
+      "description": "How many hours have elapsed since the exporter last completed a successful overall run.",
       "options": {
         "colorMode": "background",
         "graphMode": "none",
@@ -330,6 +335,7 @@
         "y": 6
       },
       "id": 6,
+      "description": "Overall heartbeat result. Healthy means the exporter completed all checks successfully on its most recent run.",
       "options": {
         "colorMode": "background",
         "graphMode": "none",
@@ -370,6 +376,7 @@
         "y": 11
       },
       "id": 7,
+      "description": "Individual validation checks that feed the overall exporter status and Prometheus alerts.",
       "panels": [],
       "title": "Common Checks",
       "type": "row"
@@ -422,6 +429,7 @@
         "y": 12
       },
       "id": 8,
+      "description": "Whether the RDAP lookup completed successfully. This is execution success, not the expiry threshold result.",
       "options": {
         "colorMode": "background",
         "graphMode": "none",
@@ -500,6 +508,7 @@
         "y": 12
       },
       "id": 9,
+      "description": "Whether Cloudflare currently returns a zone object for soyspray.vip.",
       "options": {
         "colorMode": "background",
         "graphMode": "none",
@@ -578,6 +587,7 @@
         "y": 12
       },
       "id": 10,
+      "description": "Whether the Cloudflare zone exists and reports status=active.",
       "options": {
         "colorMode": "background",
         "graphMode": "none",
@@ -656,6 +666,7 @@
         "y": 12
       },
       "id": 11,
+      "description": "Whether Cloudflare's configured nameservers match the expected nameservers stored in the domain-health secret.",
       "options": {
         "colorMode": "background",
         "graphMode": "none",
@@ -734,6 +745,7 @@
         "y": 12
       },
       "id": 12,
+      "description": "Whether public DNS NS answers for soyspray.vip match the expected Cloudflare nameservers.",
       "options": {
         "colorMode": "background",
         "graphMode": "none",
@@ -773,6 +785,7 @@
         "y": 17
       },
       "id": 13,
+      "description": "History for expiry countdown and exporter check outcomes.",
       "panels": [],
       "title": "Trends",
       "type": "row"
@@ -841,6 +854,7 @@
         "y": 18
       },
       "id": 14,
+      "description": "Trend of the RDAP expiry countdown. A healthy domain generally shows a slow downward slope with occasional resets after renewal.",
       "options": {
         "legend": {
           "calcs": [],
@@ -932,6 +946,7 @@
         "y": 18
       },
       "id": 15,
+      "description": "Per-check success signals over time. 1 means the check succeeded on that scrape interval, 0 means the most recent run failed.",
       "options": {
         "legend": {
           "calcs": [],

--- a/playbooks/argocd/applications/observability/prometheus/kustomization.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/kustomization.yaml
@@ -56,6 +56,15 @@ configMapGenerator:
       annotations:
         kustomize.toolkit.fluxcd.io/substitute: disabled
 
+  - name: grafana-dashboard-domain-health
+    files:
+      - dashboards/domain-health.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+      annotations:
+        kustomize.toolkit.fluxcd.io/substitute: disabled
+
   # Commented out large dashboard that causes "Too long" errors
   # - name: grafana-dashboard-node-exporter-full
   #   files:

--- a/playbooks/argocd/applications/observability/prometheus/kustomization.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/kustomization.yaml
@@ -70,3 +70,4 @@ configMapGenerator:
 resources:
   - alerts/backups-essential.yaml
   - alerts/cert-expiry.yaml
+  - alerts/domain-health.yaml

--- a/playbooks/argocd/applications/observability/prometheus/prometheus-application.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/prometheus-application.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "HEAD"
+    targetRevision: "issue-122-add-domain-expiry-and-dns-health-alerting-for-soyspray-vip"
     path: playbooks/argocd/applications/observability/prometheus
     kustomize:
       helm:

--- a/playbooks/argocd/applications/observability/prometheus/prometheus-application.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/prometheus-application.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "issue-122-add-domain-expiry-and-dns-health-alerting-for-soyspray-vip"
+    targetRevision: "HEAD"
     path: playbooks/argocd/applications/observability/prometheus
     kustomize:
       helm:

--- a/playbooks/argocd/applications/observability/prometheus/values.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/values.yaml
@@ -73,6 +73,17 @@ prometheus:
         - port: metrics
           interval: 60s
 
+    - name: domain-health
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: domain-health
+      namespaceSelector:
+        matchNames:
+          - domain-health
+      endpoints:
+        - port: metrics
+          interval: 60s
+
 grafana:
   namespaceOverride: monitoring
   resources:

--- a/playbooks/deploy-argocd-apps.yml
+++ b/playbooks/deploy-argocd-apps.yml
@@ -12,6 +12,7 @@
       - { name: Prometheus, role: apps/prometheus }
       - { name: Alloy Loki Manual, role: apps/alloy-loki-manual }
       - { name: Alert Test, role: apps/alert-test }
+      - { name: Domain Health, role: apps/domain-health }
 
       # Infrastructure
       - { name: Longhorn, role: apps/longhorn }

--- a/roles/apps/domain-health/tasks/main.yml
+++ b/roles/apps/domain-health/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+- name: Cloudflare API Token Secret For Domain Health
+  ansible.builtin.include_role:
+    name: app-secret
+    apply:
+      tags: [domain-health]
+  vars:
+    secret_name: cloudflare-api-token
+    secret_namespace: domain-health
+    create_namespace: true
+    secret_data:
+      - { env_var: 'CLOUDFLARE_API_TOKEN', key: 'api-token' }
+  tags: domain-health
+
+- name: Domain Health Config Secret
+  ansible.builtin.include_role:
+    name: app-secret
+    apply:
+      tags: [domain-health]
+  vars:
+    secret_name: domain-health-config
+    secret_namespace: domain-health
+    create_namespace: true
+    secret_data:
+      - { env_var: 'DOMAIN_HEALTHCHECKS_PING_URL', key: 'healthchecks-ping-url' }
+      - { env_var: 'SOYSPRAY_VIP_EXPECTED_NAMESERVERS', key: 'expected-nameservers' }
+  tags: domain-health
+
+- name: Apply Domain Health
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig_path }}"
+    namespace: argocd
+    definition: "{{ lookup('file', playbook_dir + '/argocd/applications/observability/domain-health/domain-health-application.yaml') }}"
+  tags: domain-health


### PR DESCRIPTION
## Summary
- add an in-cluster `domain-health` exporter app for `soyspray.vip`
- expose Prometheus metrics for RDAP expiry, Cloudflare zone state, nameserver checks, and exporter heartbeat
- add Prometheus alert rules and a Grafana dashboard for domain health
- create and wire a dedicated Healthchecks check for the exporter heartbeat

## What Changed
- new Argo app under `playbooks/argocd/applications/observability/domain-health`
- new Ansible role `roles/apps/domain-health`
- new Prometheus alert rules in `playbooks/argocd/applications/observability/prometheus/alerts/domain-health.yaml`
- new Grafana dashboard in `playbooks/argocd/applications/observability/prometheus/dashboards/domain-health.json`
- Prometheus updated to scrape the new exporter via `additionalServiceMonitors`

## Verification
- deployed the new app in-cluster from this branch before reverting `targetRevision`
- verified exporter `/healthz` returns `ok`
- verified live metrics for `domain_health_*` in Prometheus
- verified alert rule group `domain-health` is loaded and healthy
- verified Grafana dashboard `Domain Health` exists and renders
- verified dedicated Healthchecks check `domain-health` is receiving pings

## Notes
- both Argo app manifests now point to `HEAD` again:
  - `playbooks/argocd/applications/observability/domain-health/domain-health-application.yaml`
  - `playbooks/argocd/applications/observability/prometheus/prometheus-application.yaml`
- before merge, that means the live branch-only app can no longer rely on this branch being the source of truth
- `kube-prometheus-stack` may still show `OutOfSync` because the Prometheus operator mutates the `Prometheus` CR

Closes #122
