### PR TITLE
[codex] Bump Kubespray promotion fix

### DIFF
--- a/soydocs/one-offs/2026-07-02-control-plane-ha-stretch.md
+++ b/soydocs/one-offs/2026-07-02-control-plane-ha-stretch.md
@@ -100,6 +100,28 @@ The live check must prove:
 - Longhorn volumes are healthy with at least three replicas
 - Argo CD apps are Synced and Healthy
 
+## Promotion Rerun Note
+
+The first HA apply joined node-1 and node-2 to etcd, then stopped before the
+control-plane join. The root cause was Kubespray treating existing workers as
+already-initialized control-plane nodes because `/var/lib/kubelet/config.yaml`
+exists on workers. kube-vip also mounted a missing `admin.conf` path and left a
+directory where kubeadm later needs to write the real kubeconfig.
+
+The Kubespray fork now carries a promotion fix for this path:
+
+```text
+worker kubelet config exists
+  != control plane already exists
+
+control plane already exists
+  == kube-apiserver static pod manifest exists
+```
+
+It also forces the kube-vip kubeconfig hostPath to be a file and removes the
+stale `admin.conf` directory case before running the secondary control-plane
+join.
+
 ## Important Preflight Finding
 
 On 2026-07-02, live etcd still reported node-0's peer URL as


### PR DESCRIPTION
## What changed
- Bump the Kubespray submodule to include the worker-to-control-plane promotion fix from kpoxo6op/kubespray#3.
- Document the failed HA apply root cause and rerun behavior in the control-plane HA stretch note.

## Why
The HA stretch apply joined node-1 and node-2 to etcd, then stopped before the control-plane join because Kubespray treated existing worker kubelet config as proof that kubeadm had already initialized the control plane on those nodes. kube-vip also left /etc/kubernetes/admin.conf as a directory when the kubeconfig did not exist yet.

## Validation
- scripts/check-ha-stretch.sh --expect-ha --repo-only --vip 192.168.20.13
- source soyspray-venv/bin/activate && ansible-playbook -i kubespray/inventory/soycluster/hosts.yml --syntax-check kubespray/cluster.yml