### PR TITLE
Prepare worker storage and tailnet stretch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,13 @@ SHELL := /bin/bash
 MAKEFLAGS += --no-print-directory
 
 K8S_USER        := ubuntu
-WORKER_NODE1    := 192.168.20.10
-WORKER_NODE2    := 192.168.20.10
-WORKER_NODE3    := 192.168.20.10
-MASTER_NODE     := 192.168.20.10
+NODE0           := 192.168.20.10
+NODE1           := 192.168.20.11
+NODE2           := 192.168.20.12
+WORKER_NODE1    := $(NODE0)
+WORKER_NODE2    := $(NODE1)
+WORKER_NODE3    := $(NODE2)
+MASTER_NODE     := $(NODE0)
 
 # Adjust ArgoCD version if needed
 ARGOCD_VERSION  := v2.12.4

--- a/playbooks/argocd/applications/infrastructure/longhorn/README.md
+++ b/playbooks/argocd/applications/infrastructure/longhorn/README.md
@@ -1,11 +1,13 @@
 # Longhorn Storage
 
-Distributed block storage system for Kubernetes. This setup is optimized for a resource-constrained
-cluster, using minimal replicas and conservative resource limits.
+Distributed block storage system for Kubernetes. This setup is optimized for a
+resource-constrained cluster with three SSD-backed storage nodes and
+conservative resource limits.
 
 ## Configuration
 
-- Using single replica to conserve resources
+- New default StorageClass volumes use three replicas across the SSD-backed
+  storage nodes
 - Conservative CPU/memory limits
 - Using sda devices on each node
 - Default storage class enabled
@@ -49,7 +51,7 @@ For maintenance procedures, including uninstallation and cleanup, see:
 We will create a high-performance storage solution for Prometheus using Longhorn on miniPC SSDs:
 
 1. Create a dedicated `longhorn-monitoring` StorageClass with optimized settings
-2. Configure single-replica volumes backed by the fastest SSD on each node
+2. Configure replicated volumes backed by the SSD on each node
 3. Configure Prometheus to use this storage via PersistentVolumeClaims
 4. Implement proper retention and compaction settings
 

--- a/playbooks/argocd/applications/infrastructure/longhorn/values.yaml
+++ b/playbooks/argocd/applications/infrastructure/longhorn/values.yaml
@@ -1,11 +1,13 @@
 persistence:
   defaultClass: true
-  defaultClassReplicaCount: "1"
+  defaultClassReplicaCount: "3"
   defaultDataLocality: best-effort
   migratable: true
   metricsPort: 9500
 
 defaultSettings:
+  defaultReplicaCount: "3"
+  concurrentReplicaRebuildPerNodeLimit: "4"
   priorityClass: null
   disableRevisionCounter: null
 

--- a/playbooks/argocd/applications/observability/prometheus/dashboards/node-hardware.json
+++ b/playbooks/argocd/applications/observability/prometheus/dashboards/node-hardware.json
@@ -700,13 +700,13 @@
       },
       "targets": [
         {
-          "expr": "sum by (device) (rate(node_disk_read_bytes_total{device=~\"nvme0n1|sda|sdj\"}[5m]))",
-          "legendFormat": "{{device}} read",
+          "expr": "sum by (instance, device) (rate(node_disk_read_bytes_total{device=~\"nvme0n1|sda|sdj\"}[5m]))",
+          "legendFormat": "{{instance}} {{device}} read",
           "refId": "A"
         },
         {
-          "expr": "sum by (device) (rate(node_disk_written_bytes_total{device=~\"nvme0n1|sda|sdj\"}[5m]))",
-          "legendFormat": "{{device}} write",
+          "expr": "sum by (instance, device) (rate(node_disk_written_bytes_total{device=~\"nvme0n1|sda|sdj\"}[5m]))",
+          "legendFormat": "{{instance}} {{device}} write",
           "refId": "B"
         }
       ],
@@ -780,12 +780,12 @@
       "targets": [
         {
           "expr": "100 * rate(node_disk_io_time_seconds_total{device=~\"nvme0n1|sda|sdj\"}[5m])",
-          "legendFormat": "{{device}} util",
+          "legendFormat": "{{instance}} {{device}} util",
           "refId": "A"
         },
         {
           "expr": "node_disk_io_now{device=~\"nvme0n1|sda|sdj\"}",
-          "legendFormat": "{{device}} queue",
+          "legendFormat": "{{instance}} {{device}} queue",
           "refId": "B"
         }
       ],

--- a/playbooks/operations/README.md
+++ b/playbooks/operations/README.md
@@ -16,7 +16,9 @@ Node management and configuration playbooks.
 ### networking/
 Network setup and tooling playbooks.
 
-- install-tailscale.yml - Install Tailscale VPN
+- install-tailscale.yml - Install direct Tailscale access on worker nodes without advertising LAN routes
+- configure-openwrt-tailnet-gateway.yml - Keep OpenWrt advertising only the soyspray LAN route and remove stale old-LAN redirects
+- verify-worker-tailnet.yml - End-to-end worker access checks over `.lan`, Tailscale DNS, SSH, Tailscale ping, and Kubernetes readiness
 - remove-tailscale.yml - Remove Tailscale VPN
 - publish-headlamp-token.yml - Generate and publish Headlamp token
 
@@ -24,6 +26,7 @@ Network setup and tooling playbooks.
 Storage initialization and management playbooks.
 
 - initialize-longhorn-storage.yml - Initialize Longhorn storage system
+- prepare-longhorn-worker-ssd.yml - repartition, format, and mount new worker SSDs at `/storage` by per-host `/dev/disk/by-id` paths
 - prepare-media-usb-disk.yml - repartition, format, mount, and prepare the USB media disk at `/srv/media`
 
 ### security/

--- a/playbooks/operations/networking/configure-openwrt-tailnet-gateway.yml
+++ b/playbooks/operations/networking/configure-openwrt-tailnet-gateway.yml
@@ -1,0 +1,90 @@
+---
+# Keep the OpenWrt tailnet gateway in the expected soyspray shape.
+
+- name: Configure OpenWrt tailnet gateway
+  hosts: localhost
+  gather_facts: false
+  become: false
+  vars:
+    openwrt_host: 192.168.20.1
+    openwrt_user: root
+    openwrt_ssh_target: "{{ openwrt_user }}@{{ openwrt_host }}"
+    openwrt_tailscale_routes:
+      - 192.168.20.0/24
+  tasks:
+    - name: Read current OpenWrt Tailscale prefs
+      ansible.builtin.command:
+        argv:
+          - ssh
+          - -o
+          - BatchMode=yes
+          - "{{ openwrt_ssh_target }}"
+          - tailscale debug prefs
+      register: openwrt_tailscale_prefs_before
+      changed_when: false
+
+    - name: Parse current OpenWrt Tailscale prefs
+      ansible.builtin.set_fact:
+        openwrt_tailscale_prefs_before_json: "{{ openwrt_tailscale_prefs_before.stdout | from_json }}"
+
+    - name: Ensure OpenWrt advertises only the soyspray LAN
+      ansible.builtin.command:
+        argv:
+          - ssh
+          - -o
+          - BatchMode=yes
+          - "{{ openwrt_ssh_target }}"
+          - "tailscale set --advertise-routes={{ openwrt_tailscale_routes | join(',') }}"
+      when: (openwrt_tailscale_prefs_before_json.AdvertiseRoutes | default([], true)) != openwrt_tailscale_routes
+
+    - name: Remove known stale old-LAN WAN redirects
+      ansible.builtin.shell: |
+        ssh -o BatchMode=yes {{ openwrt_ssh_target | quote }} 'set -eu
+        changed=0
+        for name in qbittorrent-in qbittorrent-k8s; do
+          section="$(uci show firewall | sed -n "s/^\(firewall\.[^.]*\)\.name='''$name'''$/\1/p" | head -1)"
+          if [ -n "$section" ]; then
+            uci delete "$section"
+            changed=1
+          fi
+        done
+        if [ "$changed" -eq 1 ]; then
+          uci commit firewall
+          /etc/init.d/firewall reload >/dev/null
+        fi
+        echo "changed=$changed"'
+      register: openwrt_stale_redirect_cleanup
+      changed_when: "'changed=1' in openwrt_stale_redirect_cleanup.stdout"
+
+    - name: Read final OpenWrt Tailscale prefs
+      ansible.builtin.command:
+        argv:
+          - ssh
+          - -o
+          - BatchMode=yes
+          - "{{ openwrt_ssh_target }}"
+          - tailscale debug prefs
+      register: openwrt_tailscale_prefs_after
+      changed_when: false
+
+    - name: Parse final OpenWrt Tailscale prefs
+      ansible.builtin.set_fact:
+        openwrt_tailscale_prefs_after_json: "{{ openwrt_tailscale_prefs_after.stdout | from_json }}"
+
+    - name: Verify OpenWrt advertises the expected route set
+      ansible.builtin.assert:
+        that:
+          - (openwrt_tailscale_prefs_after_json.AdvertiseRoutes | default([], true)) == openwrt_tailscale_routes
+        fail_msg: "OpenWrt Tailscale advertised routes drifted from {{ openwrt_tailscale_routes }}"
+
+    - name: Verify OpenWrt firewall and dnsmasq tailnet guardrails
+      ansible.builtin.shell: |
+        ssh -o BatchMode=yes {{ openwrt_ssh_target | quote }} 'set -eu
+        uci show firewall | grep -q "firewall\\..*\\.name='\''tailscale'\''"
+        uci show firewall | grep -q "firewall\\..*\\.src='\''tailscale'\''"
+        uci show firewall | grep -q "firewall\\..*\\.dest='\''lan'\''"
+        test "$(uci -q get dhcp.@dnsmasq[0].nonwildcard)" = "0"
+        test "$(uci -q get dhcp.@dnsmasq[0].localservice)" = "0"
+        ! uci show firewall | grep -q "192\\.168\\.1\\."
+        echo ok'
+      changed_when: false

