### PR TITLE
Fix Home Assistant night light shutoff

### DIFF
--- a/playbooks/argocd/applications/home-automation/home-assistant/configmap-bootstrap.yaml
+++ b/playbooks/argocd/applications/home-automation/home-assistant/configmap-bootstrap.yaml
@@ -77,27 +77,106 @@ data:
           entity_id: sun.sun
           state: below_horizon
       actions:
-        - repeat:
-            count: 2
-            sequence:
-              - action: light.turn_on
-                continue_on_error: true
-                target:
-                  entity_id:
-                    - light.top
-                    - light.middle
-                    - light.bottom
-                data:
-                  effect: Relax
-                  transition: 0
-              - delay:
-                  seconds: 2
-        - wait_for_trigger:
-            - trigger: state
-              entity_id: binary_sensor.tapo_t100_motion
-              to: "off"
-              for:
-                minutes: 10
+        - action: light.turn_on
+          continue_on_error: true
+          target:
+            entity_id: light.top
+          data:
+            effect: Relax
+            brightness_pct: 1
+            transition: 0
+        - action: light.turn_on
+          continue_on_error: true
+          target:
+            entity_id: light.middle
+          data:
+            effect: Relax
+            brightness_pct: 1
+            transition: 0
+        - action: light.turn_on
+          continue_on_error: true
+          target:
+            entity_id: light.bottom
+          data:
+            effect: Relax
+            brightness_pct: 1
+            transition: 0
+      mode: restart
+    - id: tapo_motion_relax_lights_off_after_midnight
+      alias: Tapo motion clears Relax lights quickly after midnight
+      triggers:
+        - trigger: state
+          entity_id: binary_sensor.tapo_t100_motion
+          to: "off"
+          for:
+            minutes: 2
+      conditions:
+        - condition: time
+          after: "00:00:00"
+          before: "08:00:00"
+        - condition: state
+          entity_id: sun.sun
+          state: below_horizon
+        - condition: template
+          value_template: >-
+            {{ is_state('light.top', 'on')
+               or is_state('light.middle', 'on')
+               or is_state('light.bottom', 'on') }}
+      actions:
+        - action: light.turn_off
+          continue_on_error: true
+          target:
+            entity_id: light.top
+          data:
+            transition: 15
+        - action: light.turn_off
+          continue_on_error: true
+          target:
+            entity_id: light.middle
+          data:
+            transition: 15
+        - action: light.turn_off
+          continue_on_error: true
+          target:
+            entity_id: light.bottom
+          data:
+            transition: 15
+        - delay:
+            seconds: 20
+        - action: light.turn_off
+          continue_on_error: true
+          target:
+            entity_id: light.top
+          data:
+            transition: 0
+        - action: light.turn_off
+          continue_on_error: true
+          target:
+            entity_id: light.middle
+          data:
+            transition: 0
+        - action: light.turn_off
+          continue_on_error: true
+          target:
+            entity_id: light.bottom
+          data:
+            transition: 0
+      mode: restart
+    - id: tapo_motion_relax_lights_off_after_clear
+      alias: Tapo motion clears Relax lights after 10 minutes
+      triggers:
+        - trigger: state
+          entity_id: binary_sensor.tapo_t100_motion
+          to: "off"
+          for:
+            minutes: 10
+      conditions:
+        - condition: template
+          value_template: >-
+            {{ is_state('light.top', 'on')
+               or is_state('light.middle', 'on')
+               or is_state('light.bottom', 'on') }}
+      actions:
         - action: light.turn_off
           continue_on_error: true
           target:

--- a/playbooks/argocd/applications/home-automation/home-assistant/deployment.yaml
+++ b/playbooks/argocd/applications/home-automation/home-assistant/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       app: home-assistant
   template:
     metadata:
+      annotations:
+        soyspray.vip/bootstrap-config-revision: "2026-05-18-night-lights-v2"
       labels:
         app: home-assistant
         component: main
@@ -28,9 +30,9 @@ spec:
             - -c
             - |
               test -f /config/configuration.yaml || cp /bootstrap/configuration.yaml /config/configuration.yaml
-              test -f /config/automations.yaml || cp /bootstrap/automations.yaml /config/automations.yaml
-              test -f /config/scripts.yaml || cp /bootstrap/scripts.yaml /config/scripts.yaml
-              test -f /config/scenes.yaml || cp /bootstrap/scenes.yaml /config/scenes.yaml
+              cp /bootstrap/automations.yaml /config/automations.yaml
+              cp /bootstrap/scripts.yaml /config/scripts.yaml
+              cp /bootstrap/scenes.yaml /config/scenes.yaml
           volumeMounts:
             - name: config
               mountPath: /config


### PR DESCRIPTION
## Summary
- split the Home Assistant Tapo motion automation into independent turn-on and motion-clear shutoff automations
- set motion-triggered Tapo Relax lights to brightness_pct 1
- add a sharper post-midnight shutoff path: 2 minutes after motion clears during the pre-dawn dark period
- refresh managed Home Assistant automation/script/scene files from the bootstrap ConfigMap on pod restart

## Investigation
- Home Assistant logs showed the night motion automation erroring on a Tapo bulb timeout around 2026-05-18 05:06 NZST.
- Recorder history showed the lights came on around 05:05 NZST and did not turn off until about 07:59 NZST.
- The old single automation could abort before reaching its wait-and-shutoff section when a Tapo service call timed out.
- Argo CD login was blocked by a redirect loop because the live argocd-cmd-params-cm had lost data.server.insecure=true; re-applying the existing repo manifest and restarting argocd-server fixed it.

## Validation
- kubectl kustomize playbooks/argocd/applications/home-automation/home-assistant
- kubectl apply --dry-run=server -k playbooks/argocd/applications/home-automation/home-assistant
- curl -k -I -L --max-redirs 3 https://argocd.soyspray.vip/ returned HTTP 200
- make go logged in successfully
- argocd app get home-assistant --refresh shows Synced and Healthy at fix/homeassistant-night-lights (74e89f6)
- kubectl -n home-automation rollout status deployment/home-assistant

## Deploy note
- Temporarily deployed the PR branch by setting the live home-assistant Application targetRevision to fix/homeassistant-night-lights.
- After merge, set targetRevision back to HEAD.
