### PR TITLE
Make Tapo bulbs default to Relax

### DIFF
--- a/playbooks/argocd/applications/home-automation/home-assistant/configmap-bootstrap.yaml
+++ b/playbooks/argocd/applications/home-automation/home-assistant/configmap-bootstrap.yaml
@@ -39,6 +39,25 @@ data:
             title: Door open
             message: Front door has been open for 10 minutes
       mode: single
+    - id: tapo_l530_relax_on
+      alias: Tapo bulbs use Relax when turned on
+      triggers:
+        - trigger: state
+          entity_id:
+            - light.top
+            - light.middle
+            - light.bottom
+          to: "on"
+      conditions:
+        - condition: template
+          value_template: "{{ trigger.to_state.attributes.effect != 'Relax' }}"
+      actions:
+        - action: light.turn_on
+          data:
+            entity_id: "{{ trigger.entity_id }}"
+            effect: Relax
+      mode: parallel
+      max: 3
   scripts.yaml: |
     tapo_relax:
       alias: Tapo Relax


### PR DESCRIPTION
## Summary
- add a Home Assistant automation for the three Tapo L530 bulbs
- when top, middle, or bottom turns on, re-apply the built-in Relax effect unless it is already active

## Validation
- kubectl kustomize playbooks/argocd/applications/home-automation/home-assistant
- kubectl apply --dry-run=server -f rendered home-assistant kustomize output
- reloaded live HA automations
- turned light.bottom off, then sent plain light.turn_on, and verified it returned on with effect Relax