--- a/playbooks/operations/networking/install-tailscale.yml
+++ b/playbooks/operations/networking/install-tailscale.yml
@@ -1,31 +1,66 @@
 ---
-# Playbook to install and configure Tailscale on the home Kubernetes node
+# Install and configure direct Tailscale access on Kubernetes worker nodes.
+#
+# OpenWrt remains the canonical subnet router for 192.168.20.0/24. Do not use
+# this playbook to advertise cluster LAN routes from node-1 or node-2.
 
 - name: Common tasks for every playbook
   import_playbook: ../../../kubespray/playbooks/boilerplate.yml
 
-- name: Install and configure Tailscale on Home Node-A
-  hosts: kube_control_plane[0]
+- name: Install and configure Tailscale on Kubernetes workers
+  hosts: "{{ tailscale_target_hosts | default('node-1:node-2') }}"
   become: true
   vars:
-    tailscale_auth_key: "{{ lookup('env', 'TS_AUTH_KEY') }}"
-    tailscale_extra_args: "--advertise-routes=192.168.50.0/24"  # Advertise internal route
-    tailscale_version: "1.86.2"
+    tailscale_auth_key: "{{ lookup('env', 'TS_AUTH_KEY') | default('', true) }}"
+    tailscale_apt_release: "{{ ansible_distribution_release | default('jammy') }}"
+    tailscale_keyring_path: /usr/share/keyrings/tailscale-archive-keyring.gpg
+    tailscale_apt_repo: "deb [signed-by={{ tailscale_keyring_path }}] https://pkgs.tailscale.com/stable/ubuntu {{ tailscale_apt_release }} main"
+    tailscale_version: ""
+    tailscale_package: "{{ ('tailscale=' ~ tailscale_version) if (tailscale_version | length > 0) else 'tailscale' }}"
+    tailscale_hostname: "{{ inventory_hostname }}"
+    tailscale_operator_user: "{{ ansible_user | default('ubuntu') }}"
+    tailscale_accept_dns: false
+    tailscale_accept_routes: false
+    tailscale_advertise_routes: []
+    tailscale_enable_ssh: false
+    tailscale_force_reauth: false
   pre_tasks:
     - name: Check existing Tailscale state
-      ansible.builtin.command: tailscale status
-      register: tailscale_status
+      ansible.builtin.command: tailscale status --json
+      register: tailscale_status_before
       changed_when: false
       failed_when: false
 
+    - name: Parse existing Tailscale state
+      ansible.builtin.set_fact:
+        tailscale_status_before_json: "{{ tailscale_status_before.stdout | from_json }}"
+      when:
+        - tailscale_status_before.rc == 0
+        - tailscale_status_before.stdout | length > 0
+
+    - name: Determine whether Tailscale is already logged in
+      ansible.builtin.set_fact:
+        tailscale_logged_in_before: >-
+          {{
+            ((tailscale_status_before_json | default({})).BackendState | default('')) == 'Running'
+            and ((((tailscale_status_before_json | default({})).Self | default({})).TailscaleIPs | default([], true)) | length > 0)
+          }}
+
     - name: Ensure TS_AUTH_KEY is provided for first login
       ansible.builtin.fail:
-        msg: "TS_AUTH_KEY environment variable required for initial authentication. Set in .env file."
-      when: tailscale_status.rc != 0 and (tailscale_auth_key | length == 0)
+        msg: >-
+          TS_AUTH_KEY is required for first-time Tailscale enrollment on
+          {{ inventory_hostname }}. Generate a temporary auth key in the
+          Tailscale admin console and pass it in the environment; do not commit
+          it to the repo.
+      when:
+        - not tailscale_logged_in_before | bool
+        - tailscale_auth_key | length == 0
   tasks:
     - name: Ensure prerequisite packages are installed
       ansible.builtin.apt:
         name:
+          - ca-certificates
           - curl
           - gnupg
         state: present
@@ -33,20 +68,19 @@
 
     - name: Add Tailscale GPG key
       ansible.builtin.shell: |
-        curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/jammy.gpg \
-          | gpg --dearmor -o /usr/share/keyrings/tailscale-archive-keyring.gpg
+        curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/{{ tailscale_apt_release }}.gpg \
+          | gpg --dearmor -o {{ tailscale_keyring_path }}
       args:
-        creates: /usr/share/keyrings/tailscale-archive-keyring.gpg
+        creates: "{{ tailscale_keyring_path }}"
 
     - name: Add Tailscale apt repository
       ansible.builtin.apt_repository:
-        repo: "deb [signed-by=/usr/share/keyrings/tailscale-archive-keyring.gpg] https://pkgs.tailscale.com/stable/ubuntu jammy main"
+        repo: "{{ tailscale_apt_repo }}"
         filename: tailscale
 
     - name: Install Tailscale client and CLI
       ansible.builtin.apt:
-        name:
-          - "tailscale={{ tailscale_version }}"
+        name: "{{ tailscale_package }}"
         state: present
         update_cache: true
 
@@ -62,6 +96,62 @@
       changed_when: false
       failed_when: false
 
+    - name: Check Tailscale login state after install
+      ansible.builtin.command: tailscale status --json
+      register: tailscale_status_after_install
+      changed_when: false
+      failed_when: false
+
+    - name: Parse Tailscale login state after install
+      ansible.builtin.set_fact:
+        tailscale_status_after_install_json: "{{ tailscale_status_after_install.stdout | from_json }}"
+      when:
+        - tailscale_status_after_install.rc == 0
+        - tailscale_status_after_install.stdout | length > 0
+
+    - name: Determine whether Tailscale needs login
+      ansible.builtin.set_fact:
+        tailscale_needs_login: >-
+          {{
+            tailscale_force_reauth | bool
+            or ((tailscale_status_after_install_json | default({})).BackendState | default('')) != 'Running'
+            or ((((tailscale_status_after_install_json | default({})).Self | default({})).TailscaleIPs | default([], true)) | length == 0)
+          }}
+
     - name: Bring up Tailscale with auth key
-      ansible.builtin.command: "tailscale up --authkey={{ tailscale_auth_key }} {{ tailscale_extra_args }}"
-      when: tailscale_status.rc != 0
+      ansible.builtin.command: >-
+        tailscale up
+        --authkey={{ tailscale_auth_key }}
+        --hostname={{ tailscale_hostname }}
+        --accept-dns={{ tailscale_accept_dns | bool | ternary('true', 'false') }}
+        --accept-routes={{ tailscale_accept_routes | bool | ternary('true', 'false') }}
+        --advertise-routes={{ tailscale_advertise_routes | join(',') }}
+        --ssh={{ tailscale_enable_ssh | bool | ternary('true', 'false') }}
+      no_log: true
+      when: tailscale_needs_login | bool
+
+    - name: Apply direct-node Tailscale preferences
+      ansible.builtin.command: >-
+        tailscale set
+        --hostname={{ tailscale_hostname }}
+        --operator={{ tailscale_operator_user }}
+        --accept-dns={{ tailscale_accept_dns | bool | ternary('true', 'false') }}
+        --accept-routes={{ tailscale_accept_routes | bool | ternary('true', 'false') }}
+        --advertise-routes={{ tailscale_advertise_routes | join(',') }}
+        --ssh={{ tailscale_enable_ssh | bool | ternary('true', 'false') }}
+      register: tailscale_set_result
+      changed_when: false
+
+    - name: Verify Tailscale status
+      ansible.builtin.command: tailscale status --json
+      register: tailscale_status_final
+      changed_when: false
+
+    - name: Show Tailscale node identity
+      ansible.builtin.debug:
+        msg:
+          host: "{{ inventory_hostname }}"
+          version: "{{ tailscale_cli.stdout_lines[0] | default('unknown') }}"
+          status: "{{ (tailscale_status_final.stdout | from_json).Self.HostName }}"
+          dns_name: "{{ (tailscale_status_final.stdout | from_json).Self.DNSName }}"
+          tailscale_ips: "{{ (tailscale_status_final.stdout | from_json).Self.TailscaleIPs }}"

