### PR TITLE
Set HA motion brightness by midnight

### DIFF
--- a/playbooks/argocd/applications/home-automation/home-assistant/configmap-bootstrap.yaml
+++ b/playbooks/argocd/applications/home-automation/home-assistant/configmap-bootstrap.yaml
@@ -77,13 +77,15 @@ data:
           entity_id: sun.sun
           state: below_horizon
       actions:
+        - variables:
+            tapo_motion_brightness_pct: "{{ 1 if now().hour < 8 else 100 }}"
         - action: light.turn_on
           continue_on_error: true
           target:
             entity_id: light.top
           data:
             effect: Relax
-            brightness_pct: 1
+            brightness_pct: "{{ tapo_motion_brightness_pct }}"
             transition: 0
         - action: light.turn_on
           continue_on_error: true
@@ -91,7 +93,7 @@ data:
             entity_id: light.middle
           data:
             effect: Relax
-            brightness_pct: 1
+            brightness_pct: "{{ tapo_motion_brightness_pct }}"
             transition: 0
         - action: light.turn_on
           continue_on_error: true
@@ -99,7 +101,7 @@ data:
             entity_id: light.bottom
           data:
             effect: Relax
-            brightness_pct: 1
+            brightness_pct: "{{ tapo_motion_brightness_pct }}"
             transition: 0
       mode: restart
     - id: tapo_motion_relax_lights_off_after_midnight

--- a/playbooks/argocd/applications/home-automation/home-assistant/deployment.yaml
+++ b/playbooks/argocd/applications/home-automation/home-assistant/deployment.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        soyspray.vip/bootstrap-config-revision: "2026-05-18-night-lights-v2"
+        soyspray.vip/bootstrap-config-revision: "2026-05-18-night-lights-v3"
       labels:
         app: home-assistant
         component: main


### PR DESCRIPTION
## Summary
- set Tapo motion light brightness dynamically: 100% before midnight, 1% after midnight
- bump the Home Assistant bootstrap config revision so the managed automation file is recopied on rollout

## Validation
- kubectl kustomize playbooks/argocd/applications/home-automation/home-assistant
- kubectl apply --dry-run=server -k playbooks/argocd/applications/home-automation/home-assistant
- argocd app set/sync home-assistant to fix/homeassistant-midnight-brightness
- kubectl -n home-automation rollout status deployment/home-assistant
- verified /config/automations.yaml contains tapo_motion_brightness_pct and templated brightness_pct
- HA /api/template currently renders {{ 1 if now().hour < 8 else 100 }} as 100 before midnight
