### PR TITLE
[codex] Fix Threadfin Argo comparison

### DIFF
--- a/playbooks/argocd/applications/media/threadfin/threadfin-application.yaml
+++ b/playbooks/argocd/applications/media/threadfin/threadfin-application.yaml
@@ -22,4 +22,3 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - ServerSideApply=true


### PR DESCRIPTION
## Summary

Removes `ServerSideApply=true` from the Threadfin Argo CD Application.

## Why

After deploying the workload-placement stretch, Argo refreshed Threadfin to the new main revision but stayed in `Unknown` with this comparison error:

```text
.status.terminatingReplicas: field not declared in schema
```

This is an Argo CD stale built-in schema issue on newer Kubernetes Deployment status fields. The Threadfin app was the only simple media app using `ServerSideApply=true`; Argo CD documents server-side apply without server-side diff as one of the paths that can trigger this class of error.

Threadfin does not need server-side apply for its current manifests, so removing the sync option should let Argo compare and auto-sync normally.

## Validation

- `kubectl kustomize playbooks/argocd/applications/media/threadfin`
- `git diff --check`

Kustomize still prints the existing `commonLabels` deprecation warning in the Threadfin kustomization, but rendering succeeds.

## Deployment Note

After merge, deploy with:

```bash
source soyspray-venv/bin/activate
ansible-playbook -i kubespray/inventory/soycluster/hosts.yml \
  --become --become-user=root --user ubuntu \
  playbooks/deploy-argocd-apps.yml --tags threadfin
```

Then verify:

```bash
kubectl -n argocd get app threadfin
kubectl -n media get deploy,pod -o wide | grep threadfin
```