--- a/playbooks/operations/networking/verify-worker-tailnet.yml
+++ b/playbooks/operations/networking/verify-worker-tailnet.yml
@@ -1,0 +1,200 @@
+---
+# End-to-end checks for worker access over OpenWrt subnet routing and direct Tailscale.
+
+- name: Common tasks for every playbook
+  import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+
+- name: Verify worker Tailscale node state
+  hosts: "{{ tailscale_target_hosts | default('node-1:node-2') }}"
+  become: true
+  vars:
+    tailnet_dns_suffix: shark-garibaldi.ts.net
+  tasks:
+    - name: Read worker Tailscale status
+      ansible.builtin.command: tailscale status --json
+      register: worker_tailscale_status
+      changed_when: false
+
+    - name: Read worker Tailscale prefs
+      ansible.builtin.command: tailscale debug prefs
+      register: worker_tailscale_prefs
+      changed_when: false
+
+    - name: Parse worker Tailscale state
+      ansible.builtin.set_fact:
+        worker_tailscale_status_json: "{{ worker_tailscale_status.stdout | from_json }}"
+        worker_tailscale_prefs_json: "{{ worker_tailscale_prefs.stdout | from_json }}"
+
+    - name: Assert worker is a direct non-router Tailscale node
+      ansible.builtin.assert:
+        that:
+          - worker_tailscale_status_json.BackendState == 'Running'
+          - worker_tailscale_status_json.Self.HostName == inventory_hostname
+          - (worker_tailscale_status_json.Self.TailscaleIPs | default([], true) | length) > 0
+          - (worker_tailscale_prefs_json.AdvertiseRoutes | default([], true) | length) == 0
+          - not (worker_tailscale_prefs_json.CorpDNS | bool)
+          - not (worker_tailscale_prefs_json.RunSSH | bool)
+          - worker_tailscale_prefs_json.OperatorUser == (ansible_user | default('ubuntu'))
+
+    - name: Verify LAN route uses the tailnet subnet router from localhost
+      ansible.builtin.command:
+        argv:
+          - ip
+          - route
+          - get
+          - "{{ ansible_host }}"
+      delegate_to: localhost
+      become: false
+      register: worker_lan_route
+      changed_when: false
+
+    - name: Assert LAN route is captured by Tailscale
+      ansible.builtin.assert:
+        that:
+          - "'tailscale0' in worker_lan_route.stdout"
+        fail_msg: "Route to {{ inventory_hostname }} at {{ ansible_host }} is not using tailscale0"
+
+    - name: Verify .lan DNS resolves to the reserved LAN address
+      ansible.builtin.command:
+        argv:
+          - getent
+          - ahostsv4
+          - "{{ inventory_hostname }}.lan"
+      delegate_to: localhost
+      become: false
+      register: worker_lan_dns
+      changed_when: false
+
+    - name: Assert .lan DNS resolves correctly
+      ansible.builtin.assert:
+        that:
+          - "ansible_host in worker_lan_dns.stdout"
+
+    - name: Verify SSH by LAN DNS name
+      ansible.builtin.command:
+        argv:
+          - ssh
+          - -o
+          - BatchMode=yes
+          - -o
+          - StrictHostKeyChecking=accept-new
+          - "{{ ansible_user | default('ubuntu') }}@{{ inventory_hostname }}.lan"
+          - hostname
+      delegate_to: localhost
+      become: false
+      register: worker_lan_ssh
+      changed_when: false
+
+    - name: Verify SSH by Tailscale DNS name
+      ansible.builtin.command:
+        argv:
+          - ssh
+          - -o
+          - BatchMode=yes
+          - -o
+          - StrictHostKeyChecking=accept-new
+          - "{{ ansible_user | default('ubuntu') }}@{{ inventory_hostname }}.{{ tailnet_dns_suffix }}"
+          - hostname
+      delegate_to: localhost
+      become: false
+      register: worker_tailnet_ssh
+      changed_when: false
+
+    - name: Assert SSH returns the expected hostnames
+      ansible.builtin.assert:
+        that:
+          - worker_lan_ssh.stdout == inventory_hostname
+          - worker_tailnet_ssh.stdout == inventory_hostname
+
+    - name: Verify direct Tailscale ping
+      ansible.builtin.command:
+        argv:
+          - tailscale
+          - ping
+          - --timeout=5s
+          - "{{ inventory_hostname }}.{{ tailnet_dns_suffix }}"
+      delegate_to: localhost
+      become: false
+      changed_when: false
+
+    - name: Verify Kubernetes node is Ready
+      ansible.builtin.command:
+        argv:
+          - kubectl
+          - get
+          - node
+          - "{{ inventory_hostname }}"
+          - -o
+          - "jsonpath={.status.conditions[?(@.type=='Ready')].status}"
+      delegate_to: localhost
+      become: false
+      register: worker_kube_ready
+      changed_when: false
+
+    - name: Assert Kubernetes Ready condition
+      ansible.builtin.assert:
+        that:
+          - worker_kube_ready.stdout == 'True'
+
+    - name: Read local Tailscale peer view
+      ansible.builtin.command: tailscale status --json
+      delegate_to: localhost
+      become: false
+      register: local_tailscale_status
+      changed_when: false
+
+    - name: Parse local Tailscale peer view
+      ansible.builtin.set_fact:
+        local_tailscale_status_json: "{{ local_tailscale_status.stdout | from_json }}"
+
+    - name: Select worker peer from local Tailscale view
+      ansible.builtin.set_fact:
+        local_worker_tailscale_peer: >-
+          {{
+            (
+              local_tailscale_status_json.Peer
+              | dict2items
+              | map(attribute='value')
+              | selectattr('HostName', 'equalto', inventory_hostname)
+              | list
+            )[0] | default({})
+          }}
+
+    - name: Assert local peer route and key-expiry state
+      ansible.builtin.assert:
+        that:
+          - local_worker_tailscale_peer.HostName | default('') == inventory_hostname
+          - local_worker_tailscale_peer.Online | bool
+          - (local_worker_tailscale_peer.AllowedIPs | default([]) | select('match', '^192\\.168\\.20\\.') | list | length) == 0
+          - local_worker_tailscale_peer.KeyExpiry | default('') == ''
+
+- name: Verify OpenWrt tailnet gateway state
+  hosts: localhost
+  gather_facts: false
+  become: false
+  vars:
+    openwrt_host: 192.168.20.1
+    openwrt_user: root
+    openwrt_ssh_target: "{{ openwrt_user }}@{{ openwrt_host }}"
+    openwrt_tailscale_routes:
+      - 192.168.20.0/24
+  tasks:
+    - name: Read OpenWrt Tailscale prefs
+      ansible.builtin.command:
+        argv:
+          - ssh
+          - -o
+          - BatchMode=yes
+          - "{{ openwrt_ssh_target }}"
+          - tailscale debug prefs
+      register: openwrt_tailscale_prefs
+      changed_when: false
+
+    - name: Parse OpenWrt Tailscale prefs
+      ansible.builtin.set_fact:
+        openwrt_tailscale_prefs_json: "{{ openwrt_tailscale_prefs.stdout | from_json }}"
+
+    - name: Assert OpenWrt advertises only the LAN subnet
+      ansible.builtin.assert:
+        that:
+          - (openwrt_tailscale_prefs_json.AdvertiseRoutes | default([], true)) == openwrt_tailscale_routes

--- a/playbooks/operations/openclaw/install-openclaw-dependencies.yml
+++ b/playbooks/operations/openclaw/install-openclaw-dependencies.yml
@@ -9,7 +9,8 @@
   become: true
   vars:
     openclaw_tailscale_gpg_keyring: /usr/share/keyrings/tailscale-archive-keyring.gpg
-    openclaw_tailscale_version: "1.86.2"
+    openclaw_tailscale_version: ""
+    openclaw_tailscale_package: "{{ ('tailscale=' ~ openclaw_tailscale_version) if (openclaw_tailscale_version | length > 0) else 'tailscale' }}"
     openclaw_apt_release: "{{ ansible_distribution_release | default('jammy') }}"
     openclaw_tailscale_repo: "deb [signed-by={{ openclaw_tailscale_gpg_keyring }}] https://pkgs.tailscale.com/stable/ubuntu {{ openclaw_apt_release }} main"
 
@@ -160,7 +161,7 @@
 
         - name: Install tailscale package
           ansible.builtin.apt:
-            name: "tailscale={{ openclaw_tailscale_version }}"
+            name: "{{ openclaw_tailscale_package }}"
             state: present
             update_cache: true
 

--- a/playbooks/operations/storage/initialize-longhorn-storage.yml
+++ b/playbooks/operations/storage/initialize-longhorn-storage.yml
@@ -39,11 +39,20 @@
     storage_mount: /storage
     storage_fstype: ext4
     storage_mount_opts: defaults,nofail,x-systemd.device-timeout=10s
+    storage_force_reformat: false
     expected_storage_models:
       - Samsung SSD
       - PNY 500GB SATA
 
   pre_tasks:
+    - name: Refuse destructive run unless reformat is explicitly confirmed
+      fail:
+        msg: >-
+          This playbook repartitions and reformats {{ storage_device }} on every
+          targeted host. Re-run with -e storage_force_reformat=true after
+          confirming host limits and disk identity.
+      when: not (storage_force_reformat | bool)
+
     - name: Install required packages
       apt:
         name:

