### PR TITLE
Manage Argo CD command params in deploy path

### DIFF
--- a/playbooks/deploy-argocd-apps.yml
+++ b/playbooks/deploy-argocd-apps.yml
@@ -8,6 +8,9 @@
     # Roles own their internal task tags (e.g. `prometheus-crds`). This playbook
     # always includes all roles so `--tags <tag>` works as expected.
     argocd_app_roles:
+      # Argo CD control-plane configuration
+      - { name: Argo CD Config, role: apps/argocd-config }
+
       # Observability
       - { name: Prometheus, role: apps/prometheus }
       - { name: Alloy Loki Manual, role: apps/alloy-loki-manual }

--- a/roles/apps/argocd-config/tasks/main.yml
+++ b/roles/apps/argocd-config/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Apply Argo CD command parameters
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig_path }}"
+    namespace: argocd
+    definition: "{{ lookup('file', playbook_dir + '/argocd/config/argocd-cmd-params-cm.yaml') }}"
+  register: argocd_cmd_params
+  tags: argocd-config
+
+- name: Restart Argo CD server when command parameters change
+  kubernetes.core.k8s:
+    state: patched
+    kubeconfig: "{{ kubeconfig_path }}"
+    namespace: argocd
+    kind: Deployment
+    api_version: apps/v1
+    name: argocd-server
+    definition:
+      spec:
+        template:
+          metadata:
+            annotations:
+              soyspray.vip/argocd-cmd-params-restarted-at: "{{ ansible_date_time.iso8601 }}"
+  when: argocd_cmd_params.changed
+  tags: argocd-config


### PR DESCRIPTION
## Summary
- add an apps/argocd-config role that reapplies the repo-owned argocd-cmd-params-cm
- include that role first in the standard Argo CD app deploy playbook
- restart argocd-server only when command parameters change, so server.insecure drift is repaired repeatably

## Validation
- ansible-playbook -i kubespray/inventory/soycluster/hosts.yml --syntax-check playbooks/deploy-argocd-apps.yml
- ansible-playbook -i kubespray/inventory/soycluster/hosts.yml --become --become-user=root --user ubuntu playbooks/deploy-argocd-apps.yml --tags argocd-config
- kubectl -n argocd get cm argocd-cmd-params-cm -o jsonpath='{.data.server\.insecure}{"\n"}' returned true
- curl -k -I -L --max-redirs 3 https://argocd.soyspray.vip/ returned HTTP/2 200
- make go logged in successfully
