### PR TITLE
[codex] Fix Home Assistant bootstrap files

### DIFF
--- a/playbooks/argocd/applications/home-automation/home-assistant/configmap-bootstrap.yaml
+++ b/playbooks/argocd/applications/home-automation/home-assistant/configmap-bootstrap.yaml
@@ -39,3 +39,7 @@ data:
             title: Door open
             message: Front door has been open for 10 minutes
       mode: single
+  scripts.yaml: |
+    {}
+  scenes.yaml: |
+    []

--- a/playbooks/argocd/applications/home-automation/home-assistant/deployment.yaml
+++ b/playbooks/argocd/applications/home-automation/home-assistant/deployment.yaml
@@ -29,6 +29,8 @@ spec:
             - |
               test -f /config/configuration.yaml || cp /bootstrap/configuration.yaml /config/configuration.yaml
               test -f /config/automations.yaml || cp /bootstrap/automations.yaml /config/automations.yaml
+              test -f /config/scripts.yaml || cp /bootstrap/scripts.yaml /config/scripts.yaml
+              test -f /config/scenes.yaml || cp /bootstrap/scenes.yaml /config/scenes.yaml
           volumeMounts:
             - name: config
               mountPath: /config
@@ -61,4 +63,3 @@ spec:
         - name: bootstrap
           configMap:
             name: home-assistant-bootstrap
-


### PR DESCRIPTION
## Summary
- add empty Home Assistant bootstrap files for scripts and scenes
- make the init container copy those files into the persistent config volume when missing

## Why
Home Assistant configuration includes `scripts.yaml` and `scenes.yaml`. If the PVC is rebuilt without those files, integrations can fail during setup because HA cannot read the included files.

## Validation
- `kubectl kustomize playbooks/argocd/applications/home-automation/home-assistant`
- `git diff --check`