--- a/playbooks/operations/storage/prepare-longhorn-worker-ssd.yml
+++ b/playbooks/operations/storage/prepare-longhorn-worker-ssd.yml
@@ -1,0 +1,340 @@
+# prepare-longhorn-worker-ssd.yml
+#
+# One-shot worker storage preparation for freshly installed PNY SATA SSDs.
+# The target device must be passed as a stable /dev/disk/by-id path per host.
+
+- name: Common tasks for every playbook
+  import_playbook: ../../../kubespray/playbooks/boilerplate.yml
+
+- name: Prepare worker SSDs for Longhorn
+  hosts: node-1:node-2
+  become: true
+  gather_facts: true
+
+  vars:
+    longhorn_storage_device_by_host:
+      node-1: ""
+      node-2: ""
+    longhorn_storage_force_format: false
+    longhorn_storage_mount: /storage
+    longhorn_storage_fstype: ext4
+    longhorn_storage_mount_opts: defaults,noatime,nofail,x-systemd.device-timeout=10s
+    longhorn_storage_label_by_host:
+      node-1: longhorn-node1
+      node-2: longhorn-node2
+    longhorn_storage_expected_model_substrings:
+      - PNY
+      - 500GB
+    longhorn_storage_expected_transport: sata
+
+  pre_tasks:
+    - name: Resolve configured storage device for this host
+      ansible.builtin.set_fact:
+        longhorn_storage_device: "{{ longhorn_storage_device_by_host[inventory_hostname] | default('') }}"
+
+    - name: Refuse missing per-host storage device
+      ansible.builtin.fail:
+        msg: >-
+          No storage device configured for {{ inventory_hostname }}.
+          Pass longhorn_storage_device_by_host with stable /dev/disk/by-id paths
+          after the new SSDs are installed.
+      when: longhorn_storage_device | length == 0
+
+    - name: Refuse non-by-id storage device paths
+      ansible.builtin.fail:
+        msg: >-
+          Refusing {{ longhorn_storage_device }}. Use a stable
+          /dev/disk/by-id/... path, not /dev/sdX.
+      when: not longhorn_storage_device.startswith('/dev/disk/by-id/')
+
+    - name: Verify target device symlink exists
+      ansible.builtin.stat:
+        path: "{{ longhorn_storage_device }}"
+      register: longhorn_storage_device_stat
+
+    - name: Fail if target device does not exist
+      ansible.builtin.fail:
+        msg: "Target storage device {{ longhorn_storage_device }} does not exist on {{ inventory_hostname }}"
+      when: not longhorn_storage_device_stat.stat.exists
+
+    - name: Resolve target device path
+      ansible.builtin.command:
+        argv:
+          - readlink
+          - -f
+          - "{{ longhorn_storage_device }}"
+      register: longhorn_storage_real_device
+      changed_when: false
+
+    - name: Verify target path resolves to a disk
+      ansible.builtin.command:
+        argv:
+          - lsblk
+          - -ndo
+          - TYPE
+          - "{{ longhorn_storage_real_device.stdout }}"
+      register: longhorn_storage_device_type
+      changed_when: false
+
+    - name: Fail if target is not a whole disk
+      ansible.builtin.fail:
+        msg: >-
+          {{ longhorn_storage_device }} resolves to {{ longhorn_storage_real_device.stdout }},
+          which is type "{{ longhorn_storage_device_type.stdout | trim }}"; expected "disk".
+      when: (longhorn_storage_device_type.stdout | trim) != 'disk'
+
+    - name: Get target disk model
+      ansible.builtin.command:
+        argv:
+          - lsblk
+          - -ndo
+          - MODEL
+          - "{{ longhorn_storage_real_device.stdout }}"
+      register: longhorn_storage_model
+      changed_when: false
+
+    - name: Get target disk transport
+      ansible.builtin.command:
+        argv:
+          - lsblk
+          - -ndo
+          - TRAN
+          - "{{ longhorn_storage_real_device.stdout }}"
+      register: longhorn_storage_transport
+      changed_when: false
+
+    - name: Verify expected SSD identity
+      ansible.builtin.assert:
+        that:
+          - >-
+            (longhorn_storage_expected_model_substrings
+            | select('in', longhorn_storage_model.stdout | trim)
+            | list
+            | length) == (longhorn_storage_expected_model_substrings | length)
+          - >-
+            (longhorn_storage_expected_transport | length == 0)
+            or ((longhorn_storage_transport.stdout | trim) == longhorn_storage_expected_transport)
+        fail_msg: >-
+          Refusing to format {{ longhorn_storage_real_device.stdout }} on {{ inventory_hostname }}.
+          Expected model containing {{ longhorn_storage_expected_model_substrings | join(', ') }}
+          and transport "{{ longhorn_storage_expected_transport }}"; found model
+          "{{ longhorn_storage_model.stdout | trim }}" and transport
+          "{{ longhorn_storage_transport.stdout | trim }}".
+
+    - name: Read root filesystem source
+      ansible.builtin.command:
+        argv:
+          - findmnt
+          - -n
+          - -o
+          - SOURCE
+          - /
+      register: longhorn_storage_root_source
+      changed_when: false
+
+    - name: Refuse if target disk contains the root filesystem
+      ansible.builtin.fail:
+        msg: >-
+          Refusing {{ longhorn_storage_real_device.stdout }} because root is mounted
+          from {{ longhorn_storage_root_source.stdout | trim }}.
+      when: (longhorn_storage_root_source.stdout | trim).startswith(longhorn_storage_real_device.stdout | trim)
+
+    - name: Check if Longhorn path is already a mountpoint
+      ansible.builtin.command:
+        argv:
+          - mountpoint
+          - -q
+          - "{{ longhorn_storage_mount }}"
+      register: longhorn_storage_mountpoint_check
+      failed_when: false
+      changed_when: false
+
+    - name: Read existing Longhorn mount source
+      ansible.builtin.command:
+        argv:
+          - findmnt
+          - -n
+          - -o
+          - SOURCE
+          - --mountpoint
+          - "{{ longhorn_storage_mount }}"
+      register: longhorn_storage_existing_mount
+      changed_when: false
+      when: longhorn_storage_mountpoint_check.rc == 0
+
+    - name: Refuse to replace an existing Longhorn mount
+      ansible.builtin.fail:
+        msg: >-
+          {{ longhorn_storage_mount }} is already mounted from
+          {{ longhorn_storage_existing_mount.stdout | trim }} on {{ inventory_hostname }}.
+          Unmount or choose another mountpoint before formatting.
+      when: longhorn_storage_mountpoint_check.rc == 0
+
+    - name: Check whether target disk has mounted children
+      ansible.builtin.command:
+        argv:
+          - lsblk
+          - -nrpo
+          - MOUNTPOINTS
+          - "{{ longhorn_storage_real_device.stdout }}"
+      register: longhorn_storage_child_mounts
+      changed_when: false
+
+    - name: Refuse target disk with mounted children
+      ansible.builtin.fail:
+        msg: >-
+          Refusing {{ longhorn_storage_real_device.stdout }} because it has mounted paths:
+          {{ longhorn_storage_child_mounts.stdout_lines | reject('equalto', '') | list | join(', ') }}
+      when: (longhorn_storage_child_mounts.stdout_lines | reject('equalto', '') | list | length) > 0
+
+    - name: Refuse destructive run unless formatting is explicitly confirmed
+      ansible.builtin.fail:
+        msg: >-
+          This playbook repartitions and reformats {{ longhorn_storage_device }}
+          on {{ inventory_hostname }}. Re-run with
+          -e longhorn_storage_force_format=true after confirming the disk identity.
+      when: not (longhorn_storage_force_format | bool)
+
+    - name: Install Longhorn storage prerequisites
+      ansible.builtin.apt:
+        name:
+          - nfs-common
+          - open-iscsi
+          - cryptsetup
+          - dmsetup
+          - parted
+          - e2fsprogs
+          - util-linux
+        state: present
+        update_cache: true
+
+    - name: Ensure Longhorn kernel modules load on boot
+      ansible.builtin.copy:
+        dest: /etc/modules-load.d/longhorn.conf
+        content: |
+          iscsi_tcp
+          dm_crypt
+        mode: "0644"
+
+    - name: Load Longhorn kernel modules
+      community.general.modprobe:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - iscsi_tcp
+        - dm_crypt
+
+  tasks:
+    - name: Wipe existing signatures from target SSD
+      ansible.builtin.command:
+        argv:
+          - wipefs
+          - --all
+          - --force
+          - "{{ longhorn_storage_real_device.stdout }}"
+
+    - name: Create GPT partition table on target SSD
+      ansible.builtin.command:
+        argv:
+          - parted
+          - -s
+          - "{{ longhorn_storage_real_device.stdout }}"
+          - mklabel
+          - gpt
+
+    - name: Create Longhorn partition
+      community.general.parted:
+        device: "{{ longhorn_storage_real_device.stdout }}"
+        number: 1
+        state: present
+        part_start: 1MiB
+        part_end: 100%
+        fs_type: "{{ longhorn_storage_fstype }}"
+
+    - name: Wait for by-id partition symlink
+      ansible.builtin.wait_for:
+        path: "{{ longhorn_storage_device }}-part1"
+        timeout: 30
+
+    - name: Create filesystem on Longhorn partition
+      community.general.filesystem:
+        fstype: "{{ longhorn_storage_fstype }}"
+        dev: "{{ longhorn_storage_device }}-part1"
+        opts: "-L {{ longhorn_storage_label_by_host[inventory_hostname] }}"
+        force: true
+
+    - name: Read Longhorn partition UUID
+      ansible.builtin.command:
+        argv:
+          - blkid
+          - -s
+          - UUID
+          - -o
+          - value
+          - "{{ longhorn_storage_device }}-part1"
+      register: longhorn_storage_uuid
+      changed_when: false
+
+    - name: Ensure Longhorn mountpoint exists
+      ansible.builtin.file:
+        path: "{{ longhorn_storage_mount }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Mount Longhorn SSD by UUID
+      ansible.builtin.mount:
+        path: "{{ longhorn_storage_mount }}"
+        src: "UUID={{ longhorn_storage_uuid.stdout | trim }}"
+        fstype: "{{ longhorn_storage_fstype }}"
+        opts: "{{ longhorn_storage_mount_opts }}"
+        dump: 0
+        passno: 2
+        state: mounted
+
+    - name: Write storage preparation marker
+      ansible.builtin.copy:
+        dest: "{{ longhorn_storage_mount }}/.soyspray-longhorn-storage"
+        content: |
+          host={{ inventory_hostname }}
+          source={{ longhorn_storage_device }}
+          resolved={{ longhorn_storage_real_device.stdout }}
+          uuid={{ longhorn_storage_uuid.stdout | trim }}
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Show resulting Longhorn SSD layout
+      ansible.builtin.command:
+        argv:
+          - lsblk
+          - -o
+          - NAME,MODEL,SERIAL,SIZE,FSTYPE,MOUNTPOINTS,TRAN,ROTA
+          - "{{ longhorn_storage_real_device.stdout }}"
+      register: longhorn_storage_layout
+      changed_when: false
+
+    - name: Show mounted Longhorn storage capacity
+      ansible.builtin.command:
+        argv:
+          - df
+          - -hT
+          - "{{ longhorn_storage_mount }}"
+      register: longhorn_storage_df
+      changed_when: false
+
+    - name: Display Longhorn SSD preparation summary
+      ansible.builtin.debug:
+        msg: |
+          Longhorn worker SSD prepared successfully.
+          Host: {{ inventory_hostname }}
+          Device: {{ longhorn_storage_device }}
+          Resolved device: {{ longhorn_storage_real_device.stdout }}
+          Model: {{ longhorn_storage_model.stdout | trim }}
+          UUID: {{ longhorn_storage_uuid.stdout | trim }}
+          Mount: {{ longhorn_storage_mount }}
+
+          {{ longhorn_storage_layout.stdout }}
+
+          {{ longhorn_storage_df.stdout }}

