### PR TITLE
[codex] Clean CNPG ApplicationSet finalizers before apply

### DIFF
--- a/roles/apps/cnpg-immich-alias/tasks/main.yml
+++ b/roles/apps/cnpg-immich-alias/tasks/main.yml
@@ -1,4 +1,98 @@
 ---
+- name: Read existing CNPG Immich Alias ApplicationSet
+  kubernetes.core.k8s_info:
+    api_version: argoproj.io/v1alpha1
+    kind: ApplicationSet
+    kubeconfig: "{{ kubeconfig_path }}"
+    namespace: argocd
+    name: immich-db-alias
+  register: cnpg_immich_alias_existing_appset
+  tags: cnpg-immich-alias
+
+- name: Track existing CNPG Immich Alias generated Applications
+  ansible.builtin.set_fact:
+    cnpg_immich_alias_existing_apps: >-
+      {{
+        cnpg_immich_alias_existing_appset.resources[0].status.resources
+        if (
+          cnpg_immich_alias_existing_appset.resources | length > 0
+          and cnpg_immich_alias_existing_appset.resources[0].status is defined
+          and cnpg_immich_alias_existing_appset.resources[0].status.resources is defined
+        )
+        else []
+      }}
+  tags: cnpg-immich-alias
+
+- name: Make existing CNPG Immich Alias ApplicationSet removal safe
+  kubernetes.core.k8s:
+    state: patched
+    api_version: argoproj.io/v1alpha1
+    kind: ApplicationSet
+    kubeconfig: "{{ kubeconfig_path }}"
+    namespace: argocd
+    name: immich-db-alias
+    merge_type:
+      - merge
+    definition:
+      spec:
+        syncPolicy:
+          preserveResourcesOnDeletion: true
+        template:
+          metadata:
+            finalizers: null
+  when:
+    - cnpg_immich_alias_existing_appset.resources | length > 0
+    - >-
+      not (
+        cnpg_immich_alias_existing_appset.resources[0]
+        .spec.syncPolicy.preserveResourcesOnDeletion | default(false) | bool
+      )
+      or (
+        cnpg_immich_alias_existing_appset.resources[0]
+        .spec.template.metadata.finalizers | default([]) | length > 0
+      )
+  tags: cnpg-immich-alias
+
+- name: Read existing CNPG Immich Alias Application details
+  kubernetes.core.k8s_info:
+    api_version: argoproj.io/v1alpha1
+    kind: Application
+    kubeconfig: "{{ kubeconfig_path }}"
+    namespace: "{{ app_resource.namespace | default('argocd') }}"
+    name: "{{ app_resource.name }}"
+  loop: "{{ cnpg_immich_alias_existing_apps }}"
+  loop_control:
+    loop_var: app_resource
+    label: "{{ app_resource.name }}"
+  when:
+    - app_resource.kind == "Application"
+    - app_resource.name is defined
+  register: cnpg_immich_alias_existing_app_details
+  tags: cnpg-immich-alias
+
+- name: Remove stale finalizers from existing CNPG Immich Alias Applications
+  kubernetes.core.k8s:
+    state: patched
+    api_version: argoproj.io/v1alpha1
+    kind: Application
+    kubeconfig: "{{ kubeconfig_path }}"
+    namespace: "{{ app_lookup.resources[0].metadata.namespace | default('argocd') }}"
+    name: "{{ app_lookup.resources[0].metadata.name }}"
+    merge_type:
+      - merge
+    definition:
+      metadata:
+        finalizers: null
+  loop: "{{ cnpg_immich_alias_existing_app_details.results | default([]) }}"
+  loop_control:
+    loop_var: app_lookup
+    label: "{{ app_lookup.resources[0].metadata.name | default('missing') }}"
+  when:
+    - app_lookup.resources is defined
+    - app_lookup.resources | length > 0
+    - app_lookup.resources[0].metadata.finalizers | default([]) | length > 0
+  tags: cnpg-immich-alias
+
 - name: Apply CNPG Immich Alias ApplicationSet
   kubernetes.core.k8s:
     state: present

--- a/roles/apps/cnpg-immich-db/tasks/main.yml
+++ b/roles/apps/cnpg-immich-db/tasks/main.yml
@@ -1,4 +1,98 @@
 ---
