### PR TITLE
[codex] Upgrade BookLore to v2.2.2

### DIFF
--- a/playbooks/argocd/applications/media/booklore/booklore-application.yaml
+++ b/playbooks/argocd/applications/media/booklore/booklore-application.yaml
@@ -10,7 +10,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "HEAD"
+    targetRevision: "codex/booklore-upgrade"
     path: playbooks/argocd/applications/media/booklore
   destination:
     server: "https://kubernetes.default.svc"

--- a/playbooks/argocd/applications/media/booklore/booklore-application.yaml
+++ b/playbooks/argocd/applications/media/booklore/booklore-application.yaml
@@ -10,7 +10,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "codex/booklore-upgrade"
+    targetRevision: "HEAD"
     path: playbooks/argocd/applications/media/booklore
   destination:
     server: "https://kubernetes.default.svc"

--- a/playbooks/argocd/applications/media/booklore/deployment.yaml
+++ b/playbooks/argocd/applications/media/booklore/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: booklore
-          image: ghcr.io/booklore-app/booklore:v1.16.0
+          image: ghcr.io/the-booklore/booklore:v2.2.2
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 6060

--- a/playbooks/argocd/applications/media/booklore/deployment.yaml
+++ b/playbooks/argocd/applications/media/booklore/deployment.yaml
@@ -17,6 +17,7 @@ spec:
     metadata:
       labels:
         app: booklore
+        component: web
     spec:
       enableServiceLinks: false
       containers:

--- a/playbooks/argocd/applications/media/booklore/service.yaml
+++ b/playbooks/argocd/applications/media/booklore/service.yaml
@@ -15,3 +15,4 @@ spec:
       name: http
   selector:
     app: booklore
+    component: web


### PR DESCRIPTION
## What changed
Upgrades BookLore from `ghcr.io/booklore-app/booklore:v1.16.0` to `ghcr.io/the-booklore/booklore:v2.2.2`.

Also tightens the `booklore` service selector so it only targets the web pod. This avoids routing BookLore HTTP traffic to the MariaDB pod, which was possible because of legacy live labels in the cluster.

## Why
BookLore was pinned well behind the latest upstream release.

The service-selector fix is included because it surfaced during deployment validation and can cause intermittent ingress failures during or after rollout.

## Impact
This changes the BookLore application image and keeps the Argo Application manifest PR-safe by restoring `targetRevision` to `HEAD`.

## Validation
- Verified the latest official upstream release tag via GitHub API: `v2.2.2` published on 2026-04-14.
- Deployed the branch revision to the cluster before resetting `targetRevision`.
- Confirmed the app rolled out on `ghcr.io/the-booklore/booklore:v2.2.2`.
- Confirmed in-pod HTTP on `127.0.0.1:6060` returned `200`.
- Confirmed `https://booklore.soyspray.vip` returned `HTTP/2 200` after rollout.
- Confirmed Argo later reconciled the service-selector fix revision cleanly.

## Notes
The temporary branch-tracking change used for pre-merge deployment was reverted to `HEAD` before opening this PR, per repo workflow.