### PR TITLE
Cancel Tapo fades when motion returns

### DIFF
--- a/playbooks/argocd/applications/home-automation/home-assistant/configmap-bootstrap.yaml
+++ b/playbooks/argocd/applications/home-automation/home-assistant/configmap-bootstrap.yaml
@@ -77,7 +77,21 @@ data:
           entity_id: sun.sun
           state: below_horizon
       actions:
-        - action: script.tapo_relax
+        - repeat:
+            count: 2
+            sequence:
+              - action: light.turn_on
+                continue_on_error: true
+                target:
+                  entity_id:
+                    - light.top
+                    - light.middle
+                    - light.bottom
+                data:
+                  effect: Relax
+                  transition: 0
+              - delay:
+                  seconds: 2
         - wait_for_trigger:
             - trigger: state
               entity_id: binary_sensor.tapo_t100_motion
@@ -85,6 +99,7 @@ data:
               for:
                 minutes: 10
         - action: light.turn_off
+          continue_on_error: true
           target:
             entity_id: light.top
           data:
@@ -92,6 +107,7 @@ data:
         - delay:
             minutes: 3
         - action: light.turn_off
+          continue_on_error: true
           target:
             entity_id: light.middle
           data:
@@ -99,10 +115,22 @@ data:
         - delay:
             minutes: 3
         - action: light.turn_off
+          continue_on_error: true
           target:
             entity_id: light.bottom
           data:
             transition: 180
+        - delay:
+            minutes: 3
+        - action: light.turn_off
+          continue_on_error: true
+          target:
+            entity_id:
+              - light.top
+              - light.middle
+              - light.bottom
+          data:
+            transition: 0
       mode: restart
   scripts.yaml: |
     tapo_relax:


### PR DESCRIPTION
## Summary
- make the night motion automation explicitly re-send Relax/on commands to all three bulbs when motion starts
- tolerate intermittent TP-Link service errors so one unavailable bulb does not abort the sequence
- add a final hard all-off command after the staged fade-out completes

## Validation
- kubectl kustomize playbooks/argocd/applications/home-automation/home-assistant
- kubectl apply --dry-run=server -f rendered home-assistant kustomize output
- copied matching automations.yaml to live HA and reloaded automations
- homeassistant.check_config returned []
- started a top fade, triggered the automation start path, then verified top/middle/bottom were on with Relax