--- a/soydocs/one-offs/2026-06-29-two-node-intake.md
+++ b/soydocs/one-offs/2026-06-29-two-node-intake.md
@@ -206,3 +206,85 @@ again at about 21:01 local time, then came back with Ubuntu SSH:
 - A cloud-init override was added on the node:
   `/etc/cloud/cloud.cfg.d/99-soyspray-preserve-hostname.cfg` with
   `preserve_hostname: true`.
+
+## 2026-06-29 Kubespray Scale Completion
+
+Both new nodes were added to `kubespray/inventory/soycluster/hosts.yml` on the
+`upgrade/kubespray-latest` submodule branch and assigned to `kube_node`:
+
+| Node | IP | Role |
+| --- | --- | --- |
+| `node-1` | `192.168.20.11` | worker |
+| `node-2` | `192.168.20.12` | worker |
+
+The inventory parsed with:
+
+```sh
+ansible-inventory -i kubespray/inventory/soycluster/hosts.yml --graph
+```
+
+SSH and privilege escalation worked for all three hosts:
+
+```sh
+source soyspray-venv/bin/activate
+ansible -i kubespray/inventory/soycluster/hosts.yml all \
+  -m ping --become --become-user=root --user ubuntu
+```
+
+The Kubespray add-node flow was run from inside the Kubespray submodule so its
+own fact-cache settings were active:
+
+```sh
+cd kubespray
+source ../soyspray-venv/bin/activate
+ANSIBLE_CONFIG=ansible.cfg ansible-playbook \
+  -i inventory/soycluster/hosts.yml \
+  --become --become-user=root --user ubuntu \
+  playbooks/facts.yml
+ANSIBLE_CONFIG=ansible.cfg ansible-playbook \
+  -i inventory/soycluster/hosts.yml \
+  --become --become-user=root --user ubuntu \
+  scale.yml --limit=node-1,node-2
+```
+
+The first scale attempt reached `kubeadm join` but failed because Kubernetes
+bootstrap discovery still advertised the pre-move API endpoint
+`https://192.168.1.10:6443`. The live `kubeadm-config` ConfigMap and API server
+certificate were already correct for `192.168.20.10`, but the public
+`kube-public/cluster-info` ConfigMap still contained the old server URL.
+
+Before retrying, `cluster-info` was backed up to:
+
+```text
+/tmp/soyspray-cluster-info-before-20260629T094346Z.yaml
+```
+
+Then its kubeconfig `server` value was patched to:
+
+```text
+https://192.168.20.10:6443
+```
+
+After that, the rerun of `scale.yml --limit=node-1,node-2` completed
+successfully:
+
+```text
+node-1 : failed=0
+node-2 : failed=0
+```
+
+Final node state:
+
+```text
+node-0  Ready  control-plane,worker  192.168.20.10  Ubuntu 22.04.5 LTS
+node-1  Ready  <none>                192.168.20.11  Ubuntu 22.04.5 LTS
+node-2  Ready  <none>                192.168.20.12  Ubuntu 22.04.5 LTS
+```
+
+Confirmed on `node-1` and `node-2`:
+
+- Hostnames are `node-1` and `node-2`.
+- `kubelet` is active.
+- `containerd` is active.
+- Core node pods are running: `calico-node`, `kube-proxy`, `nginx-proxy`, and
+  `nodelocaldns`.

--- a/soydocs/one-offs/2026-06-29-two-node-intake.md
+++ b/soydocs/one-offs/2026-06-29-two-node-intake.md
@@ -1,0 +1,208 @@
+# 2026-06-29 Two Node Intake
+
+## Summary
+
+Two new Lenovo mini PCs were moved from the upstream `192.168.10.0/24` network
+onto the OpenWrt-managed soyspray LAN through the switch.
+
+The existing cluster node stayed online during the intake:
+
+- `node-0`: `192.168.20.10`
+- SSH returned hostname `node-0`
+- `kubectl get nodes -o wide` showed `node-0` as `Ready`
+
+The two new machines were first observed while still running Windows, then
+OpenWrt DHCP reservations were added for the planned Kubernetes node IPs.
+
+`node-2` has since booted Ubuntu from the 22.04.5 autoinstall USB and is
+reachable on its reserved address. SSH key access works after replacing the
+stale local `known_hosts` entry for `192.168.20.12`.
+
+## Observed Devices
+
+Initial temporary DHCP leases:
+
+| Planned node | MAC | Temporary DHCP lease | Hostname seen |
+| --- | --- | --- | --- |
+| `node-1` | `98:fa:9b:17:f0:50` | `192.168.20.240` | `*` |
+| `node-2` | `98:fa:9b:17:f1:1b` | `192.168.20.236` | `DESKTOP-N7J6OTJ` |
+
+Both MACs were visible on the OpenWrt bridge as wired clients on `br-lan`.
+Both machines responded like Windows hosts: ICMP was blocked, and TCP `7680`
+was open.
+
+## Stable IP Plan
+
+Pin the new Kubernetes nodes with OpenWrt DHCP reservations:
+
+| Node | MAC | Reserved IP |
+| --- | --- | --- |
+| `node-1` | `98:fa:9b:17:f0:50` | `192.168.20.11` |
+| `node-2` | `98:fa:9b:17:f1:1b` | `192.168.20.12` |
+
+Reasoning:
+
+- Existing cluster node is `node-0` at `192.168.20.10`.
+- OpenWrt DHCP pool is `192.168.20.100-192.168.20.249`.
+- MetalLB service range is `192.168.20.20-192.168.20.38`.
+- Laptop `mox` is reserved at `192.168.20.50`.
+- `192.168.20.11` and `192.168.20.12` sit next to `node-0` and are outside the
+  DHCP pool and MetalLB range.
+
+## Verification
+
+OpenWrt ping checks before assigning reservations:
+
+```text
+PING 192.168.20.11: 3 packets transmitted, 0 packets received
+PING 192.168.20.12: 3 packets transmitted, 0 packets received
+```
+
+OpenWrt neighbor state after the checks:
+
+```text
+192.168.20.11  FAILED
+192.168.20.12  INCOMPLETE
+```
+
+That confirms the planned stable addresses were not in active use at the time
+of this intake.
+
+## Next Steps
+
+1. Add OpenWrt DHCP reservations for the new MACs:
+   - `node-1`: `98:fa:9b:17:f0:50` -> `192.168.20.11`
+   - `node-2`: `98:fa:9b:17:f1:1b` -> `192.168.20.12`
+2. Reboot the two Windows machines, or force DHCP renew, and verify OpenWrt
+   leases move from `.240` and `.236` to `.11` and `.12`.
+3. Install Ubuntu on the new nodes.
+4. Verify SSH access as `ubuntu` on `192.168.20.11` and `192.168.20.12`.
+5. Update `kubespray/inventory/soycluster/hosts.yml` with `node-1` and
+   `node-2`.
+6. Run the Kubespray scale workflow only after the stable IPs and SSH access
+   are confirmed.
+
+Do not add the current temporary DHCP addresses `.240` and `.236` to Kubespray.
+Kubernetes nodes need stable addresses.
+
+## OpenWrt Reservations Applied
+
+The planned reservations were applied on OpenWrt and dnsmasq was reloaded:
+
+| Node | MAC | Reserved IP |
+| --- | --- | --- |
+| `node-1` | `98:fa:9b:17:f0:50` | `192.168.20.11` |
+| `node-2` | `98:fa:9b:17:f1:1b` | `192.168.20.12` |
+
+Post-reservation state observed from OpenWrt:
+
+- `node-2` requested `192.168.20.12` as MAC `98:fa:9b:17:f1:1b`.
+- OpenWrt ARP showed `192.168.20.12` reachable on `br-lan`.
+- TCP port `22` on `192.168.20.12` was open.
+- SSH banner: `SSH-2.0-OpenSSH_8.9p1 Ubuntu-3ubuntu0.10`.
+
+This means `node-2` is no longer behaving like the original Windows boot. It
+has at least reached an Ubuntu environment with OpenSSH running.
+
+## 2026-06-29 Autoinstall Status
+
+After selecting the automatic Ubuntu installer on `node-2`, the display flashed
+and went blank. Network checks showed:
+
+- DHCP moved to the pinned address `192.168.20.12`.
+- SSH stayed open across repeated checks.
+- OpenWrt logs showed DHCP activity around the install/reboot window.
+- A later monitor flash matched fresh DHCP activity at about 19:29 local time.
+  SSH returned immediately afterward with banner
+  `SSH-2.0-OpenSSH_8.9p1 Ubuntu-3ubuntu0.15`, suggesting first-boot package
+  updates and a reboot rather than a crash.
+- A one-minute watch after that reboot showed stable ping and SSH on every
+  sample.
+- Public key auth initially failed because the local SSH `known_hosts` entry was
+  stale from the earlier install state.
+- After replacing the stale host key entry, SSH key auth worked for both
+  `ubuntu` and `root`.
+- Password auth failed for `ubuntu` and `root` using `123`, `ubuntu`,
+  `password`, `soyspray`, `k8s-node`, and `k8s`.
+- The initial autoinstall hostname `node-192-168-20-12` was corrected
+  imperatively to `node-2`.
+- `/etc/hosts` was corrected from a literal `$NEW_HOSTNAME` entry to
+  `127.0.1.1 node-2`.
+- A cloud-init override was added on the node:
+  `/etc/cloud/cloud.cfg.d/99-soyspray-preserve-hostname.cfg` with
+  `preserve_hostname: true`.
+
+The practical state is: the machine is online at the correct stable IP and
+administrable over SSH key auth.
+
+Confirmed from `node-2`:
+
+- Hostname: `node-2`
+- Operating system: Ubuntu 22.04.5 LTS
+- Kernel: `5.15.0-185-generic`
+- `cloud-init status --long`: `status: done`
+- `systemctl is-system-running`: `running`
+- Root filesystem: `/dev/nvme0n1p2`, 233 GiB, 4% used
+- Network interface: `eno1` at `192.168.20.12/24`
+
+Next recovery options:
+
+1. Repeat the Ubuntu install for `node-1` and verify SSH key access on
+   `192.168.20.11`.
+2. Add both nodes to the Kubespray inventory only after `node-1` is also
+   reachable on its pinned IP.
+
+## 2026-06-29 Node-1 Install Start
+
+After selecting the automatic Ubuntu installer on `node-1`, the display also
+went blank during the early install stage.
+
+OpenWrt confirmed the node started using its pinned lease:
+
+- At about 19:46 local time, OpenWrt sent a DHCPNAK for the old Windows lease
+  `192.168.20.240` because a static lease was available.
+- OpenWrt then offered and acknowledged `192.168.20.11` for MAC
+  `98:fa:9b:17:f0:50` with hostname `node-1`.
+- ARP showed `192.168.20.11` reachable on `br-lan`.
+- ICMP ping and TCP port `22` were not available yet during the first minute of
+  monitoring, which is expected while the installer is still in early stages.
+
+A second autoinstall attempt was started at about 20:13 local time after the
+first attempt did not reach SSH. OpenWrt saw a fresh DHCP request and ACK for
+`192.168.20.11` at about 20:13 local time. During monitoring, `192.168.20.11`
+remained on the static lease but did not expose SSH. By about 20:35 local time,
+OpenWrt still had the static lease, but ARP for `192.168.20.11` was
+`INCOMPLETE`, ICMP ping failed, and SSH returned `No route to host`.
+
+After rebooting `node-1` without the USB drive, OpenWrt saw fresh DHCP activity
+for `192.168.20.11` at about 20:37-20:38 local time. ARP became reachable again,
+but ICMP ping still failed and TCP ports `22`, `80`, `443`, and `7680` were
+closed. That indicates the machine is on the LAN at layer 2 and receiving the
+pinned lease, but it has not booted into the expected installed Ubuntu system
+with SSH available.
+
+A follow-up port probe showed TCP `7680` open on `192.168.20.11` while SSH
+remained closed. This matches the Windows behavior observed before the Ubuntu
+install attempts and indicates `node-1` likely booted back into Windows from the
+internal disk.
+
+An attempted Windows interaction check found no usable remote-management
+surface: RDP `3389`, SMB `445`, WinRM `5985`/`5986`, and SSH `22` were closed.
+A full TCP connect scan found only TCP `7680` open.
+
+A later autoinstall run succeeded. OpenWrt saw fresh DHCP for
+`192.168.20.11` at about 20:52 local time. The node rebooted and requested DHCP
+again at about 21:01 local time, then came back with Ubuntu SSH:
+
+- SSH banner: `SSH-2.0-OpenSSH_8.9p1 Ubuntu-3ubuntu0.15`.
+- Key auth worked for both `ubuntu` and `root` after replacing the stale local
+  `known_hosts` entry for `192.168.20.11`.
+- `cloud-init status --long`: `status: done`.
+- `systemctl is-system-running`: `running`.
+- The initial autoinstall hostname `node-192-168-20-11` was corrected
+  imperatively to `node-1`.
+- `/etc/hosts` was corrected from a literal `$NEW_HOSTNAME` entry to
+  `127.0.1.1 node-1`.
+- A cloud-init override was added on the node:
+  `/etc/cloud/cloud.cfg.d/99-soyspray-preserve-hostname.cfg` with
+  `preserve_hostname: true`.

