### PR TITLE
[codex] Make CNPG generated apps safe to prune

### DIFF
--- a/playbooks/argocd/applications/database/cnpg/README.md
+++ b/playbooks/argocd/applications/database/cnpg/README.md
@@ -16,6 +16,25 @@
 
 **Quick rules:** Edit only targetTime file; keep one prod cluster with backups; delete inactive PVCs before restore.
 **Note:** ApplicationSets disable automation - sync apps explicitly to avoid ownership conflicts.
+Generated apps intentionally omit Argo resource finalizers and set
+`preserveResourcesOnDeletion: true`, so deleting a generated Application does
+not prune CNPG clusters, secrets, backups, or the active alias Service.
+
+## Argo Cleanup Safety
+
+Before reducing the generated app matrix, first sync these ApplicationSets and
+confirm the generated Applications no longer carry
+`resources-finalizer.argocd.argoproj.io`:
+
+```bash
+kubectl -n argocd get app \
+  immich-db-a-initdb immich-db-a-prod immich-db-a-restore \
+  immich-db-b-initdb immich-db-b-prod immich-db-b-restore \
+  immich-db-active-a immich-db-active-b \
+  -o json | jq -r '.items[] | [.metadata.name, (.metadata.finalizers // [])] | @tsv'
+```
+
+Do not delete or stop generating inactive apps until that check is clean.
 
 ## Key Components
 - `base/`: Shared cluster-base for external CNPG references

--- a/playbooks/argocd/applications/database/cnpg/apps/applicationset-immich-alias.yaml
+++ b/playbooks/argocd/applications/database/cnpg/apps/applicationset-immich-alias.yaml
@@ -1,12 +1,13 @@
-# Generates two alias apps (A and B) without automation so you flip explicitly:
-#   argocd app delete immich-db-active-a && argocd app sync immich-db-active-b
-# Keeps zero-edit DR flips and avoids Argo ownership collisions on the Service.
+# Generates two alias apps (A and B) without automation so you flip explicitly.
+# These apps must not prune the shared alias Service when a generated app is removed.
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: immich-db-alias
   namespace: argocd
 spec:
+  syncPolicy:
+    preserveResourcesOnDeletion: true
   generators:
     - list:
         elements:
@@ -15,8 +16,6 @@ spec:
   template:
     metadata:
       name: immich-db-active-{{active}}
-      finalizers:
-        - resources-finalizer.argocd.argoproj.io
     spec:
       project: default
       destination:
@@ -29,4 +28,3 @@ spec:
       syncPolicy:
         syncOptions:
           - CreateNamespace=true
-          - ServerSideApply=true

--- a/playbooks/argocd/applications/database/cnpg/apps/applicationset-immich-db.yaml
+++ b/playbooks/argocd/applications/database/cnpg/apps/applicationset-immich-db.yaml
@@ -1,11 +1,13 @@
 # Generates six DB apps (a/b x initdb/prod/restore) without automation.
-# You explicitly sync exactly one role per letter at any time per your runbooks.
+# These apps must not prune database resources when a generated app is removed.
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: immich-db
   namespace: argocd
 spec:
+  syncPolicy:
+    preserveResourcesOnDeletion: true
   generators:
     - matrix:
         generators:
@@ -21,8 +23,6 @@ spec:
   template:
     metadata:
       name: immich-db-{{letter}}-{{role}}
-      finalizers:
-        - resources-finalizer.argocd.argoproj.io
     spec:
       project: default
       destination:
@@ -37,4 +37,3 @@ spec:
       syncPolicy:
         syncOptions:
           - CreateNamespace=true
-          - ServerSideApply=true

--- a/playbooks/argocd/applications/database/cnpg/cnpg-operator-application.yaml
+++ b/playbooks/argocd/applications/database/cnpg/cnpg-operator-application.yaml
@@ -20,4 +20,3 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - ServerSideApply=true


### PR DESCRIPTION
## What changed

- Removed `ServerSideApply=true` from the CNPG operator Application.
- Removed Argo resource finalizers from generated Immich DB and alias Applications.
- Added `preserveResourcesOnDeletion: true` to the Immich DB and alias ApplicationSets.
- Documented the required finalizer check before reducing the generated app matrix.

## Why

`cnpg-operator` is currently `Unknown` because Argo server-side diff chokes on the live `.status.terminatingReplicas` field. The generated Immich apps also all carry resource finalizers, so deleting noisy generated apps before removing those finalizers could prune shared database resources.

This PR is the safe first step. It prepares the cluster so the inactive generated apps can be removed in a later PR without deleting CNPG clusters, secrets, backups, or the active alias Service.

## Validation

- `kubectl explain applicationset.spec.syncPolicy.preserveResourcesOnDeletion`
- `kubectl apply --dry-run=server -f playbooks/argocd/applications/database/cnpg/cnpg-operator-application.yaml -f playbooks/argocd/applications/database/cnpg/apps/applicationset-immich-db.yaml -f playbooks/argocd/applications/database/cnpg/apps/applicationset-immich-alias.yaml`
- `git diff --check`

The server dry-run accepted all Application/ApplicationSet changes.