### PR TITLE
Upgrade Home Assistant to 2026.5.4

### DIFF
--- a/playbooks/argocd/applications/home-automation/home-assistant/deployment.yaml
+++ b/playbooks/argocd/applications/home-automation/home-assistant/deployment.yaml
@@ -68,7 +68,7 @@ spec:
               mountPath: /config
       containers:
         - name: home-assistant
-          image: ghcr.io/home-assistant/home-assistant:2025.7.2
+          image: ghcr.io/home-assistant/home-assistant:2026.5.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8123


### PR DESCRIPTION
## Summary
- upgrade Home Assistant from `2025.7.2` to `2026.5.4`
- pick the current official stable Home Assistant container version reported by `https://version.home-assistant.io/stable.json`

## Why
The current Home Assistant pod is repeatedly logging TP-Link/Tapo local API errors from the L530 bulbs. This image bump brings in current Home Assistant and integration dependency fixes before we consider alert silencing.

## Validation
- `curl -fsSL https://version.home-assistant.io/stable.json | jq .homeassistant.default` returned `2026.5.4`
- `kubectl kustomize playbooks/argocd/applications/home-automation/home-assistant`
- `kubectl apply --dry-run=client --validate=false -f /tmp/home-assistant-render.yaml`
- `git diff --check`