### PR TITLE
[codex] Stretch control plane for one node loss

### DIFF
--- a/soydocs/one-offs/2026-07-02-control-plane-ha-stretch.md
+++ b/soydocs/one-offs/2026-07-02-control-plane-ha-stretch.md
@@ -78,6 +78,10 @@ After the HA config PR, the repo should pass target mode:
 scripts/check-ha-stretch.sh --expect-ha --repo-only --vip 192.168.20.13
 ```
 
+The target inventory puts `node-0`, `node-1`, and `node-2` in both
+`kube_control_plane` and `etcd`. The API VIP is `192.168.20.13` on `eno1` via
+kube-vip ARP mode, and CoreDNS is pinned to at least two replicas.
+
 After the Kubespray apply, the live cluster should pass target mode:
 
 ```bash


### PR DESCRIPTION
## What changed
- Bumped the Kubespray submodule to `4c6a5e3b`, which includes kpoxo6op/kubespray#2.
- The Kubespray change adds node-1 and node-2 to `kube_control_plane` and `etcd`, enables kube-vip API VIP `192.168.20.13` on `eno1`, and sets `dns_min_replicas: 2`.
- Updated the HA stretch runbook note with the concrete target config.

## Why
The cluster already has three workers and SSD-backed Longhorn replicas, but the Kubernetes API and etcd were still single-node on node-0. This is the main remaining blocker for temporarily losing any one node.

Known exceptions remain node-0 external media and MQTT/gateway hardware.

## Validation
- Merged Kubespray PR: https://github.com/kpoxo6op/kubespray/pull/2
- `scripts/check-ha-stretch.sh --expect-ha --repo-only --vip 192.168.20.13`
- `source soyspray-venv/bin/activate && ansible-playbook -i kubespray/inventory/soycluster/hosts.yml --syntax-check kubespray/cluster.yml`
- Verified `192.168.20.13` did not respond to ping and is not assigned to a current LoadBalancer service.
- Verified all nodes use `eno1` for the `192.168.20.0/24` LAN.