### PR TITLE
Stop Home Assistant from managing itself

### DIFF
--- a/playbooks/argocd/applications/home-automation/home-assistant/kustomization.yaml
+++ b/playbooks/argocd/applications/home-automation/home-assistant/kustomization.yaml
@@ -4,7 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - homeassistant-application.yaml
   - configmap-bootstrap.yaml
   - deployment.yaml
   - service.yaml


### PR DESCRIPTION
## Summary
- remove the Home Assistant Argo Application manifest from the Home Assistant child kustomization
- keep the application manifest file available for bootstrap, but prevent the running app from creating a duplicate child Application in home-automation

## Validation
- kubectl kustomize playbooks/argocd/applications/home-automation/home-assistant
- kubectl apply --dry-run=server -f rendered home-assistant kustomize output