### PR TITLE
[codex] Stretch workload placement after SSD install

### DIFF
--- a/playbooks/argocd/applications/home-automation/mosquitto/deployment.yaml
+++ b/playbooks/argocd/applications/home-automation/mosquitto/deployment.yaml
@@ -19,7 +19,19 @@ spec:
       labels:
         app: mosquitto
         component: main
+        soyspray.vip/placement: longhorn-worker-preferred
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 80
+              preference:
+                matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - node-1
+                      - node-2
       containers:
         - name: mosquitto
           image: eclipse-mosquitto:2.0.18
@@ -52,4 +64,3 @@ spec:
             claimName: mosquitto-data
         - name: log
           emptyDir: {}
-

--- a/playbooks/argocd/applications/home-automation/zigbee2mqtt/deployment.yaml
+++ b/playbooks/argocd/applications/home-automation/zigbee2mqtt/deployment.yaml
@@ -20,6 +20,8 @@ spec:
         app: zigbee2mqtt
         component: main
     spec:
+      nodeSelector:
+        kubernetes.io/hostname: node-0
       initContainers:
         - name: copy-config
           image: busybox:stable
@@ -70,4 +72,3 @@ spec:
         - name: zigbee2mqtt-config
           configMap:
             name: zigbee2mqtt-config
-

--- a/playbooks/argocd/applications/infrastructure/longhorn/storageclass-rwx.yaml
+++ b/playbooks/argocd/applications/infrastructure/longhorn/storageclass-rwx.yaml
@@ -6,6 +6,7 @@ metadata:
 provisioner: driver.longhorn.io
 parameters:
   share: "true"
+  numberOfReplicas: "3"
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 allowVolumeExpansion: true

--- a/playbooks/argocd/applications/media/prowlarr/deployment.yaml
+++ b/playbooks/argocd/applications/media/prowlarr/deployment.yaml
@@ -19,7 +19,26 @@ spec:
       labels:
         app: prowlarr
         component: main
+        soyspray.vip/placement: longhorn-worker-preferred
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 80
+              preference:
+                matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - node-1
+                      - node-2
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              soyspray.vip/placement: longhorn-worker-preferred
       initContainers:
         - name: seed-config
           image: busybox:1.36

--- a/playbooks/argocd/applications/media/threadfin/deployment.yaml
+++ b/playbooks/argocd/applications/media/threadfin/deployment.yaml
@@ -19,7 +19,26 @@ spec:
       labels:
         app: threadfin
         component: main
+        soyspray.vip/placement: longhorn-worker-preferred
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 80
+              preference:
+                matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - node-1
+                      - node-2
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              soyspray.vip/placement: longhorn-worker-preferred
       # Init container to bootstrap configuration from ConfigMaps
       initContainers:
         - name: bootstrap-config

