### PR TITLE
Fix Alertmanager routing and watchdog cadence

### DIFF
--- a/playbooks/argocd/applications/observability/prometheus/README.md
+++ b/playbooks/argocd/applications/observability/prometheus/README.md
@@ -49,7 +49,7 @@ This UUID corresponds to the check configured in the Healthchecks.io dashboard:
 
 ![Healthchecks.io Dashboard Config](https://healthchecks.io/checks/ee92de78-bf59-4cb8-a41a-01382feb9a65/details)
 
-*Note: The Healthchecks.io check is configured with a Period of ~2 minutes and a Grace Time of ~1 minute to match the AlertManager `repeat_interval`.*
+*Note: The Healthchecks.io check is configured with a Period of ~2 minutes and a Grace Time of ~1 minute. The Watchdog Alertmanager route sets both `group_interval` and `repeat_interval` to 1 minute so this cadence is not stretched by the default alert grouping interval.*
 
 ## Monitored Components
 

--- a/playbooks/argocd/applications/observability/prometheus/prometheus-application.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/prometheus-application.yaml
@@ -20,6 +20,11 @@ spec:
   destination:
     server: "https://kubernetes.default.svc"
     namespace: monitoring
+  ignoreDifferences:
+    - group: monitoring.coreos.com
+      kind: Prometheus
+      jsonPointers:
+        - /spec/enableOTLPReceiver
   syncPolicy:
       automated:
         prune: true
@@ -33,3 +38,4 @@ spec:
       syncOptions:
         - CreateNamespace=true
         - AllowClusterResourceInNamespacedApp=true
+        - RespectIgnoreDifferences=true

--- a/playbooks/argocd/applications/observability/prometheus/values.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/values.yaml
@@ -190,16 +190,25 @@ alertmanager:
       group_wait: 30s
       group_interval: 5m
       repeat_interval: 4h
-      receiver: "telegram"
+      receiver: "null"
       routes:
         - matchers:
             - alertname = "Watchdog"
           receiver: "watchdog-healthchecks"
+          group_wait: 0s
+          group_interval: 1m
           repeat_interval: 1m
+        - matchers:
+            - alertname = "InfoInhibitor"
+          receiver: "null"
+        - matchers:
+            - severity=~"none|info"
+          receiver: "null"
         - matchers:
             - severity=~"warning|critical"
           receiver: "telegram"
     receivers:
+      - name: "null"
       - name: "telegram"
         telegram_configs:
           - api_url: "https://api.telegram.org"


### PR DESCRIPTION
## Summary
- route unmatched/info alerts to a null receiver instead of Telegram
- make the Watchdog Healthchecks route set both group_interval and repeat_interval to 1m
- ignore Prometheus enableOTLPReceiver API-default drift so Argo stops self-healing kube-prometheus-stack continuously
- update the Watchdog documentation to match the actual route timing

## Validation
- kubectl kustomize --enable-helm playbooks/argocd/applications/observability/prometheus
- kubectl apply --dry-run=client --validate=false -f /tmp/soyspray-prometheus-render.yaml
- kubectl apply --dry-run=client --validate=false -f playbooks/argocd/applications/observability/prometheus/prometheus-application.yaml
- git diff --check