### PR TITLE
[codex] Bump Kubespray promotion preflight fix

### DIFF
--- a/soydocs/one-offs/2026-07-02-control-plane-ha-stretch.md
+++ b/soydocs/one-offs/2026-07-02-control-plane-ha-stretch.md
@@ -122,6 +122,15 @@ It also forces the kube-vip kubeconfig hostPath to be a file and removes the
 stale `admin.conf` directory case before running the secondary control-plane
 join.
 
+Because node-1 and node-2 are existing workers, `kubeadm join --control-plane`
+also sees an existing kubelet config and an already-used kubelet port. The fork
+adds these kubeadm preflight ignores only for worker-promotion joins:
+
+```text
+FileAvailable--etc-kubernetes-kubelet.conf
+Port-10250
+```
+
 ## Important Preflight Finding
 
 On 2026-07-02, live etcd still reported node-0's peer URL as


### PR DESCRIPTION
## What changed
- Bump the Kubespray submodule to include kpoxo6op/kubespray#4.
- Document the existing-worker kubeadm preflight behavior in the HA stretch note.

## Why
The HA rerun reached kubeadm join on node-1 and node-2, then kubeadm stopped because those nodes are already workers with /etc/kubernetes/kubelet.conf present and kubelet listening on 10250. The fork now ignores only those expected preflights when joining a promoted worker as a control-plane node.

## Validation
- scripts/check-ha-stretch.sh --expect-ha --repo-only --vip 192.168.20.13
- source soyspray-venv/bin/activate && ansible-playbook -i kubespray/inventory/soycluster/hosts.yml --syntax-check kubespray/cluster.yml