### PR TITLE
[codex] Generate only active Immich CNPG apps

### DIFF
--- a/playbooks/argocd/applications/database/cnpg/README.md
+++ b/playbooks/argocd/applications/database/cnpg/README.md
@@ -4,7 +4,7 @@
 
 ## Architecture
 - **Base + Overlays**: Shared cluster config + single role overlays (initdb/prod/restore)
-- **ApplicationSets**: Generate 6 DB apps (A/B x 3 roles) + 2 alias apps via nameSuffix injection
+- **ApplicationSets**: Generate the active DB app + active alias app via nameSuffix injection
 - **Alias Service**: `immich-db-active` ExternalName switches A/B
 - **NameRefs**: Backups track generated cluster names
 - **DB Secret**: Managed by DB stack, independent of alias lifecycle
@@ -14,7 +14,7 @@
 - **A/B Restore**: See `docs/restore-exercise/README.md`
 - **Kustomize Validation**: See `docs/kustomize-validation/README.md`
 
-**Quick rules:** Edit only targetTime file; keep one prod cluster with backups; delete inactive PVCs before restore.
+**Quick rules:** Generate only the active role by default; edit only targetTime file for restores; keep one prod cluster with backups; delete inactive PVCs before restore.
 **Note:** ApplicationSets disable automation - sync apps explicitly to avoid ownership conflicts.
 Generated apps intentionally omit Argo resource finalizers and set
 `preserveResourcesOnDeletion: true`, so deleting a generated Application does
@@ -36,12 +36,25 @@ kubectl -n argocd get app \
 
 Do not delete or stop generating inactive apps until that check is clean.
 
+The default rendered set is:
+
+```text
+immich-db-a-initdb
+immich-db-active-a
+```
+
+To prepare a B-side restore, temporarily add the needed B-side role to
+`apps/applicationset-immich-db.yaml`, set the restore target time, then sync the
+generated restore app. To flip the alias, change
+`apps/applicationset-immich-alias.yaml` from `active: a` to `active: b` in the
+same reviewed change.
+
 ## Key Components
 - `base/`: Shared cluster-base for external CNPG references
 - `immich-db/base/`: DB secret and cluster config (vectors, monitoring, S3 backup)
 - `immich-db/overlays/{initdb,prod,restore}/`: Single-copy overlays per role
 - `immich-db-active/overlays/{active-a,active-b}/`: Alias switching
-- `apps/`: ApplicationSets inject -a/-b suffixes via kustomize.nameSuffix
+- `apps/`: ApplicationSets inject active -a/-b suffixes via kustomize.nameSuffix
 - `docs/`: Bootstrap/restore guides
 
 ## Quick Commands
@@ -55,6 +68,7 @@ kubectl -n postgresql get cluster,backup,scheduledbackup
 
 # A→B restore
 $EDITOR immich-db/overlays/restore/target-time.yaml
+# Add letter=b, role=restore to apps/applicationset-immich-db.yaml first.
 argocd app sync immich-db-b-restore immich-db-active-b
 kubectl -n immich rollout restart deployment/immich-server
 

--- a/playbooks/argocd/applications/database/cnpg/apps/applicationset-immich-alias.yaml
+++ b/playbooks/argocd/applications/database/cnpg/apps/applicationset-immich-alias.yaml
@@ -1,4 +1,5 @@
-# Generates two alias apps (A and B) without automation so you flip explicitly.
+# Generates the active alias app only.
+# Edit this list deliberately when flipping Immich to the other database side.
 # These apps must not prune the shared alias Service when a generated app is removed.
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
@@ -12,7 +13,6 @@ spec:
     - list:
         elements:
           - active: a
-          - active: b
   template:
     metadata:
       name: immich-db-active-{{active}}

--- a/playbooks/argocd/applications/database/cnpg/apps/applicationset-immich-db.yaml
+++ b/playbooks/argocd/applications/database/cnpg/apps/applicationset-immich-db.yaml
@@ -1,4 +1,5 @@
-# Generates six DB apps (a/b x initdb/prod/restore) without automation.
+# Generates the active DB app only.
+# Edit this list deliberately for A/B restore or failover exercises.
 # These apps must not prune database resources when a generated app is removed.
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
@@ -9,17 +10,10 @@ spec:
   syncPolicy:
     preserveResourcesOnDeletion: true
   generators:
-    - matrix:
-        generators:
-          - list:
-              elements:
-                - letter: a
-                - letter: b
-          - list:
-              elements:
-                - role: initdb
-                - role: prod
-                - role: restore
+    - list:
+        elements:
+          - letter: a
+            role: initdb
   template:
     metadata:
       name: immich-db-{{letter}}-{{role}}


### PR DESCRIPTION
## What changed

- Reduced the Immich DB ApplicationSet to generate only `immich-db-a-initdb` by default.
- Reduced the Immich alias ApplicationSet to generate only `immich-db-active-a` by default.
- Updated CNPG docs so B-side restore/failover requires an explicit generator edit in the reviewed change.

## Why

The live cluster currently has only `immich-db-a` and the A-side alias in use. The previous generator continuously created inactive A prod/restore apps, inactive B apps, and inactive B alias apps, which leaves Argo full of expected-but-unused OutOfSync Applications.

This PR removes that drift by rendering only the active intent.

## Ordering

This is stacked on #163 and should be merged/deployed only after #163 has synced and the generated Applications no longer have `resources-finalizer.argocd.argoproj.io`. That avoids deleting shared CNPG resources when the inactive generated Applications disappear.

## Validation

- `kubectl apply --dry-run=server -f playbooks/argocd/applications/database/cnpg/apps/applicationset-immich-db.yaml -f playbooks/argocd/applications/database/cnpg/apps/applicationset-immich-alias.yaml`
- `git diff --check`

The server dry-run accepted the reduced ApplicationSets.