### PR TITLE
Fix post-SSD monitoring alerts

### DIFF
--- a/playbooks/argocd/applications/database/cnpg/immich-db/overlays/initdb/backup-config-patch.yaml
+++ b/playbooks/argocd/applications/database/cnpg/immich-db/overlays/initdb/backup-config-patch.yaml
@@ -8,7 +8,7 @@ spec:
     retentionPolicy: "60d"
     barmanObjectStore:
       destinationPath: s3://immich-offsite-archive-au2/immich/db/
-      serverName: immich-db
+      serverName: immich-db-a-post-ssd-20260506
       s3Credentials:
         accessKeyId:
           name: immich-offsite-writer
@@ -19,4 +19,3 @@ spec:
         region:
           name: immich-offsite-writer
           key: AWS_REGION
-

--- a/playbooks/argocd/applications/database/cnpg/immich-db/overlays/prod/backup-config-patch.yaml
+++ b/playbooks/argocd/applications/database/cnpg/immich-db/overlays/prod/backup-config-patch.yaml
@@ -8,7 +8,7 @@ spec:
     retentionPolicy: "60d"
     barmanObjectStore:
       destinationPath: s3://immich-offsite-archive-au2/immich/db/
-      serverName: immich-db
+      serverName: immich-db-a-post-ssd-20260506
       s3Credentials:
         accessKeyId:
           name: immich-offsite-writer
@@ -19,4 +19,3 @@ spec:
         region:
           name: immich-offsite-writer
           key: AWS_REGION
-

--- a/playbooks/argocd/applications/database/redis/values.yaml
+++ b/playbooks/argocd/applications/database/redis/values.yaml
@@ -25,7 +25,7 @@ master:
   persistence:
     enabled: true
     storageClass: longhorn
-    size: 5Gi
+    size: 8Gi
   resources:
     requests:
       memory: 128Mi

--- a/playbooks/argocd/applications/database/redis/values.yaml
+++ b/playbooks/argocd/applications/database/redis/values.yaml
@@ -24,15 +24,16 @@ image:
 master:
   persistence:
     enabled: true
-    storageClass: longhorn
     size: 8Gi
   resources:
     requests:
       memory: 128Mi
-      cpu: 50m
+      cpu: 100m
+      ephemeral-storage: 50Mi
     limits:
-      memory: 256Mi
+      memory: 192Mi
       cpu: 500m
+      ephemeral-storage: 2Gi
   extraEnvVars:
     - name: ALLOW_EMPTY_PASSWORD
       value: "yes"

--- a/playbooks/argocd/applications/database/redis/values.yaml
+++ b/playbooks/argocd/applications/database/redis/values.yaml
@@ -21,7 +21,7 @@ image:
   repository: bitnamilegacy/redis
   tag: 8.2.1-debian-12-r0
 
-primary:
+master:
   persistence:
     enabled: true
     storageClass: longhorn
@@ -32,7 +32,7 @@ primary:
       cpu: 50m
     limits:
       memory: 256Mi
-      cpu: 200m
+      cpu: 500m
   extraEnvVars:
     - name: ALLOW_EMPTY_PASSWORD
       value: "yes"

--- a/playbooks/argocd/applications/observability/prometheus/alerts/backups-essential.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/alerts/backups-essential.yaml
@@ -2,7 +2,7 @@
 # Minimal backup alerts: 1) Media CronJob stale; 2) CNPG last available backup stale
 # No S3 requests; relies on kube-state-metrics and CNPG exporter; 36h thresholds
 # Assumes Prometheus Operator CRDs and monitoring namespace 'monitoring'
-# Requires CNPG PodMonitor enabled for immich-db (see notes)
+# Requires CNPG PodMonitor enabled for immich-db-a (see notes)
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -28,12 +28,11 @@ spec:
         - alert: CNPGBackupStale
           expr: |
             time() - max by (cluster) (
-              cnpg_collector_last_available_backup_timestamp{cluster="immich-db"}
+              cnpg_collector_last_available_backup_timestamp{cluster="immich-db-a"}
             ) > 36 * 60 * 60
           for: 15m
           labels:
             severity: critical
           annotations:
