### PR TITLE
[codex] Co-schedule Immich media backup with server

### DIFF
--- a/playbooks/argocd/applications/backups/immich-offsite-backup/README.md
+++ b/playbooks/argocd/applications/backups/immich-offsite-backup/README.md
@@ -18,11 +18,13 @@ Backups for Immich using CloudNativePG (database) and AWS CLI (media), managed b
 
 ### Media Backup (CronJob)
 
-- **Schedule**: `30 2 * * *` - 02:30 UTC (14:30 NZST)
+- **Schedule**: `45 4 * * *` - 04:45 UTC
 - **Method**: AWS CLI `s3 sync` with optimized multipart uploads
 - **Source**: Immich library PVC (`immich-library`)
 - **Destination**: `s3://$BUCKET_NAME/$MEDIA_PREFIX`
 - **Behavior**: Append-only incremental sync (no deletes, aligns with IAM policy)
+- **Placement**: Required pod affinity keeps the backup job on the same node
+  as the Immich server, because `immich-library` is `ReadWriteOnce`
 
 ## Prerequisites
 
@@ -109,6 +111,9 @@ The `/library` path in the backup script is where we mount the `immich-library` 
 - `/library` is configured in `cronjob-media-sync.yaml` as `volumeMounts.mountPath`
 - The PVC is defined as `volumes.persistentVolumeClaim.claimName: immich-library`
 - We chose `/library` for simplicity - it could be any path like `/backup` or `/data`
+- The backup job mounts `/library` read-only and must run on the same node as
+  the Immich server pod, otherwise the RWO Longhorn volume can stay attached
+  elsewhere and the job can sit in `ContainerCreating`
 
 ### Media Directory Structure
 

--- a/playbooks/argocd/applications/backups/immich-offsite-backup/cronjob-media-sync.yaml
+++ b/playbooks/argocd/applications/backups/immich-offsite-backup/cronjob-media-sync.yaml
@@ -36,6 +36,7 @@ spec:
                   readOnly: true
                 - name: library
                   mountPath: /library
+                  readOnly: true
               resources:
                 requests:
                   cpu: "100m"
@@ -45,6 +46,14 @@ spec:
           securityContext:
             runAsUser: 0
             runAsGroup: 0
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      app.kubernetes.io/instance: immich
+                      app.kubernetes.io/name: server
+                  topologyKey: kubernetes.io/hostname
           volumes:
             - name: scripts
               configMap:
@@ -53,4 +62,4 @@ spec:
             - name: library
               persistentVolumeClaim:
                 claimName: immich-library
-
+                readOnly: true


### PR DESCRIPTION
## What changed

- Added required pod affinity to `immich-media-offsite-sync` so the media backup job schedules on the same node as the Immich server pod.
- Mounted `immich-library` read-only in the backup container and PVC volume.
- Updated the Immich offsite-backup README with the actual schedule and RWO placement rule.

## Why

After adding the two worker nodes, the media backup CronJob scheduled on `node-2` while `immich-library` was attached to the Immich server on `node-0`. The backup pod then sat in `ContainerCreating` because the Longhorn volume is `ReadWriteOnce`.

The backup only needs to read the library. Co-scheduling it with the server keeps the RWO mount local to the attached node and avoids cross-node attach deadlock.

## Live evidence

- `immich-server-6ddff46cbc-jrw6v` was running on `node-0`.
- `immich-media-offsite-sync-29716125-tvd6v` was pending on `node-2` in `ContainerCreating`.
- Longhorn volume `pvc-d0fe275c-664a-46cc-b44c-8de70cc45095` was attached to `node-0`.
- Current media backup last success was `2026-06-29T04:45:09Z`.

## Validation

- `kubectl kustomize playbooks/argocd/applications/backups/immich-offsite-backup`
- `kubectl apply --dry-run=server -k playbooks/argocd/applications/backups/immich-offsite-backup`
- `git diff --check`

Server dry-run accepted the rendered ServiceAccount, ConfigMap, and CronJob.

## After merge

Deploy `immich-offsite-backup`, then delete the currently stuck Job so the recreated job uses the corrected pod template or wait for the next CronJob run.