### PR TITLE
Add Home Assistant Tapo Relax scene

### DIFF
--- a/playbooks/argocd/applications/home-automation/home-assistant/configmap-bootstrap.yaml
+++ b/playbooks/argocd/applications/home-automation/home-assistant/configmap-bootstrap.yaml
@@ -40,6 +40,30 @@ data:
             message: Front door has been open for 10 minutes
       mode: single
   scripts.yaml: |
-    {}
+    tapo_relax:
+      alias: Tapo Relax
+      description: Turn all Tapo L530 bulbs on using the built-in Relax theme.
+      mode: single
+      sequence:
+        - action: light.turn_on
+          target:
+            entity_id:
+              - light.top
+              - light.middle
+              - light.bottom
+          data:
+            effect: Relax
   scenes.yaml: |
-    []
+    - id: tapo_relax
+      name: Tapo Relax
+      icon: mdi:lightbulb-night
+      entities:
+        light.top:
+          state: "on"
+          effect: Relax
+        light.middle:
+          state: "on"
+          effect: Relax
+        light.bottom:
+          state: "on"
+          effect: Relax


### PR DESCRIPTION
## Summary
- add a Home Assistant script for turning all Tapo L530 bulbs on with the Relax effect
- add a matching Tapo Relax scene so it appears as an activatable HA scene

## Validation
- kubectl kustomize playbooks/argocd/applications/home-automation/home-assistant
- kubectl apply --dry-run=server -f rendered home-assistant kustomize output
- clicked Tapo Relax in the HA browser and verified light.top, light.middle, and light.bottom are on with effect Relax