### PR TITLE
[codex] fix prometheus alert cleanup

### DIFF
--- a/playbooks/argocd/applications/observability/prometheus/prometheus-application.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/prometheus-application.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "fix/prometheus-alert-cleanup"
+    targetRevision: "HEAD"
     path: playbooks/argocd/applications/observability/prometheus
     kustomize:
       helm:

--- a/playbooks/argocd/applications/observability/prometheus/prometheus-application.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/prometheus-application.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "HEAD"
+    targetRevision: "fix/prometheus-alert-cleanup"
     path: playbooks/argocd/applications/observability/prometheus
     kustomize:
       helm:

--- a/playbooks/argocd/applications/observability/prometheus/values.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/values.yaml
@@ -230,7 +230,6 @@ prometheus-node-exporter:
       cpu: 50m
       memory: 64Mi
     limits:
-      cpu: 200m
       memory: 128Mi
 
 kube-state-metrics:


### PR DESCRIPTION
## Summary
- remove the `prometheus-node-exporter` CPU limit to stop false-positive `CPUThrottlingHigh` alerts
- keep the Prometheus Argo application on `HEAD` after the temporary branch-based deploy
- document that the stale SMART alert noise came from old resources stuck live while Argo CD was pinned to a deleted branch

## Notes
- I deployed this fix from `fix/prometheus-alert-cleanup` before opening the PR, then reset `targetRevision` back to `HEAD`
- live verification showed the stale `node-hardware` rule and `smartctl-exporter` resources were pruned, and the current `node-exporter` pod no longer has a CPU limit
