### PR TITLE
Use Dreamehome-capable HA vacuum integration

### DIFF
--- a/playbooks/argocd/applications/home-automation/home-assistant/README.md
+++ b/playbooks/argocd/applications/home-automation/home-assistant/README.md
@@ -39,7 +39,9 @@ that depend on these entities, including the Tapo Relax light behavior.
 
 The Dreame L10s Ultra robot vacuum is visible on the LAN as
 `dreame_vacuum_r2228o` at `192.168.20.170`. Home Assistant does not ship a
-built-in Dreame Home integration, so the Deployment installs the pinned
-`Tasshack/dreame-vacuum` custom component into the HA config PVC on pod start.
-The actual Dreame account/device config entry is still HA runtime state in the
-PVC after login.
+built-in Dreamehome integration, so the Deployment installs the pinned
+`Tasshack/dreame-vacuum` beta custom component into the HA config PVC on pod
+start. The beta line is intentional because the stable `v1.x` flow only supports
+Xiaomi Home accounts, while this vacuum is paired to a Dreamehome account. The
+actual Dreame account/device config entry is still HA runtime state in the PVC
+after login.

--- a/playbooks/argocd/applications/home-automation/home-assistant/deployment.yaml
+++ b/playbooks/argocd/applications/home-automation/home-assistant/deployment.yaml
@@ -44,8 +44,8 @@ spec:
             - |
               set -euo pipefail
               apk add --no-cache ca-certificates unzip wget >/dev/null
-              version="v1.0.9"
-              expected_sha256="c04a9a75ca9e9640d88c93dfdd0a1b9af89cfb970b94bbcbcf461e31dc983854"
+              version="v2.0.0b23"
+              expected_sha256="7cd8e3af9d90c3a4b018970b9a05faa48c4c43d40cb007b0e7b031e174db068e"
               install_dir="/config/custom_components/dreame_vacuum"
               version_file="${install_dir}/.soyspray-version"
 


### PR DESCRIPTION
## Summary
- switch the pinned dreame_vacuum custom component from stable v1.0.9 to beta v2.0.0b23
- document why the beta line is intentional: this L10s Ultra is paired through the Dreamehome app, not Xiaomi Home

## Validation
- downloaded v2.0.0b23 and recorded SHA256
- verified v2.0.0b23 exposes Dreamehome Account in the config flow source
- kubectl kustomize playbooks/argocd/applications/home-automation/home-assistant
- kubectl apply --dry-run=server -f rendered home-assistant kustomize output