--- a/soydocs/one-offs/2026-07-01-workload-placement-stretch.md
+++ b/soydocs/one-offs/2026-07-01-workload-placement-stretch.md
@@ -1,0 +1,87 @@
+# Workload Placement Stretch
+
+Date: 2026-07-01
+
+This note follows the worker SSD install. Longhorn data replicas are already
+spread across the three SSD-backed nodes. The next useful stretch is workload
+placement: make safe Longhorn-backed singletons prefer the worker nodes, while
+leaving node-local workloads obvious.
+
+## Current Shape
+
+```text
+Longhorn data:
+
+  node-0 SSD  +  node-1 SSD  +  node-2 SSD
+       \            |             /
+        \------ 3 replicas -------/
+
+Not 3-node portable:
+
+  media/media-downloads
+    local PV: /srv/media/downloads
+    node: node-0
+    size: 1800Gi
+
+  zigbee2mqtt
+    uses host /dev for the USB coordinator
+    node: node-0 until the device is moved and tested
+```
+
+## Changes In This Branch
+
+- Add Kubespray-managed labels for the three SSD-backed Longhorn nodes.
+- Mark `node-0` as the only node with the local media download disk.
+- Set `longhorn-rwx` to create future RWX volumes with three replicas.
+- Make small Longhorn-only services prefer `node-1` and `node-2`:
+  - `media/prowlarr`
+  - `media/threadfin`
+  - `home-automation/mosquitto`
+- Pin `zigbee2mqtt` to `node-0` because it uses host `/dev`.
+
+These placement rules are intentionally soft for Longhorn-backed apps. If the
+worker nodes are not available, the scheduler can still place them on `node-0`.
+
+## Apply Order
+
+Kubespray inventory labels do not apply through Argo CD. Apply them before
+deploying the Argo app changes:
+
+```bash
+source soyspray-venv/bin/activate
+ansible-playbook -i kubespray/inventory/soycluster/hosts.yml \
+  --become --become-user=root --user ubuntu \
+  kubespray/cluster.yml --tags node-label
+```
+
+Then deploy the Argo-managed apps:
+
+```bash
+source soyspray-venv/bin/activate
+ansible-playbook -i kubespray/inventory/soycluster/hosts.yml \
+  --become --become-user=root --user ubuntu \
+  playbooks/deploy-argocd-apps.yml --tags longhorn,prowlarr,threadfin,mosquitto,zigbee2mqtt
+```
+
+## Expected Result
+
+```text
+node-0:
+  control plane
+  local media download disk
+  zigbee USB workload
+  can still run fallback Longhorn-backed apps
+
+node-1 / node-2:
+  preferred home for selected Longhorn-backed singleton apps
+  Longhorn replicas already present
+```
+
+## Verification
+
+```bash
+kubectl get nodes --show-labels
+kubectl get pods -n media -o wide | grep -E 'prowlarr|threadfin'
+kubectl get pods -n home-automation -o wide | grep -E 'mosquitto|zigbee2mqtt'
+kubectl get sc longhorn-rwx -o jsonpath='{.parameters.numberOfReplicas}{"\n"}'
+```


### PR DESCRIPTION
## Summary

This follows the SSD/Longhorn work and handles the next smaller stretch layer: workload placement and remaining node-local exceptions.

- Points the `kubespray` submodule at `8a5eb1d1a` on `codex/stretch-worker-node-labels`, which adds inventory-managed labels for the SSD-backed Longhorn nodes and marks `node-0` as the local-media node.
- Sets `longhorn-rwx` to create future RWX volumes with `numberOfReplicas: "3"`.
- Makes small Longhorn-only singleton services prefer `node-1` and `node-2`: `prowlarr`, `threadfin`, and `mosquitto`.
- Pins `zigbee2mqtt` to `node-0` because it mounts host `/dev` for the USB coordinator.
- Adds an operator note with the current shape, apply order, and verification commands.

## Why

The Longhorn volume replicas are already stretched across the three SSDs. The remaining problem is that some workloads still naturally land on `node-0`, and some workloads should stay there because they depend on node-local media or USB devices.

This keeps those two facts separate: Longhorn-backed services get soft worker preference, while node-local exceptions stay explicit.

## Deployment Notes

No live deploy was run from this branch.

Apply Kubespray labels before the Argo app changes:

```bash
source soyspray-venv/bin/activate
ansible-playbook -i kubespray/inventory/soycluster/hosts.yml \
  --become --become-user=root --user ubuntu \
  kubespray/cluster.yml --tags node-label
```

Then deploy the app changes with:

```bash
source soyspray-venv/bin/activate
ansible-playbook -i kubespray/inventory/soycluster/hosts.yml \
  --become --become-user=root --user ubuntu \
  playbooks/deploy-argocd-apps.yml --tags longhorn,prowlarr,threadfin,mosquitto,zigbee2mqtt
```

## Validation

- `kubectl kustomize playbooks/argocd/applications/media/prowlarr`
- `kubectl kustomize playbooks/argocd/applications/media/threadfin`
- `kubectl kustomize playbooks/argocd/applications/home-automation/mosquitto`
- `kubectl kustomize playbooks/argocd/applications/home-automation/zigbee2mqtt`
- `kubectl kustomize --enable-helm playbooks/argocd/applications/infrastructure/longhorn`
- `source soyspray-venv/bin/activate && ansible-inventory -i kubespray/inventory/soycluster/hosts.yml --list`
- `git diff --check`

Kustomize emitted existing `commonLabels` deprecation warnings in some app kustomizations; the rendered manifests succeeded.