### PR TITLE
[codex] Remove unused Argo apps

### DIFF
--- a/playbooks/deploy-argocd-apps.yml
+++ b/playbooks/deploy-argocd-apps.yml
@@ -11,7 +11,6 @@
       # Observability
       - { name: Prometheus, role: apps/prometheus }
       - { name: Alloy Loki Manual, role: apps/alloy-loki-manual }
-      - { name: Alert Test, role: apps/alert-test }
       - { name: Domain Health, role: apps/domain-health }
 
       # Infrastructure
@@ -32,13 +31,11 @@
       - { name: Obsidian, role: apps/obsidian }
 
       # Media
-      - { name: Plex, role: apps/plex }
       - { name: Jellyfin, role: apps/jellyfin }
       - { name: Prowlarr, role: apps/prowlarr }
       - { name: qBittorrent, role: apps/qbittorrent }
       - { name: LazyLibrarian, role: apps/lazylibrarian }
       - { name: Booklore, role: apps/booklore }
-      - { name: Sonarr, role: apps/sonarr }
       - { name: Threadfin, role: apps/threadfin }
       - { name: Streamlink, role: apps/streamlink }
       - { name: Immich, role: apps/immich }


### PR DESCRIPTION
## Summary
- stop deploying the alert-test Argo application
- stop deploying unused Plex and Sonarr Argo applications
- keep the live cleanup aligned with future deploy-argocd-apps runs

## Why
These apps were deprovisioned from the live cluster after they generated stale/noisy alerts or were no longer used. Removing them from the deployment playbook prevents a future Ansible run from recreating them.

## Validation
- `git diff --check`
- live cluster cleanup verified with `kubectl`: no `alert-test`, `plex`, `sonarr`, or `splunk` apps/pods/namespaces remain
- Redis was recreated on a fresh PVC and verified with `redis-cli ping` returning `PONG`
- Argo shows `redis` and `immich` as `Synced` / `Healthy`