+- name: Read existing CNPG Immich Database ApplicationSet
+  kubernetes.core.k8s_info:
+    api_version: argoproj.io/v1alpha1
+    kind: ApplicationSet
+    kubeconfig: "{{ kubeconfig_path }}"
+    namespace: argocd
+    name: immich-db
+  register: cnpg_immich_db_existing_appset
+  tags: cnpg-immich-db
+
+- name: Track existing CNPG Immich Database generated Applications
+  ansible.builtin.set_fact:
+    cnpg_immich_db_existing_apps: >-
+      {{
+        cnpg_immich_db_existing_appset.resources[0].status.resources
+        if (
+          cnpg_immich_db_existing_appset.resources | length > 0
+          and cnpg_immich_db_existing_appset.resources[0].status is defined
+          and cnpg_immich_db_existing_appset.resources[0].status.resources is defined
+        )
+        else []
+      }}
+  tags: cnpg-immich-db
+
+- name: Make existing CNPG Immich Database ApplicationSet removal safe
+  kubernetes.core.k8s:
+    state: patched
+    api_version: argoproj.io/v1alpha1
+    kind: ApplicationSet
+    kubeconfig: "{{ kubeconfig_path }}"
+    namespace: argocd
+    name: immich-db
+    merge_type:
+      - merge
+    definition:
+      spec:
+        syncPolicy:
+          preserveResourcesOnDeletion: true
+        template:
+          metadata:
+            finalizers: null
+  when:
+    - cnpg_immich_db_existing_appset.resources | length > 0
+    - >-
+      not (
+        cnpg_immich_db_existing_appset.resources[0]
+        .spec.syncPolicy.preserveResourcesOnDeletion | default(false) | bool
+      )
+      or (
+        cnpg_immich_db_existing_appset.resources[0]
+        .spec.template.metadata.finalizers | default([]) | length > 0
+      )
+  tags: cnpg-immich-db
+
+- name: Read existing CNPG Immich Database Application details
+  kubernetes.core.k8s_info:
+    api_version: argoproj.io/v1alpha1
+    kind: Application
+    kubeconfig: "{{ kubeconfig_path }}"
+    namespace: "{{ app_resource.namespace | default('argocd') }}"
+    name: "{{ app_resource.name }}"
+  loop: "{{ cnpg_immich_db_existing_apps }}"
+  loop_control:
+    loop_var: app_resource
+    label: "{{ app_resource.name }}"
+  when:
+    - app_resource.kind == "Application"
+    - app_resource.name is defined
+  register: cnpg_immich_db_existing_app_details
+  tags: cnpg-immich-db
+
+- name: Remove stale finalizers from existing CNPG Immich Database Applications
+  kubernetes.core.k8s:
+    state: patched
+    api_version: argoproj.io/v1alpha1
+    kind: Application
+    kubeconfig: "{{ kubeconfig_path }}"
+    namespace: "{{ app_lookup.resources[0].metadata.namespace | default('argocd') }}"
+    name: "{{ app_lookup.resources[0].metadata.name }}"
+    merge_type:
+      - merge
+    definition:
+      metadata:
+        finalizers: null
+  loop: "{{ cnpg_immich_db_existing_app_details.results | default([]) }}"
+  loop_control:
+    loop_var: app_lookup
+    label: "{{ app_lookup.resources[0].metadata.name | default('missing') }}"
+  when:
+    - app_lookup.resources is defined
+    - app_lookup.resources | length > 0
+    - app_lookup.resources[0].metadata.finalizers | default([]) | length > 0
+  tags: cnpg-immich-db
+
 - name: Apply CNPG Immich Database ApplicationSet
   kubernetes.core.k8s:
     state: present


### PR DESCRIPTION
## What changed

- Added pre-apply cleanup to the Immich DB ApplicationSet role.
- Added the same cleanup to the Immich DB alias ApplicationSet role.
- Each role now reads the existing ApplicationSet, makes deletion safe before generator changes, reads currently generated Applications, and removes stale Argo resource finalizers only when present.

## Why

During the SSD/Argo cleanup, removing `resources-finalizer.argocd.argoproj.io` from the desired ApplicationSet template was not enough. The `kubernetes.core.k8s` default patch style preserved the omitted nested CRD field, so stale finalizers had to be patched manually before inactive generated Applications could disappear safely.

This makes that cleanup part of the deploy role instead of a manual live step.

## Validation

- `ansible-playbook -i kubespray/inventory/soycluster/hosts.yml --become --become-user=root --user ubuntu playbooks/deploy-argocd-apps.yml --tags cnpg-immich-db,cnpg-immich-alias --syntax-check`
- `ansible-playbook -i kubespray/inventory/soycluster/hosts.yml --become --become-user=root --user ubuntu playbooks/deploy-argocd-apps.yml --tags cnpg-immich-db,cnpg-immich-alias --check`
- `git diff --check`

Check mode on the already-clean live cluster reported `changed=0`.