### PR TITLE
Install Dreame vacuum integration for Home Assistant

### DIFF
--- a/playbooks/argocd/applications/home-automation/home-assistant/README.md
+++ b/playbooks/argocd/applications/home-automation/home-assistant/README.md
@@ -36,3 +36,10 @@ Current TP-Link Smart Home entries added through Home Assistant:
 
 The bootstrap ConfigMap keeps HA's declarative automations, scripts, and scenes
 that depend on these entities, including the Tapo Relax light behavior.
+
+The Dreame L10s Ultra robot vacuum is visible on the LAN as
+`dreame_vacuum_r2228o` at `192.168.20.170`. Home Assistant does not ship a
+built-in Dreame Home integration, so the Deployment installs the pinned
+`Tasshack/dreame-vacuum` custom component into the HA config PVC on pod start.
+The actual Dreame account/device config entry is still HA runtime state in the
+PVC after login.

--- a/playbooks/argocd/applications/home-automation/home-assistant/deployment.yaml
+++ b/playbooks/argocd/applications/home-automation/home-assistant/deployment.yaml
@@ -36,6 +36,34 @@ spec:
               mountPath: /config
             - name: bootstrap
               mountPath: /bootstrap
+        - name: install-dreame-vacuum
+          image: alpine:3.20
+          command:
+            - sh
+            - -c
+            - |
+              set -euo pipefail
+              apk add --no-cache ca-certificates unzip wget >/dev/null
+              version="v1.0.9"
+              expected_sha256="c04a9a75ca9e9640d88c93dfdd0a1b9af89cfb970b94bbcbcf461e31dc983854"
+              install_dir="/config/custom_components/dreame_vacuum"
+              version_file="${install_dir}/.soyspray-version"
+
+              if [ -f "${version_file}" ] && [ "$(cat "${version_file}")" = "${version}" ]; then
+                exit 0
+              fi
+
+              tmp_dir="$(mktemp -d)"
+              wget -q -O "${tmp_dir}/dreame_vacuum.zip" "https://github.com/Tasshack/dreame-vacuum/releases/download/${version}/dreame_vacuum.zip"
+              echo "${expected_sha256}  ${tmp_dir}/dreame_vacuum.zip" | sha256sum -c -
+              rm -rf "${install_dir}"
+              mkdir -p "${install_dir}"
+              unzip -q "${tmp_dir}/dreame_vacuum.zip" -d "${install_dir}"
+              echo "${version}" > "${version_file}"
+              rm -rf "${tmp_dir}"
+          volumeMounts:
+            - name: config
+              mountPath: /config
       containers:
         - name: home-assistant
           image: ghcr.io/home-assistant/home-assistant:2025.7.2


### PR DESCRIPTION
## Summary
- install the pinned Tasshack/dreame-vacuum custom component into the HA config PVC on pod start
- document the Dreame L10s Ultra LAN identity and runtime config-entry boundary

## Validation
- confirmed Dreame app shows L10s Ultra
- confirmed router DHCP has dreame_vacuum_r2228o at 192.168.20.170
- verified upstream integration supports dreame.vacuum.r2228o L10s Ultra
- kubectl kustomize playbooks/argocd/applications/home-automation/home-assistant
- kubectl apply --dry-run=server -f rendered home-assistant kustomize output