--- a/soydocs/one-offs/2026-06-29-worker-tailnet-prep.md
+++ b/soydocs/one-offs/2026-06-29-worker-tailnet-prep.md
@@ -1,0 +1,144 @@
+# 2026-06-29 Worker Tailnet Prep
+
+## Context
+
+The cluster now has three Kubernetes nodes on the OpenWrt-managed LAN:
+
+| Node | LAN IP | Tailnet state |
+| --- | --- | --- |
+| `node-0` | `192.168.20.10` | Direct Tailscale machine, Funnel enabled |
+| `node-1` | `192.168.20.11` | Direct Tailscale machine and reachable through OpenWrt subnet route |
+| `node-2` | `192.168.20.12` | Direct Tailscale machine and reachable through OpenWrt subnet route |
+
+OpenWrt should remain the only subnet router for `192.168.20.0/24`. Do not
+advertise LAN routes from `node-1` or `node-2`; direct Tailscale on the worker
+nodes is for machine identity and direct host access only.
+
+## Timeline
+
+- `2026-06-29 23:05 NZST`: Tailscale DNS had only
+  `soyspray.vip -> 100.96.77.28` as split DNS. Added split DNS
+  `lan -> 100.96.77.28` in the Tailscale admin console so remote tailnet
+  clients can resolve OpenWrt DHCP names such as `node-1.lan` and `node-2.lan`.
+- `2026-06-29 23:05 NZST`: OpenWrt was advertising
+  `192.168.20.0/24` and a redundant pending `192.168.20.20/32` route. Ran
+  `tailscale set --advertise-routes=192.168.20.0/24` on OpenWrt so only the
+  approved LAN route remains.
+- `2026-06-29 23:05 NZST`: Deleted two stale OpenWrt WAN redirects named
+  `qbittorrent-in` and `qbittorrent-k8s` that still pointed to old
+  `192.168.1.x` hosts, then reloaded the firewall. Existing current redirects
+  to `192.168.20.20` were left intact.
+- `2026-06-29 23:05 NZST`: Disabled Tailscale key expiry on `node-0` ahead of
+  worker enrollment.
+- `2026-06-29 23:05 NZST`: Refactored
+  `playbooks/operations/networking/install-tailscale.yml` for direct worker
+  enrollment. It defaults to `node-1:node-2`, keeps `accept-dns=false`,
+  `accept-routes=false`, `ssh=false`, and `advertise-routes=[]`.
+- `2026-06-29 23:10 NZST`: Generated a temporary reusable auth key in the
+  Tailscale admin console, used it once through the worker enrollment playbook,
+  and revoked it immediately afterward.
+- `2026-06-29 23:12 NZST`: Enrolled the workers as direct machines:
+  `node-1.shark-garibaldi.ts.net` at `100.123.125.4` and
+  `node-2.shark-garibaldi.ts.net` at `100.103.213.105`.
+- `2026-06-29 23:13 NZST`: Disabled key expiry on `node-1` and `node-2`.
+- `2026-06-29 23:15 NZST`: Verified SSH by LAN IP through the subnet router,
+  SSH by `node-1.lan` and `node-2.lan`, SSH by Tailscale DNS name, and direct
+  `tailscale ping` to both workers.
+- `2026-06-29 23:15 NZST`: `kubectl get nodes -o wide` showed `node-0`,
+  `node-1`, and `node-2` all `Ready` after the Tailscale install.
+- `2026-06-29 23:25 NZST`: Added repeatable playbooks for OpenWrt gateway
+  reconciliation, worker tailnet enrollment, and worker tailnet verification.
+  Verified the OpenWrt and worker playbooks are idempotent with `changed=0`.
+
+## Imperative Changes Performed
+
+These changes were made live before or alongside the repo updates. This section
+exists so the live state is not mistaken for something that arrived only from
+Git.
+
+| Area | Live change | How it was done | Repeatable coverage |
+| --- | --- | --- | --- |
+| Tailscale DNS | Added split DNS `lan -> 100.96.77.28` | Tailscale admin console, DNS page | Verified by `verify-worker-tailnet.yml` through `node-1.lan` and `node-2.lan`; not currently configured by Ansible |
+| OpenWrt Tailscale | Removed redundant advertised route `192.168.20.20/32`; kept only `192.168.20.0/24` | `ssh root@192.168.20.1 'tailscale set --advertise-routes=192.168.20.0/24'` | Enforced by `configure-openwrt-tailnet-gateway.yml` |
+| OpenWrt firewall | Removed stale WAN redirects `qbittorrent-in` and `qbittorrent-k8s` pointing to old `192.168.1.x` hosts | OpenWrt UCI delete/commit plus firewall reload | Enforced by `configure-openwrt-tailnet-gateway.yml` |
+| Tailscale machines | Disabled key expiry for `node-0`, `node-1`, and `node-2` | Tailscale admin console, Machines page | Verified by `verify-worker-tailnet.yml`; disabling expiry for a brand-new replacement remains a manual admin-console step |
+| Tailscale auth key | Generated a temporary reusable auth key for worker enrollment and revoked it after use | Tailscale admin console, Keys page | No secret is stored in Git; future replacement uses a fresh temporary `TS_AUTH_KEY` |
+| Worker nodes | Installed Tailscale and enrolled `node-1` and `node-2` as direct machines | `playbooks/operations/networking/install-tailscale.yml` with temporary `TS_AUTH_KEY` | Re-runnable via `install-tailscale.yml`; already-enrolled nodes do not require `TS_AUTH_KEY` |
+
+No Tailscale auth key, API token, or OAuth client secret was written to this
+repo. The only documented key values are redacted placeholders.
+
+## Direct Worker Enrollment
+
+For a fresh replacement node, generate a temporary Tailscale auth key in the
+admin console, run the worker enrollment playbook, then revoke the key. Do not
+store the key in the repo.
+
+```sh
+source soyspray-venv/bin/activate
+TS_AUTH_KEY='tskey-auth-REDACTED' ansible-playbook \
+  -i kubespray/inventory/soycluster/hosts.yml \
+  --become --become-user=root --user ubuntu \
+  playbooks/operations/networking/install-tailscale.yml \
+  -e tailscale_target_hosts=node-1
+```
+
+Run the e2e verifier after enrollment:
+
+```sh
+source soyspray-venv/bin/activate
+ansible-playbook -i kubespray/inventory/soycluster/hosts.yml \
+  --become --become-user=root --user ubuntu \
+  playbooks/operations/networking/verify-worker-tailnet.yml \
+  -e tailscale_target_hosts=node-1
+```
+
+OpenWrt gateway guardrails can be reconciled separately if networking looks
+off:
+
+```sh
+source soyspray-venv/bin/activate
+ansible-playbook -i kubespray/inventory/soycluster/hosts.yml \
+  playbooks/operations/networking/configure-openwrt-tailnet-gateway.yml
+```
+
+After enrollment, disable key expiry on the new machine in the Tailscale admin
+console. The temporary manual key used during the 2026-06-29 prep run was
+revoked.
+
+## Observed State After Enrollment
+
+| Node | Tailscale DNS | Tailscale IPv4 | Worker prefs |
+| --- | --- | --- | --- |
+| `node-1` | `node-1.shark-garibaldi.ts.net` | `100.123.125.4` | `accept-dns=false`, `accept-routes=false`, `ssh=false`, no advertised routes |
+| `node-2` | `node-2.shark-garibaldi.ts.net` | `100.103.213.105` | `accept-dns=false`, `accept-routes=false`, `ssh=false`, no advertised routes |
+
+## Verification
+
+Baseline subnet-router checks:
+
+```sh
+ip route get 192.168.20.11
+ip route get 192.168.20.12
+ssh ubuntu@192.168.20.11 hostname
+ssh ubuntu@192.168.20.12 hostname
+getent ahostsv4 node-1.lan
+getent ahostsv4 node-2.lan
+```
+
+After direct worker enrollment:
+
+```sh
+tailscale status --json | jq -r '.Peer[] | [.HostName, .DNSName, (.TailscaleIPs | join(",")), .Online] | @tsv'
+ssh ubuntu@node-1.shark-garibaldi.ts.net hostname
+ssh ubuntu@node-2.shark-garibaldi.ts.net hostname
+```
+
+Expected state:
+
+- Tailscale admin Machines includes `node-0`, `node-1`, and `node-2`.
+- OpenWrt advertises only `192.168.20.0/24`.
+- `node-1` and `node-2` do not advertise routes.
+- `node-1.lan` and `node-2.lan` resolve through split DNS.
+- SSH works by LAN IP through the subnet router and by Tailscale DNS name after
+  direct enrollment.