-            summary: "CNPG backup stale (cluster=immich-db)"
+            summary: "CNPG backup stale (cluster=immich-db-a)"
             description: "CNPG reports last available backup older than 36h."
-

--- a/playbooks/argocd/applications/observability/prometheus/smartctl-exporter-daemonset.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/smartctl-exporter-daemonset.yaml
@@ -42,7 +42,7 @@ spec:
             - --smartctl.interval=5m
             - --smartctl.rescan=30m
             - --smartctl.device=/dev/disk/by-id/nvme-eui.00080d02005b0230
-            - --smartctl.device=/dev/disk/by-id/ata-Samsung_SSD_870_EVO_500GB_S5Y4NFOR5613453
+            - --smartctl.device=/dev/disk/by-id/ata-PNY_500GB_SATA_SSD_PNL03260552550304994
             - --smartctl.device=/dev/disk/by-id/wwn-0x5000000000000001;scsi
           ports:
             - name: metrics
@@ -55,7 +55,6 @@ spec:
               cpu: 10m
               memory: 32Mi
             limits:
-              cpu: 100m
               memory: 128Mi
           volumeMounts:
             - name: dev

--- a/soydocs/incidents/2026-05-01-obsidian-longhorn-storage.md
+++ b/soydocs/incidents/2026-05-01-obsidian-longhorn-storage.md
@@ -433,6 +433,38 @@ Post-recreate validation:
 - Main workload apps checked after the batch recreate were healthy; temporary
   completed bootstrap/debug/backup jobs were the only non-running pods reported.
 
+### 2026-05-07 Post-SSD Monitoring Cleanup
+
+After the replacement SSD workload recreate, Alertmanager paged Telegram for
+`CNPGBackupBarmanError`. The alert was caused by the freshly recreated
+`immich-db-a` cluster trying to archive WALs under the old Barman server name
+`immich-db`. Barman correctly rejected the destination with `Expected empty
+archive` because that S3 archive namespace already contained previous backup
+state.
+
+The live fix moved the recreated empty database onto a fresh Barman server
+namespace:
+
+```text
+immich-db-a-post-ssd-20260506
+```
+
+Post-fix CNPG logs showed WAL archive commands using the new namespace, and
+Alertmanager only showed the normal `Watchdog` alert.
+
+The same cleanup updated monitoring to match the replacement SSD:
+
+- `smartctl-exporter` now scrapes
+  `/dev/disk/by-id/ata-PNY_500GB_SATA_SSD_PNL03260552550304994`
+  instead of the removed Samsung SSD path.
+- The SMART exporter CPU limit was removed, leaving a memory limit and CPU
+  request, because the exporter was being throttled during device scans.
+- The CNPG stale-backup Prometheus alert now watches `cluster="immich-db-a"`.
+- Redis chart values were corrected from the ignored `primary:` key to the
+  chart's active `master:` key, while preserving the existing `8Gi` PVC size.
+  Redis CPU limit was raised to `500m` to clear the post-recreate
+  `CPUThrottlingHigh` info alert without recreating the StatefulSet.
+
 ### Immediate
 
 - Do not delete the original Obsidian PVC.


### PR DESCRIPTION
## Summary
- move recreated Immich CNPG WAL archive writes to a fresh Barman server namespace
- update post-SSD monitoring for the replacement PNY SSD and immich-db-a alert labels
- relax CPU caps that were causing smartctl-exporter and Redis CPU throttling alerts
- document the post-SSD alert cleanup in the incident note

## Validation
- make go
- rendered CNPG initdb overlay and Prometheus kustomization
- rendered Redis Helm values against chart 22.0.7
- synced immich-db-a-initdb, kube-prometheus-stack, and redis from this branch
- verified Alertmanager and Prometheus only show Watchdog firing
- verified CNPG WAL archive logs use immich-db-a-post-ssd-20260506
