### PR TITLE
[codex] Stop rendering nested home automation apps

### DIFF
--- a/playbooks/argocd/applications/home-automation/mosquitto/kustomization.yaml
+++ b/playbooks/argocd/applications/home-automation/mosquitto/kustomization.yaml
@@ -4,7 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - mosquitto-application.yaml
   - deployment.yaml
   - service.yaml
   - pvc-data.yaml
@@ -15,4 +14,3 @@ namespace: home-automation
 commonLabels:
   app: mosquitto
   managed-by: argocd
-

--- a/playbooks/argocd/applications/home-automation/zigbee2mqtt/kustomization.yaml
+++ b/playbooks/argocd/applications/home-automation/zigbee2mqtt/kustomization.yaml
@@ -4,7 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - zigbee2mqtt-application.yaml
   - deployment.yaml
   - service.yaml
   - ingress.yaml
@@ -16,4 +15,3 @@ namespace: home-automation
 commonLabels:
   app: zigbee2mqtt
   managed-by: argocd
-


### PR DESCRIPTION
## Summary

Removes the nested Argo `Application` resources from the Mosquitto and Zigbee2MQTT workload kustomizations.

The top-level `*-application.yaml` files stay in the repo and are still used by `playbooks/deploy-argocd-apps.yml`.

## Why

After the workload-placement deploy, both top-level apps were Synced but stuck in Argo `Progressing` because they were tracking stale child `Application` objects in the `home-automation` namespace:

```text
Application home-automation/mosquitto     Progressing Pending deletion
Application home-automation/zigbee2mqtt   Progressing Pending deletion
```

Those child Applications came from the app kustomizations rendering their own Argo Application manifests under `namespace: home-automation`. They are not needed inside the workload render and make app health noisy.

## Validation

- `kubectl kustomize playbooks/argocd/applications/home-automation/mosquitto`
- `kubectl kustomize playbooks/argocd/applications/home-automation/zigbee2mqtt`
- `git diff --check`

The rendered kinds are now only workload resources. Kustomize still prints the existing `commonLabels` deprecation warning, but rendering succeeds.