### PR TITLE
[codex] Bump Kubespray DNS autoscaler reconciliation

### DIFF
--- a/soydocs/one-offs/2026-07-02-control-plane-ha-stretch.md
+++ b/soydocs/one-offs/2026-07-02-control-plane-ha-stretch.md
@@ -142,6 +142,12 @@ kube-vip had created an empty `/etc/kubernetes/admin.conf` file on the promoted
 workers. Kubespray already removed the directory case; the fork now also removes
 the empty file case before kubeadm writes the real control-plane kubeconfigs.
 
+After the control-plane join succeeded, the live checker caught CoreDNS still at
+one replica. The inventory had `dns_min_replicas: 2`, but the existing
+`dns-autoscaler` ConfigMap still held the old `min: 1` policy. The fork now
+reconciles that ConfigMap from Kubespray so CoreDNS scaling follows inventory
+changes instead of stale live state.
+
 ## Important Preflight Finding
 
 On 2026-07-02, live etcd still reported node-0's peer URL as


### PR DESCRIPTION
## What changed
- Bump Kubespray to the merged DNS autoscaler ConfigMap reconciliation fix.
- Add a note to the HA stretch runbook explaining the stale CoreDNS autoscaler policy found after promotion.

## Why
The HA checker found CoreDNS still running one replica because the live dns-autoscaler ConfigMap kept the old min:1 policy. The Kubespray fork now reconciles that ConfigMap from inventory.

## Validation
- source soyspray-venv/bin/activate && ansible-playbook -i kubespray/inventory/soycluster/hosts.yml --syntax-check kubespray/cluster.yml
- scripts/check-ha-stretch.sh --expect-ha --repo-only --vip 192.168.20.13
- make go