--- a/soydocs/one-offs/2026-06-30-worker-ssd-prep.md
+++ b/soydocs/one-offs/2026-06-30-worker-ssd-prep.md
@@ -8,7 +8,7 @@ Prepare them as Longhorn data disks after they are physically installed.
 Two RAM kits are also ordered for `node-1` and `node-2` so the worker nodes can
 be brought closer to the `node-0` memory profile.
 
-## Parked Handoff For Next Session
+## Parked Handoff Before Install
 
 Work is parked before the physical SSD installation boundary. In the next
 session, assume Boris may have installed the new SSDs in `node-1` and `node-2`,
@@ -38,6 +38,41 @@ Current live state checked on 2026-06-29:
 Longhorn has already created `/storage` disk entries for the new workers while
 `/storage` is still on the root filesystem. Do not schedule real data there
 until the new SSDs are mounted and Longhorn disk state has been reconciled.
+
+## Provisioning Result On 2026-07-01
+
+The worker SSDs were installed, prepared with
+`playbooks/operations/storage/prepare-longhorn-worker-ssd.yml`, and mounted at
+`/storage`.
+
+| Node | SSD by-id path | Filesystem UUID | Longhorn disk UUID |
+| --- | --- | --- | --- |
+| `node-1` | `/dev/disk/by-id/ata-PNY_500GB_SATA_SSD_PNL03260552550304519` | `47a1ece0-aca9-4f1d-8ac1-b3a1ee9c699a` | `96833268-f6cb-4dd8-b52c-27e0777b1a02` |
+| `node-2` | `/dev/disk/by-id/ata-PNY_500GB_SATA_SSD_PNL03260552550303454` | `49c092f4-dd55-41f5-99c6-854f8b44af4e` | `062dcb89-f3cf-4eb3-af9d-683c0372e83a` |
+
+Final host state:
+
+- `node-1`: `/dev/sda1` mounted at `/storage`, ext4, 458G size, 435G
+  available.
+- `node-2`: `/dev/sda1` mounted at `/storage`, ext4, 458G size, 435G
+  available.
+- Both mounts are persisted in `/etc/fstab` by filesystem UUID with
+  `defaults,noatime,nofail,x-systemd.device-timeout=10s`.
+- A write/sync/delete test succeeded on `/storage` on both workers.
+
+Longhorn reconciliation:
+
+- The old root-backed worker disk entries reported `DiskFilesystemChanged`
+  after the SSDs were mounted.
+- There were zero Longhorn replicas on `node-1` or `node-2`, so the stale empty
+  disk entries were disabled, removed, and re-added against the new SSD-backed
+  `/storage` filesystems.
+- `node-1` and `node-2` now report Longhorn disk `Ready=True` and
+  `Schedulable=True`.
+- `storageReserved` is `147331952640` bytes on each worker, matching the
+  reservation size used for the 500GB PNY disk on `node-0`.
+- Existing Longhorn volumes remained single-replica on `node-0`; no workload
+  volume replicas were moved during this step.
 
 ## Discover New SSD IDs
 
