### PR TITLE
[codex] Bump Kubespray empty admin.conf fix

### DIFF
--- a/soydocs/one-offs/2026-07-02-control-plane-ha-stretch.md
+++ b/soydocs/one-offs/2026-07-02-control-plane-ha-stretch.md
@@ -137,6 +137,11 @@ failed because stale local API proxy pods from the old worker shape still bound
 `nginx-proxy.yml` and `haproxy.yml` static pod manifests before writing the
 kube-vip manifest.
 
+The following rerun got past the proxy cleanup, then kubeadm failed because
+kube-vip had created an empty `/etc/kubernetes/admin.conf` file on the promoted
+workers. Kubespray already removed the directory case; the fork now also removes
+the empty file case before kubeadm writes the real control-plane kubeconfigs.
+
 ## Important Preflight Finding
 
 On 2026-07-02, live etcd still reported node-0's peer URL as


### PR DESCRIPTION
## What changed
- bump the Kubespray submodule to the merged empty `admin.conf` promotion fix
- document the empty kube-vip placeholder failure found during the HA stretch apply

## Why
After stale local API proxies were cleaned up, `kubeadm join --control-plane` reached kubeconfig generation but failed on node-1 and node-2 because `/etc/kubernetes/admin.conf` existed as a zero-byte file. The Kubespray bump removes that placeholder before kubeadm writes the real control-plane kubeconfigs.

## Validation
- scripts/check-ha-stretch.sh --expect-ha --repo-only --vip 192.168.20.13
- ansible-playbook -i kubespray/inventory/soycluster/hosts.yml --syntax-check kubespray/cluster.yml