### PR TITLE
[codex] Bump Kubespray kube-vip proxy cleanup

### DIFF
--- a/soydocs/one-offs/2026-07-02-control-plane-ha-stretch.md
+++ b/soydocs/one-offs/2026-07-02-control-plane-ha-stretch.md
@@ -131,6 +131,12 @@ FileAvailable--etc-kubernetes-kubelet.conf
 Port-10250
 ```
 
+The next rerun reached the intended worker-promotion ignores, then kubeadm
+failed because stale local API proxy pods from the old worker shape still bound
+`127.0.0.1:6443` on node-1 and node-2. The fork now removes old
+`nginx-proxy.yml` and `haproxy.yml` static pod manifests before writing the
+kube-vip manifest.
+
 ## Important Preflight Finding
 
 On 2026-07-02, live etcd still reported node-0's peer URL as


### PR DESCRIPTION
## What changed
- bump the Kubespray submodule to the merged kube-vip local proxy cleanup
- document the stale worker API proxy blocker found during the HA stretch apply

## Why
The control-plane promotion retry now gets past the intended worker kubelet preflight ignores, but old `nginx-proxy.yml` static pods on worker nodes still bind `127.0.0.1:6443` and block `kubeadm join --control-plane`. The Kubespray bump makes that cleanup happen through Ansible before kube-vip is written.

## Validation
- scripts/check-ha-stretch.sh --expect-ha --repo-only --vip 192.168.20.13
- ansible-playbook -i kubespray/inventory/soycluster/hosts.yml --syntax-check kubespray/cluster.yml