### PR TITLE
[codex] Relax Threadfin startup probes

### DIFF
--- a/playbooks/argocd/applications/media/threadfin/deployment.yaml
+++ b/playbooks/argocd/applications/media/threadfin/deployment.yaml
@@ -70,16 +70,18 @@ spec:
           livenessProbe:
             tcpSocket:
               port: http
-            initialDelaySeconds: 20
+            initialDelaySeconds: 180
             periodSeconds: 10
-            failureThreshold: 3
+            timeoutSeconds: 5
+            failureThreshold: 6
           readinessProbe:
             httpGet:
               path: /
               port: http
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
             periodSeconds: 10
-            failureThreshold: 3
+            timeoutSeconds: 5
+            failureThreshold: 12
           env:
             - name: THREADFIN_BRANCH
               value: "main"


### PR DESCRIPTION
## Summary

Relaxes Threadfin startup probes so the pod can finish loading playlists and EPG data before liveness restarts it.

## Why

After Threadfin moved from `node-0` to `node-1`, the Longhorn volume attached successfully and the container started, but the app needed roughly a minute to download and parse playlist/EPG inputs before opening port `34400`.

The old liveness probe started after 20 seconds and killed the container before startup completed.

## Changes

- Increase liveness initial delay from `20s` to `180s`.
- Add a `5s` probe timeout.
- Increase liveness failure threshold from `3` to `6`.
- Increase readiness initial delay from `10s` to `30s`.
- Increase readiness failure threshold from `3` to `12`.

## Validation

- `kubectl kustomize playbooks/argocd/applications/media/threadfin`
- `git diff --check`

Kustomize still prints the existing `commonLabels` deprecation warning, but rendering succeeds.