@@ -73,8 +108,8 @@ ansible-playbook -i kubespray/inventory/soycluster/hosts.yml \
   -e longhorn_storage_force_format=true \
   -e '{
     "longhorn_storage_device_by_host": {
-      "node-1": "/dev/disk/by-id/ata-PNY_500GB_SATA_SSD_REPLACE_NODE1_SERIAL",
-      "node-2": "/dev/disk/by-id/ata-PNY_500GB_SATA_SSD_REPLACE_NODE2_SERIAL"
+      "node-1": "/dev/disk/by-id/ata-PNY_500GB_SATA_SSD_PNL03260552550304519",
+      "node-2": "/dev/disk/by-id/ata-PNY_500GB_SATA_SSD_PNL03260552550303454"
     }
   }'
 ```
@@ -177,14 +212,14 @@ If the RAM upgrade changes scheduling assumptions, capture the new live output
 in this note and then decide whether any workload placement, requests, or
 Kong/lab sizing docs need to be adjusted.
 
-## Follow-Up Repo Changes After Install
+## Remaining Follow-Up
 
-Once the two new serials are known:
+The SSD install and Longhorn disk reconciliation are complete. Remaining work:
 
 - Add the new worker SSD by-id paths to
   `playbooks/argocd/applications/observability/prometheus/smartctl-exporter-daemonset.yaml`
   if the exporter can tolerate per-node missing devices, or split the exporter
   into node-specific device args.
-- Record the final by-id paths and UUIDs in this runbook.
-- Decide whether to keep Longhorn at one replica or move selected PVCs to two
-  or three replicas after the workers have real SSD-backed `/storage`.
+- Decide when to rebuild existing one-replica Longhorn volumes onto two or
+  three replicas. The default StorageClass now creates new volumes with three
+  replicas, but existing volumes remain unchanged until handled deliberately.

--- a/soydocs/one-offs/2026-06-30-worker-ssd-prep.md
+++ b/soydocs/one-offs/2026-06-30-worker-ssd-prep.md
@@ -1,0 +1,146 @@
+# 2026-06-30 Worker SSD Prep
+
+## Context
+
+Two PNY CS900 500GB SATA SSDs are expected for `node-1` and `node-2`.
+Prepare them as Longhorn data disks after they are physically installed.
+
+## Parked Handoff For Next Session
+
+Work is parked before the physical SSD installation boundary. In the next
+session, assume Boris may have installed the new SSDs in `node-1` and `node-2`,
+but verify the live device state before formatting anything.
+
+Start here:
+
+1. Run the discovery commands below and capture the stable `ata-PNY_...` by-id
+   path for each worker.
+2. Run `prepare-longhorn-worker-ssd.yml` with the discovered by-id paths to
+   format, mount, and persist `/storage` on both workers.
+3. Verify Longhorn node disk state before scheduling replicas to the workers.
+4. Stretch the cluster deliberately: enable real worker-backed Longhorn storage,
+   then decide which PVCs can move from one replica to two or three replicas.
+5. Update monitoring once SSD serials are known: fix `smartctl-exporter` device
+   args or split it into node-specific exporters, then verify SMART metrics for
+   all three nodes.
+
+Current live state checked on 2026-06-29:
+
+| Node | Current storage state |
+| --- | --- |
+| `node-0` | Existing PNY 500GB SATA SSD at `/dev/sda1`, mounted at `/storage` |
+| `node-1` | Only NVMe root disk present; `/storage` exists but is not a mountpoint |
+| `node-2` | Only NVMe root disk present; `/storage` exists but is not a mountpoint |
+
+Longhorn has already created `/storage` disk entries for the new workers while
+`/storage` is still on the root filesystem. Do not schedule real data there
+until the new SSDs are mounted and Longhorn disk state has been reconciled.
+
+## Discover New SSD IDs
+
+After installing the drives, collect stable device paths:
+
+```sh
+for host in 192.168.20.11 192.168.20.12; do
+  ssh ubuntu@"$host" '
+    hostname
+    lsblk -e7 -o NAME,PATH,MODEL,SERIAL,SIZE,TYPE,FSTYPE,MOUNTPOINTS,TRAN,ROTA
+    echo "--- by-id PNY links ---"
+    find /dev/disk/by-id -maxdepth 1 -type l -printf "%f -> %l\n" | sort | grep -E "PNY|500GB|wwn" || true
+    echo "--- /storage ---"
+    mountpoint /storage || true
+    df -hT / /storage 2>/dev/null || true
+  '
+done
+```
+
+Use the `ata-PNY_...` by-id link for each new whole disk. Do not use `/dev/sdX`
+because those names can move.
+
+## Prepare The Disks
+
+Fill in the two by-id paths from the discovery output and run from the repo
+root:
+
+```sh
+source soyspray-venv/bin/activate
+ansible-playbook -i kubespray/inventory/soycluster/hosts.yml \
+  --become --become-user=root --user ubuntu \
+  playbooks/operations/storage/prepare-longhorn-worker-ssd.yml \
+  -e longhorn_storage_force_format=true \
+  -e '{
+    "longhorn_storage_device_by_host": {
+      "node-1": "/dev/disk/by-id/ata-PNY_500GB_SATA_SSD_REPLACE_NODE1_SERIAL",
+      "node-2": "/dev/disk/by-id/ata-PNY_500GB_SATA_SSD_REPLACE_NODE2_SERIAL"
+    }
+  }'
+```
+
+The playbook refuses to run unless:
+
+- A by-id path is provided per target host.
+- The target resolves to a whole disk.
+- The disk model contains `PNY` and `500GB`.
+- The disk transport is `sata`.
+- `/storage` is not already a mountpoint.
+- The disk has no mounted children.
+- `longhorn_storage_force_format=true` is explicitly passed.
+
+## Post-Mount Checks
+
+After the playbook completes:
+
+```sh
+for host in 192.168.20.11 192.168.20.12; do
+  ssh ubuntu@"$host" '
+    hostname
+    mountpoint /storage
+    df -hT /storage
+    lsblk -e7 -o NAME,PATH,MODEL,SERIAL,SIZE,TYPE,FSTYPE,MOUNTPOINTS,TRAN,ROTA
+  '
+done
+```
+
+Then verify Longhorn before letting workloads rely on the new disks:
+
+```sh
+kubectl -n longhorn-system get nodes.longhorn.io node-1 node-2 -o yaml
+kubectl -n longhorn-system get replicas.longhorn.io -o wide
+kubectl -n longhorn-system get volumes.longhorn.io -o wide
+```
+
+If Longhorn reports the original root-backed `/storage` disk as not ready after
+the mount, reconcile the Longhorn node disk entries before scheduling replicas
+to the workers. Current `node-0` history shows the pattern: a stale default disk
+can remain while a replacement `/storage` disk is active.
+
+## Monitoring Prep
+
+Grafana's Kubernetes and Longhorn dashboards do not need fixed-node changes for
+the worker additions. They use Kubernetes/Longhorn metrics and should discover
+the new nodes from Prometheus labels.
+
+Live check on 2026-06-29 showed:
+
+- `kube_node_info` count is `3`.
+- `node-exporter` has three healthy targets:
+  `192.168.20.10:9100`, `192.168.20.11:9100`, `192.168.20.12:9100`.
+- `smartctl-exporter` is running on all three nodes, but SMART status metrics
+  are currently emitted only by the original node-0 pod because the exporter
+  args still point at node-0 by-id devices.
+
+The `node-hardware` dashboard source was adjusted so disk throughput/utilization
+series include `instance` as well as `device`. Without that, same-name devices
+such as `nvme0n1` on different nodes get aggregated into one line.
+
+## Follow-Up Repo Changes After Install
+
+Once the two new serials are known:
+
+- Add the new worker SSD by-id paths to
+  `playbooks/argocd/applications/observability/prometheus/smartctl-exporter-daemonset.yaml`
+  if the exporter can tolerate per-node missing devices, or split the exporter
+  into node-specific device args.
+- Record the final by-id paths and UUIDs in this runbook.
+- Decide whether to keep Longhorn at one replica or move selected PVCs to two
+  or three replicas after the workers have real SSD-backed `/storage`.

--- a/soydocs/one-offs/2026-06-30-worker-ssd-prep.md
+++ b/soydocs/one-offs/2026-06-30-worker-ssd-prep.md
@@ -71,8 +71,21 @@ Longhorn reconciliation:
   `Schedulable=True`.
 - `storageReserved` is `147331952640` bytes on each worker, matching the
   reservation size used for the 500GB PNY disk on `node-0`.
-- Existing Longhorn volumes remained single-replica on `node-0`; no workload
-  volume replicas were moved during this step.
+
+Replica expansion:
+
+- Longhorn defaults were moved to three replicas for new default-class volumes.
+- All 20 active Longhorn workload volumes were patched to
+  `numberOfReplicas=3`.
+- Longhorn rebuilt the new replicas across `node-0`, `node-1`, and `node-2`.
+- Final check at `2026-07-01T15:15:21+12:00`: `20` active 3-replica volumes
+  were `healthy`, engine modes were `RW:60`, and failed replicas remained `0`.
+- One old preserved volume, `pvc-87a2e7b1-6011-4580-8dce-e9433a6f0900`,
+  remains `unknown` with `numberOfReplicas=1`; it was not part of the active
+  workload expansion.
+- Final Longhorn disk schedule was balanced at roughly `303Gi` scheduled on
+  each SSD-backed `/storage` disk, with all three disks reporting
+  `Ready=True` and `Schedulable=True`.
 
 ## Discover New SSD IDs
 
@@ -220,6 +233,5 @@ The SSD install and Longhorn disk reconciliation are complete. Remaining work:
   `playbooks/argocd/applications/observability/prometheus/smartctl-exporter-daemonset.yaml`
   if the exporter can tolerate per-node missing devices, or split the exporter
   into node-specific device args.
-- Decide when to rebuild existing one-replica Longhorn volumes onto two or
-  three replicas. The default StorageClass now creates new volumes with three
-  replicas, but existing volumes remain unchanged until handled deliberately.
+- Reconcile GitOps drift by merging the branch containing the Longhorn
+  three-replica defaults and then syncing the Longhorn Argo app back to `HEAD`.

--- a/soydocs/one-offs/2026-06-30-worker-ssd-prep.md
+++ b/soydocs/one-offs/2026-06-30-worker-ssd-prep.md
@@ -1,9 +1,12 @@
-# 2026-06-30 Worker SSD Prep
+# 2026-06-30 Worker SSD And RAM Prep
 
 ## Context
 
 Two PNY CS900 500GB SATA SSDs are expected for `node-1` and `node-2`.
 Prepare them as Longhorn data disks after they are physically installed.
+
+Two RAM kits are also ordered for `node-1` and `node-2` so the worker nodes can
+be brought closer to the `node-0` memory profile.
 
 ## Parked Handoff For Next Session
 
@@ -132,6 +135,47 @@ Live check on 2026-06-29 showed:
 The `node-hardware` dashboard source was adjusted so disk throughput/utilization
 series include `instance` as well as `device`. Without that, same-name devices
 such as `nvme0n1` on different nodes get aggregated into one line.
+
+## RAM Order And Install Prep
+
+Boris placed the worker RAM order on 2026-06-30:
+
+| Field | Value |
+| --- | --- |
+| AliExpress order | `8212777184122085` |
+| Status when recorded | Processing |
+| Store | StoreSkill Franchise Store |
+| Item | `2PCS PUSKILL Killblade DDR4 Notebook Ram 32GB 16GB 8GB 1.2V 3200MHz 2666MHz 2400MHz 260-PiN Sodimm Memory` |
+| Variant | `China Mainland`, `DDR4 16GB 2666x2pcs` |
+| Quantity | `2` kits |
+| Intended install | one `2x16GB` DDR4 SODIMM kit per worker node |
+| Subtotal | `NZ$446.62` |
+| Total paid | `NZ$513.61` |
+| Estimated delivery | 2026-07-16 |
+
+Do not assume the RAM has been installed just because the order exists. After
+physical install, verify both workers live:
+
+```sh
+for host in 192.168.20.11 192.168.20.12; do
+  ssh ubuntu@"$host" '
+    hostname
+    free -h
+    sudo dmidecode -t memory | grep -E "Locator:|Size:|Speed:|Part Number:" | sed "s/^/  /"
+  '
+done
+```
+
+Expected target state after install:
+
+- `node-1`: roughly 32 GiB RAM from two 16 GB DDR4 SODIMMs.
+- `node-2`: roughly 32 GiB RAM from two 16 GB DDR4 SODIMMs.
+- `node-0`: remains the larger baseline node with its existing 32 GB plus 4 GB
+  layout unless it is changed separately.
+
+If the RAM upgrade changes scheduling assumptions, capture the new live output
+in this note and then decide whether any workload placement, requests, or
+Kong/lab sizing docs need to be adjusted.
 
 ## Follow-Up Repo Changes After Install
 


### PR DESCRIPTION
## Summary
- document two-node intake, worker tailnet preparation, SSD provisioning, RAM order state, and final Longhorn replica expansion
- add worker SSD preparation and tailnet/OpenWrt verification playbooks
- move Longhorn defaults to three replicas now that all three nodes have SSD-backed /storage
- record that all 20 active Longhorn workload volumes rebuilt successfully to 3 replicas

## Validation
- git diff --check origin/main...HEAD
- kubectl kustomize --enable-helm playbooks/argocd/applications/infrastructure/longhorn >/tmp/soyspray-longhorn-render.yaml
- verified rendered Longhorn settings include default-replica-count: "3" and StorageClass numberOfReplicas: "3"
- ansible-playbook --syntax-check playbooks/operations/storage/prepare-longhorn-worker-ssd.yml
- ansible-playbook --syntax-check playbooks/operations/networking/verify-worker-tailnet.yml
- ansible-playbook --syntax-check playbooks/operations/networking/configure-openwrt-tailnet-gateway.yml
- live Longhorn check at 2026-07-01T15:15:21+12:00: 20 active 3-replica volumes healthy, engine modes RW:60, failed replicas 0
- live Kubernetes check: no non-Ready nodes and no pods outside Running/Completed

## Notes
- One old preserved Longhorn volume remains unknown with numberOfReplicas=1 and was not part of the active workload expansion.
- Longhorn application targetRevision remains HEAD; after merge, sync Longhorn back to HEAD to clear current GitOps drift from the live emergency/default changes.