### PR TITLE
Implement cluster SSO with Authentik

### DIFF
--- a/playbooks/argocd/applications/home-automation/zigbee2mqtt/authentik-forward-auth.yaml
+++ b/playbooks/argocd/applications/home-automation/zigbee2mqtt/authentik-forward-auth.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: auth-proxy-set-headers-zigbee2mqtt
+  namespace: home-automation
+data:
+  X-Forwarded-Host: "$http_host"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: authentik-server-zigbee2mqtt
+  namespace: home-automation
+spec:
+  type: ExternalName
+  externalName: authentik-server.authentik.svc.cluster.local
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: zigbee2mqtt-authentik-outpost
+  namespace: home-automation
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - zigbee2mqtt.soyspray.vip
+      secretName: prod-cert-tls
+  rules:
+    - host: zigbee2mqtt.soyspray.vip
+      http:
+        paths:
+          - path: /outpost.goauthentik.io
+            pathType: Prefix
+            backend:
+              service:
+                name: authentik-server-zigbee2mqtt
+                port:
+                  number: 80

--- a/playbooks/argocd/applications/home-automation/zigbee2mqtt/deployment.yaml
+++ b/playbooks/argocd/applications/home-automation/zigbee2mqtt/deployment.yaml
@@ -14,11 +14,13 @@ spec:
   selector:
     matchLabels:
       app: zigbee2mqtt
+      managed-by: argocd
   template:
     metadata:
       labels:
         app: zigbee2mqtt
         component: main
+        managed-by: argocd
     spec:
       nodeSelector:
         kubernetes.io/hostname: node-0

--- a/playbooks/argocd/applications/home-automation/zigbee2mqtt/ingress.yaml
+++ b/playbooks/argocd/applications/home-automation/zigbee2mqtt/ingress.yaml
@@ -7,6 +7,11 @@ metadata:
   namespace: home-automation
   labels:
     app: zigbee2mqtt
+  annotations:
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-server.authentik.svc.cluster.local/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://zigbee2mqtt.soyspray.vip/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-entitlements,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/auth-proxy-set-headers: "home-automation/auth-proxy-set-headers-zigbee2mqtt"
 spec:
   ingressClassName: nginx
   tls:

--- a/playbooks/argocd/applications/home-automation/zigbee2mqtt/kustomization.yaml
+++ b/playbooks/argocd/applications/home-automation/zigbee2mqtt/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - authentik-forward-auth.yaml
   - deployment.yaml
   - service.yaml
   - ingress.yaml
@@ -12,6 +13,8 @@ resources:
 
 namespace: home-automation
 
-commonLabels:
-  app: zigbee2mqtt
-  managed-by: argocd
+labels:
+  - pairs:
+      app: zigbee2mqtt
+      managed-by: argocd
+    includeSelectors: false

--- a/playbooks/argocd/applications/infrastructure/cert-manager/prod-certificate.yaml
+++ b/playbooks/argocd/applications/infrastructure/cert-manager/prod-certificate.yaml
@@ -11,9 +11,9 @@ spec:
     annotations:
       reflector-test-ts: "1769845000"
       reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "argocd,longhorn-system,monitoring,immich,media,headlamp,home-automation,obsidian"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "argocd,longhorn-system,monitoring,immich,media,headlamp,home-automation,obsidian,authentik"
       reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "argocd,longhorn-system,monitoring,immich,media,headlamp,home-automation,obsidian"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "argocd,longhorn-system,monitoring,immich,media,headlamp,home-automation,obsidian,authentik"
   issuerRef:
     name: letsencrypt-prod
     kind: ClusterIssuer

--- a/playbooks/argocd/applications/infrastructure/headlamp/values.yaml
+++ b/playbooks/argocd/applications/infrastructure/headlamp/values.yaml
@@ -11,3 +11,26 @@ ingress:
       paths:
         - path: /
           type: Prefix
+
+config:
+  oidc:
+    secret:
+      create: false
+    externalSecret:
+      enabled: true
+      name: headlamp-oidc
+
+extraManifests:
+  - |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: authentik-cluster-admins
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: cluster-admin
+    subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: oidc:cluster-admins

--- a/playbooks/argocd/applications/infrastructure/longhorn/authentik-forward-auth.yaml
+++ b/playbooks/argocd/applications/infrastructure/longhorn/authentik-forward-auth.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: auth-proxy-set-headers-longhorn
+  namespace: longhorn-system
+data:
+  X-Forwarded-Host: "$http_host"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: authentik-server-longhorn
+  namespace: longhorn-system
+spec:
+  type: ExternalName
+  externalName: authentik-server.authentik.svc.cluster.local
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: longhorn-authentik-outpost
+  namespace: longhorn-system
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - longhorn.soyspray.vip
+      secretName: prod-cert-tls
+  rules:
+    - host: longhorn.soyspray.vip
+      http:
+        paths:
+          - path: /outpost.goauthentik.io
+            pathType: Prefix
+            backend:
+              service:
+                name: authentik-server-longhorn
+                port:
+                  number: 80

--- a/playbooks/argocd/applications/infrastructure/longhorn/kustomization.yaml
+++ b/playbooks/argocd/applications/infrastructure/longhorn/kustomization.yaml
@@ -12,6 +12,7 @@ helmCharts:
     valuesFile: values.yaml
 
 resources:
+  - authentik-forward-auth.yaml
   - setting-default-data-path.yaml
   - storageclass-rwx.yaml
 

--- a/playbooks/argocd/applications/infrastructure/longhorn/values.yaml
+++ b/playbooks/argocd/applications/infrastructure/longhorn/values.yaml
@@ -65,6 +65,10 @@ ingress:
   pathType: Prefix
   annotations:
     kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-server.authentik.svc.cluster.local/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://longhorn.soyspray.vip/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-entitlements,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/auth-proxy-set-headers: "longhorn-system/auth-proxy-set-headers-longhorn"
 
 service:
   ui:

--- a/playbooks/argocd/applications/media/lazylibrarian/authentik-forward-auth.yaml
+++ b/playbooks/argocd/applications/media/lazylibrarian/authentik-forward-auth.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: auth-proxy-set-headers-lazylibrarian
+  namespace: media
+data:
+  X-Forwarded-Host: "$http_host"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: authentik-server-lazylibrarian
+  namespace: media
+spec:
+  type: ExternalName
+  externalName: authentik-server.authentik.svc.cluster.local
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: lazylibrarian-authentik-outpost
+  namespace: media
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - lazylibrarian.soyspray.vip
+      secretName: prod-cert-tls
+  rules:
+    - host: lazylibrarian.soyspray.vip
+      http:
+        paths:
+          - path: /outpost.goauthentik.io
+            pathType: Prefix
+            backend:
+              service:
+                name: authentik-server-lazylibrarian
+                port:
+                  number: 80

--- a/playbooks/argocd/applications/media/lazylibrarian/ingress.yaml
+++ b/playbooks/argocd/applications/media/lazylibrarian/ingress.yaml
@@ -8,6 +8,10 @@ metadata:
   namespace: media
   annotations:
     kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-server.authentik.svc.cluster.local/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://lazylibrarian.soyspray.vip/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-entitlements,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/auth-proxy-set-headers: "media/auth-proxy-set-headers-lazylibrarian"
 spec:
   ingressClassName: nginx
   tls:

--- a/playbooks/argocd/applications/media/lazylibrarian/kustomization.yaml
+++ b/playbooks/argocd/applications/media/lazylibrarian/kustomization.yaml
@@ -7,6 +7,7 @@ kind: Kustomization
 namespace: media
 
 resources:
+  - authentik-forward-auth.yaml
   - pvc-config.yaml
   - pvc-books.yaml
   - initial-config-configmap.yaml

--- a/playbooks/argocd/applications/media/qbittorrent/authentik-forward-auth.yaml
+++ b/playbooks/argocd/applications/media/qbittorrent/authentik-forward-auth.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: auth-proxy-set-headers-qbittorrent
+  namespace: media
+data:
+  X-Forwarded-Host: "$http_host"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: authentik-server-qbittorrent
+  namespace: media
+spec:
+  type: ExternalName
+  externalName: authentik-server.authentik.svc.cluster.local
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: qbittorrent-authentik-outpost
+  namespace: media
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - torrent.soyspray.vip
+      secretName: prod-cert-tls
+  rules:
+    - host: torrent.soyspray.vip
+      http:
+        paths:
+          - path: /outpost.goauthentik.io
+            pathType: Prefix
+            backend:
+              service:
+                name: authentik-server-qbittorrent
+                port:
+                  number: 80

--- a/playbooks/argocd/applications/media/qbittorrent/ingress.yaml
+++ b/playbooks/argocd/applications/media/qbittorrent/ingress.yaml
@@ -11,6 +11,10 @@ metadata:
   namespace: media
   annotations:
     kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-server.authentik.svc.cluster.local/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://torrent.soyspray.vip/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-entitlements,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/auth-proxy-set-headers: "media/auth-proxy-set-headers-qbittorrent"
 spec:
   ingressClassName: nginx
   tls:

--- a/playbooks/argocd/applications/media/qbittorrent/kustomization.yaml
+++ b/playbooks/argocd/applications/media/qbittorrent/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 namespace: media
 
 resources:
+  - authentik-forward-auth.yaml
   - storageclass-local-media.yaml
   - pv-downloads.yaml
   - pvc-downloads.yaml
@@ -14,5 +15,7 @@ resources:
   - configmap.yaml
   - bootstrap-job.yaml
 
-commonLabels:
-  app: qbittorrent
+labels:
+  - pairs:
+      app: qbittorrent
+    includeSelectors: false

--- a/playbooks/argocd/applications/media/qbittorrent/service.yaml
+++ b/playbooks/argocd/applications/media/qbittorrent/service.yaml
@@ -6,8 +6,7 @@ metadata:
   labels:
     app: qbittorrent
 spec:
-  type: LoadBalancer
-  loadBalancerIP: 192.168.20.30
+  type: ClusterIP
   ports:
     - port: 8080
       targetPort: 8080

--- a/playbooks/argocd/applications/observability/prometheus/authentik-forward-auth.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/authentik-forward-auth.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: auth-proxy-set-headers-prometheus
+  namespace: monitoring
+data:
+  X-Forwarded-Host: "$http_host"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: authentik-server-prometheus
+  namespace: monitoring
+spec:
+  type: ExternalName
+  externalName: authentik-server.authentik.svc.cluster.local
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prometheus-authentik-outpost
+  namespace: monitoring
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - prometheus.soyspray.vip
+      secretName: prod-cert-tls
+  rules:
+    - host: prometheus.soyspray.vip
+      http:
+        paths:
+          - path: /outpost.goauthentik.io
+            pathType: Prefix
+            backend:
+              service:
+                name: authentik-server-prometheus
+                port:
+                  number: 80

--- a/playbooks/argocd/applications/observability/prometheus/kustomization.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/kustomization.yaml
@@ -86,6 +86,7 @@ configMapGenerator:
   #     disableNameSuffixHash: true
 
 resources:
+  - authentik-forward-auth.yaml
   - smartctl-exporter-daemonset.yaml
   - alerts/backups-essential.yaml
   - alerts/cert-expiry.yaml

--- a/playbooks/argocd/applications/observability/prometheus/prometheus-application.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/prometheus-application.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
-    targetRevision: "kong-goals-foundation"
+    targetRevision: "HEAD"
     path: playbooks/argocd/applications/observability/prometheus
     kustomize:
       helm:

--- a/playbooks/argocd/applications/observability/prometheus/prometheus-application.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/prometheus-application.yaml
@@ -14,9 +14,7 @@ spec:
     repoURL: "https://github.com/kpoxo6op/soyspray.git"
     targetRevision: "HEAD"
     path: playbooks/argocd/applications/observability/prometheus
-    kustomize:
-      helm:
-        skipCrds: true
+    kustomize: {}
   destination:
     server: "https://kubernetes.default.svc"
     namespace: monitoring
@@ -29,12 +27,12 @@ spec:
       automated:
         prune: true
         selfHeal: true
-        retry:
-          limit: 5
-          backoff:
-            duration: "10s"
-            factor: 2
-            maxDuration: "5m"
+      retry:
+        limit: 5
+        backoff:
+          duration: "10s"
+          factor: 2
+          maxDuration: "5m"
       syncOptions:
         - CreateNamespace=true
         - AllowClusterResourceInNamespacedApp=true

--- a/playbooks/argocd/applications/observability/prometheus/values.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/values.yaml
@@ -115,9 +115,26 @@ grafana:
       memory: 192Mi
   grafana.ini:
     auth.anonymous:
-      enabled: true
+      enabled: false
       org_name: "Main Org."
       org_role: "Viewer"
+    auth.generic_oauth:
+      enabled: true
+      name: authentik
+      allow_sign_up: true
+      auto_login: true
+      client_id: "$__env{GRAFANA_OIDC_CLIENT_ID}"
+      client_secret: "$__env{GRAFANA_OIDC_CLIENT_SECRET}"
+      scopes: "openid profile email groups"
+      auth_url: https://auth.soyspray.vip/application/o/authorize/
+      token_url: https://auth.soyspray.vip/application/o/token/
+      api_url: https://auth.soyspray.vip/application/o/userinfo/
+      signout_redirect_url: https://auth.soyspray.vip/application/o/grafana/end-session/
+      role_attribute_path: "contains(groups, 'cluster-admins') && 'GrafanaAdmin' || 'Viewer'"
+      role_attribute_strict: true
+      allow_assign_grafana_admin: true
+    server:
+      root_url: https://grafana.soyspray.vip
     date_formats:
       default_timezone: "Pacific/Auckland"
   defaultDashboardsTimezone: "Pacific/Auckland"
@@ -149,7 +166,11 @@ grafana:
 
   service:
     type: ClusterIP
-  adminPassword: "admin"
+  envFromSecret: grafana-oidc
+  admin:
+    existingSecret: grafana-oidc
+    userKey: admin-user
+    passwordKey: admin-password
   image:
     tag: 11.3.0
 

--- a/playbooks/argocd/applications/observability/prometheus/values.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/values.yaml
@@ -9,11 +9,15 @@ prometheusOperator:
 
 prometheus:
   service:
-    type: LoadBalancer
-    loadBalancerIP: 192.168.20.34
+    type: ClusterIP
   ingress:
     enabled: true
     ingressClassName: nginx
+    annotations:
+      nginx.ingress.kubernetes.io/auth-url: "http://authentik-server.authentik.svc.cluster.local/outpost.goauthentik.io/auth/nginx"
+      nginx.ingress.kubernetes.io/auth-signin: "https://prometheus.soyspray.vip/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri"
+      nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-entitlements,X-authentik-email,X-authentik-name,X-authentik-uid"
+      nginx.ingress.kubernetes.io/auth-proxy-set-headers: "monitoring/auth-proxy-set-headers-prometheus"
     hosts:
       - prometheus.soyspray.vip
     paths:

--- a/playbooks/argocd/applications/security/authentik/authentik-application.yaml
+++ b/playbooks/argocd/applications/security/authentik/authentik-application.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: authentik
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: https://charts.goauthentik.io
+      chart: authentik
+      targetRevision: "2026.5.6"
+      helm:
+        releaseName: authentik
+        valueFiles:
+          - $values/playbooks/argocd/applications/security/authentik/values.yaml
+    - repoURL: https://github.com/kpoxo6op/soyspray.git
+      targetRevision: "HEAD"
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: authentik
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/playbooks/argocd/applications/security/authentik/blueprints/cluster-sso.yaml
+++ b/playbooks/argocd/applications/security/authentik/blueprints/cluster-sso.yaml
@@ -1,0 +1,126 @@
+# yaml-language-server: $schema=https://version-2026-5.goauthentik.io/blueprints/schema.json
+version: 1
+metadata:
+  name: Soyspray cluster SSO
+entries:
+  - model: authentik_blueprints.metaapplyblueprint
+    attrs:
+      identifiers:
+        name: Default - Authentication flow
+
+  - model: authentik_blueprints.metaapplyblueprint
+    attrs:
+      identifiers:
+        name: Default - Provider authorization flow (implicit consent)
+
+  - model: authentik_blueprints.metaapplyblueprint
+    attrs:
+      identifiers:
+        name: Default - Provider invalidation flow
+
+  - model: authentik_blueprints.metaapplyblueprint
+    attrs:
+      identifiers:
+        name: System - OAuth2 Provider - Scopes
+
+  - model: authentik_core.group
+    id: cluster-admins
+    identifiers:
+      name: cluster-admins
+
+  - model: authentik_core.user
+    id: boris-user
+    state: created
+    identifiers:
+      username: boris
+    attrs:
+      name: Boris
+      email: kpoxo6op@gmail.com
+      groups:
+        - !KeyOf cluster-admins
+      password: !Env SSO_PASSWORD
+
+  - model: authentik_providers_oauth2.oauth2provider
+    id: argocd-provider
+    identifiers:
+      name: Argo CD
+    attrs:
+      authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      client_type: confidential
+      client_id: soyspray-argocd
+      client_secret: !Env ARGOCD_OIDC_CLIENT_SECRET
+      grant_types: [authorization_code, refresh_token]
+      redirect_uris:
+        - matching_mode: strict
+          url: https://argocd.soyspray.vip/auth/callback
+          redirect_uri_type: authorization
+        - matching_mode: strict
+          url: http://localhost:8085/auth/callback
+          redirect_uri_type: authorization
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-openid]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-email]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-profile]]
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+      issuer_mode: per_provider
+      include_claims_in_id_token: true
+
+  - model: authentik_core.application
+    id: argocd-application
+    identifiers:
+      slug: argocd
+    attrs:
+      name: Argo CD
+      provider: !KeyOf argocd-provider
+      meta_launch_url: https://argocd.soyspray.vip
+      policy_engine_mode: all
+
+  - model: authentik_policies.policybinding
+    identifiers:
+      target: !KeyOf argocd-application
+      order: 0
+    attrs:
+      group: !KeyOf cluster-admins
+
+  - model: authentik_providers_oauth2.oauth2provider
+    id: grafana-provider
+    identifiers:
+      name: Grafana
+    attrs:
+      authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      client_type: confidential
+      client_id: soyspray-grafana
+      client_secret: !Env GRAFANA_OIDC_CLIENT_SECRET
+      grant_types: [authorization_code, refresh_token]
+      redirect_uris:
+        - matching_mode: strict
+          url: https://grafana.soyspray.vip/login/generic_oauth
+          redirect_uri_type: authorization
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-openid]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-email]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-profile]]
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+      issuer_mode: per_provider
+      include_claims_in_id_token: true
+
+  - model: authentik_core.application
+    id: grafana-application
+    identifiers:
+      slug: grafana
+    attrs:
+      name: Grafana
+      provider: !KeyOf grafana-provider
+      meta_launch_url: https://grafana.soyspray.vip
+      policy_engine_mode: all
+
+  - model: authentik_policies.policybinding
+    identifiers:
+      target: !KeyOf grafana-application
+      order: 0
+    attrs:
+      group: !KeyOf cluster-admins

--- a/playbooks/argocd/applications/security/authentik/blueprints/cluster-sso.yaml
+++ b/playbooks/argocd/applications/security/authentik/blueprints/cluster-sso.yaml
@@ -124,3 +124,45 @@ entries:
       order: 0
     attrs:
       group: !KeyOf cluster-admins
+
+  - model: authentik_providers_oauth2.oauth2provider
+    id: headlamp-provider
+    identifiers:
+      name: Headlamp
+    attrs:
+      authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      client_type: confidential
+      client_id: headlamp
+      client_secret: !Env HEADLAMP_OIDC_CLIENT_SECRET
+      grant_types: [authorization_code, refresh_token]
+      redirect_uris:
+        - matching_mode: strict
+          url: https://headlamp.soyspray.vip/oidc-callback
+          redirect_uri_type: authorization
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-openid]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-email]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-profile]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-offline_access]]
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+      issuer_mode: per_provider
+      include_claims_in_id_token: true
+
+  - model: authentik_core.application
+    id: headlamp-application
+    identifiers:
+      slug: headlamp
+    attrs:
+      name: Headlamp
+      provider: !KeyOf headlamp-provider
+      meta_launch_url: https://headlamp.soyspray.vip
+      policy_engine_mode: all
+
+  - model: authentik_policies.policybinding
+    identifiers:
+      target: !KeyOf headlamp-application
+      order: 0
+    attrs:
+      group: !KeyOf cluster-admins

--- a/playbooks/argocd/applications/security/authentik/blueprints/legacy-forward-auth.yaml
+++ b/playbooks/argocd/applications/security/authentik/blueprints/legacy-forward-auth.yaml
@@ -176,6 +176,7 @@ entries:
     attrs:
       name: authentik Embedded Outpost
       type: proxy
+      # Browser redirects use the public host; embedded backchannel calls use a Unix socket.
       config:
         authentik_host: https://auth.soyspray.vip
       providers:

--- a/playbooks/argocd/applications/security/authentik/blueprints/legacy-forward-auth.yaml
+++ b/playbooks/argocd/applications/security/authentik/blueprints/legacy-forward-auth.yaml
@@ -1,0 +1,174 @@
+# yaml-language-server: $schema=https://version-2026-5.goauthentik.io/blueprints/schema.json
+version: 1
+metadata:
+  name: Soyspray legacy web forward auth
+entries:
+  - model: authentik_blueprints.metaapplyblueprint
+    attrs:
+      identifiers:
+        name: Default - Authentication flow
+
+  - model: authentik_blueprints.metaapplyblueprint
+    attrs:
+      identifiers:
+        name: Default - Provider authorization flow (implicit consent)
+
+  - model: authentik_blueprints.metaapplyblueprint
+    attrs:
+      identifiers:
+        name: Default - Provider invalidation flow
+
+  - model: authentik_providers_proxy.proxyprovider
+    id: longhorn-proxy-provider
+    identifiers:
+      name: Longhorn forward auth
+    attrs:
+      authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      external_host: https://longhorn.soyspray.vip
+      mode: forward_single
+
+  - model: authentik_core.application
+    id: longhorn-proxy-application
+    identifiers:
+      slug: longhorn
+    attrs:
+      name: Longhorn
+      provider: !KeyOf longhorn-proxy-provider
+      meta_launch_url: https://longhorn.soyspray.vip
+      policy_engine_mode: all
+
+  - model: authentik_policies.policybinding
+    identifiers:
+      target: !KeyOf longhorn-proxy-application
+      order: 0
+    attrs:
+      group: !Find [authentik_core.group, [name, cluster-admins]]
+
+  - model: authentik_providers_proxy.proxyprovider
+    id: prometheus-proxy-provider
+    identifiers:
+      name: Prometheus forward auth
+    attrs:
+      authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      external_host: https://prometheus.soyspray.vip
+      mode: forward_single
+
+  - model: authentik_core.application
+    id: prometheus-proxy-application
+    identifiers:
+      slug: prometheus
+    attrs:
+      name: Prometheus
+      provider: !KeyOf prometheus-proxy-provider
+      meta_launch_url: https://prometheus.soyspray.vip
+      policy_engine_mode: all
+
+  - model: authentik_policies.policybinding
+    identifiers:
+      target: !KeyOf prometheus-proxy-application
+      order: 0
+    attrs:
+      group: !Find [authentik_core.group, [name, cluster-admins]]
+
+  - model: authentik_providers_proxy.proxyprovider
+    id: zigbee2mqtt-proxy-provider
+    identifiers:
+      name: Zigbee2MQTT forward auth
+    attrs:
+      authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      external_host: https://zigbee2mqtt.soyspray.vip
+      mode: forward_single
+
+  - model: authentik_core.application
+    id: zigbee2mqtt-proxy-application
+    identifiers:
+      slug: zigbee2mqtt
+    attrs:
+      name: Zigbee2MQTT
+      provider: !KeyOf zigbee2mqtt-proxy-provider
+      meta_launch_url: https://zigbee2mqtt.soyspray.vip
+      policy_engine_mode: all
+
+  - model: authentik_policies.policybinding
+    identifiers:
+      target: !KeyOf zigbee2mqtt-proxy-application
+      order: 0
+    attrs:
+      group: !Find [authentik_core.group, [name, cluster-admins]]
+
+  - model: authentik_providers_proxy.proxyprovider
+    id: lazylibrarian-proxy-provider
+    identifiers:
+      name: LazyLibrarian forward auth
+    attrs:
+      authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      external_host: https://lazylibrarian.soyspray.vip
+      mode: forward_single
+      skip_path_regex: ^/(api|opds|rss_feed)(/|$)|^/nzbfile\.nzb(/|$)
+
+  - model: authentik_core.application
+    id: lazylibrarian-proxy-application
+    identifiers:
+      slug: lazylibrarian
+    attrs:
+      name: LazyLibrarian
+      provider: !KeyOf lazylibrarian-proxy-provider
+      meta_launch_url: https://lazylibrarian.soyspray.vip
+      policy_engine_mode: all
+
+  - model: authentik_policies.policybinding
+    identifiers:
+      target: !KeyOf lazylibrarian-proxy-application
+      order: 0
+    attrs:
+      group: !Find [authentik_core.group, [name, cluster-admins]]
+
+  - model: authentik_providers_proxy.proxyprovider
+    id: qbittorrent-proxy-provider
+    identifiers:
+      name: qBittorrent forward auth
+    attrs:
+      authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      external_host: https://torrent.soyspray.vip
+      mode: forward_single
+      skip_path_regex: ^/api/v2(/|$)
+
+  - model: authentik_core.application
+    id: qbittorrent-proxy-application
+    identifiers:
+      slug: qbittorrent
+    attrs:
+      name: qBittorrent
+      provider: !KeyOf qbittorrent-proxy-provider
+      meta_launch_url: https://torrent.soyspray.vip
+      policy_engine_mode: all
+
+  - model: authentik_policies.policybinding
+    identifiers:
+      target: !KeyOf qbittorrent-proxy-application
+      order: 0
+    attrs:
+      group: !Find [authentik_core.group, [name, cluster-admins]]
+
+  - model: authentik_outposts.outpost
+    identifiers:
+      managed: goauthentik.io/outposts/embedded
+    attrs:
+      name: authentik Embedded Outpost
+      type: proxy
+      providers:
+        - !KeyOf longhorn-proxy-provider
+        - !KeyOf prometheus-proxy-provider
+        - !KeyOf zigbee2mqtt-proxy-provider
+        - !KeyOf lazylibrarian-proxy-provider
+        - !KeyOf qbittorrent-proxy-provider

--- a/playbooks/argocd/applications/security/authentik/blueprints/legacy-forward-auth.yaml
+++ b/playbooks/argocd/applications/security/authentik/blueprints/legacy-forward-auth.yaml
@@ -177,8 +177,7 @@ entries:
       name: authentik Embedded Outpost
       type: proxy
       config:
-        authentik_host: http://localhost:9000
-        authentik_host_browser: https://auth.soyspray.vip
+        authentik_host: https://auth.soyspray.vip
       providers:
         - !KeyOf longhorn-proxy-provider
         - !KeyOf prometheus-proxy-provider

--- a/playbooks/argocd/applications/security/authentik/blueprints/legacy-forward-auth.yaml
+++ b/playbooks/argocd/applications/security/authentik/blueprints/legacy-forward-auth.yaml
@@ -6,6 +6,16 @@ entries:
   - model: authentik_blueprints.metaapplyblueprint
     attrs:
       identifiers:
+        name: Soyspray cluster SSO
+
+  - model: authentik_blueprints.metaapplyblueprint
+    attrs:
+      identifiers:
+        name: System - Proxy Provider - Scopes
+
+  - model: authentik_blueprints.metaapplyblueprint
+    attrs:
+      identifiers:
         name: Default - Authentication flow
 
   - model: authentik_blueprints.metaapplyblueprint

--- a/playbooks/argocd/applications/security/authentik/blueprints/legacy-forward-auth.yaml
+++ b/playbooks/argocd/applications/security/authentik/blueprints/legacy-forward-auth.yaml
@@ -177,7 +177,7 @@ entries:
       name: authentik Embedded Outpost
       type: proxy
       config:
-        authentik_host: https://auth.soyspray.vip
+        authentik_host: http://localhost:9000
         authentik_host_browser: https://auth.soyspray.vip
       providers:
         - !KeyOf longhorn-proxy-provider

--- a/playbooks/argocd/applications/security/authentik/blueprints/legacy-forward-auth.yaml
+++ b/playbooks/argocd/applications/security/authentik/blueprints/legacy-forward-auth.yaml
@@ -176,6 +176,9 @@ entries:
     attrs:
       name: authentik Embedded Outpost
       type: proxy
+      config:
+        authentik_host: https://auth.soyspray.vip
+        authentik_host_browser: https://auth.soyspray.vip
       providers:
         - !KeyOf longhorn-proxy-provider
         - !KeyOf prometheus-proxy-provider

--- a/playbooks/argocd/applications/security/authentik/blueprints/native-apps.yaml
+++ b/playbooks/argocd/applications/security/authentik/blueprints/native-apps.yaml
@@ -1,0 +1,120 @@
+# yaml-language-server: $schema=https://version-2026-5.goauthentik.io/blueprints/schema.json
+version: 1
+metadata:
+  name: Soyspray native application SSO
+entries:
+  - model: authentik_blueprints.metaapplyblueprint
+    attrs:
+      identifiers:
+        name: Default - Authentication flow
+
+  - model: authentik_blueprints.metaapplyblueprint
+    attrs:
+      identifiers:
+        name: Default - Provider authorization flow (implicit consent)
+
+  - model: authentik_blueprints.metaapplyblueprint
+    attrs:
+      identifiers:
+        name: Default - Provider invalidation flow
+
+  - model: authentik_blueprints.metaapplyblueprint
+    attrs:
+      identifiers:
+        name: System - OAuth2 Provider - Scopes
+
+  - model: authentik_providers_oauth2.oauth2provider
+    id: immich-provider
+    identifiers:
+      name: Immich
+    attrs:
+      authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      client_type: confidential
+      client_id: immich
+      client_secret: !Env IMMICH_OIDC_CLIENT_SECRET
+      grant_types: [authorization_code, refresh_token]
+      redirect_uris:
+        - matching_mode: strict
+          url: https://immich.soyspray.vip/auth/login
+          redirect_uri_type: authorization
+        - matching_mode: strict
+          url: https://immich.soyspray.vip/user-settings
+          redirect_uri_type: authorization
+        - matching_mode: strict
+          url: app.immich:///oauth-callback
+          redirect_uri_type: authorization
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-openid]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-email]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-profile]]
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+      issuer_mode: per_provider
+      include_claims_in_id_token: true
+
+  - model: authentik_core.application
+    id: immich-application
+    identifiers:
+      slug: immich
+    attrs:
+      name: Immich
+      provider: !KeyOf immich-provider
+      meta_launch_url: https://immich.soyspray.vip
+      policy_engine_mode: all
+
+  - model: authentik_policies.policybinding
+    identifiers:
+      target: !KeyOf immich-application
+      order: 0
+    attrs:
+      group: !Find [authentik_core.group, [name, cluster-admins]]
+
+  - model: authentik_providers_oauth2.oauth2provider
+    id: booklore-provider
+    identifiers:
+      name: BookLore
+    attrs:
+      authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      client_type: public
+      client_id: booklore
+      grant_types: [authorization_code, refresh_token]
+      redirect_uris:
+        - matching_mode: strict
+          url: https://booklore.soyspray.vip/oauth2-callback
+          redirect_uri_type: authorization
+        - matching_mode: strict
+          url: booklore://oauth2-callback
+          redirect_uri_type: authorization
+        - matching_mode: strict
+          url: https://booklore.soyspray.vip/login
+          redirect_uri_type: logout
+      logout_method: backchannel
+      logout_uri: https://booklore.soyspray.vip/api/v1/auth/oidc/backchannel-logout
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-openid]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-email]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-profile]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-offline_access]]
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+      issuer_mode: per_provider
+      include_claims_in_id_token: true
+
+  - model: authentik_core.application
+    id: booklore-application
+    identifiers:
+      slug: booklore
+    attrs:
+      name: BookLore
+      provider: !KeyOf booklore-provider
+      meta_launch_url: https://booklore.soyspray.vip
+      policy_engine_mode: all
+
+  - model: authentik_policies.policybinding
+    identifiers:
+      target: !KeyOf booklore-application
+      order: 0
+    attrs:
+      group: !Find [authentik_core.group, [name, cluster-admins]]

--- a/playbooks/argocd/applications/security/authentik/database/authentik-postgresql-application.yaml
+++ b/playbooks/argocd/applications/security/authentik/database/authentik-postgresql-application.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: authentik-postgresql
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/kpoxo6op/soyspray.git
+    targetRevision: "HEAD"
+    path: playbooks/argocd/applications/security/authentik/database
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: authentik
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/playbooks/argocd/applications/security/authentik/database/cluster.yaml
+++ b/playbooks/argocd/applications/security/authentik/database/cluster.yaml
@@ -1,0 +1,51 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: authentik-postgresql
+  namespace: authentik
+spec:
+  instances: 2
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.5
+  bootstrap:
+    initdb:
+      database: authentik
+      owner: authentik
+      secret:
+        name: authentik-postgresql-app
+  storage:
+    size: 5Gi
+    storageClass: longhorn
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+  monitoring:
+    enablePodMonitor: true
+  backup:
+    retentionPolicy: "30d"
+    barmanObjectStore:
+      destinationPath: s3://immich-offsite-archive-au2/authentik/postgresql/
+      s3Credentials:
+        accessKeyId:
+          name: authentik-offsite-writer
+          key: AWS_ACCESS_KEY_ID
+        secretAccessKey:
+          name: authentik-offsite-writer
+          key: AWS_SECRET_ACCESS_KEY
+        region:
+          name: authentik-offsite-writer
+          key: AWS_REGION
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: authentik-postgresql-daily
+  namespace: authentik
+spec:
+  schedule: "0 30 3 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: authentik-postgresql

--- a/playbooks/argocd/applications/security/authentik/database/cluster.yaml
+++ b/playbooks/argocd/applications/security/authentik/database/cluster.yaml
@@ -20,7 +20,7 @@ spec:
       cpu: 100m
       memory: 256Mi
     limits:
-      cpu: 500m
+      cpu: "1"
       memory: 1Gi
   monitoring:
     enablePodMonitor: true

--- a/playbooks/argocd/applications/security/authentik/database/kustomization.yaml
+++ b/playbooks/argocd/applications/security/authentik/database/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: authentik
+
+resources:
+  - cluster.yaml
+  - networkpolicy.yaml

--- a/playbooks/argocd/applications/security/authentik/database/networkpolicy.yaml
+++ b/playbooks/argocd/applications/security/authentik/database/networkpolicy.yaml
@@ -15,3 +15,10 @@ spec:
       ports:
         - protocol: TCP
           port: 5432
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cnpg-system
+      ports:
+        - protocol: TCP
+          port: 8000

--- a/playbooks/argocd/applications/security/authentik/database/networkpolicy.yaml
+++ b/playbooks/argocd/applications/security/authentik/database/networkpolicy.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: authentik-postgresql-ingress
+  namespace: authentik
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: authentik-postgresql
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+      ports:
+        - protocol: TCP
+          port: 5432

--- a/playbooks/argocd/applications/security/authentik/values.yaml
+++ b/playbooks/argocd/applications/security/authentik/values.yaml
@@ -14,7 +14,7 @@ blueprints:
 server:
   replicas: 2
   podAnnotations:
-    soyspray.vip/runtime-secret-revision: "2026-08-09-1"
+    soyspray.vip/runtime-secret-revision: "2026-08-09-2"
   pdb:
     enabled: true
     minAvailable: 1
@@ -44,7 +44,7 @@ server:
 worker:
   replicas: 2
   podAnnotations:
-    soyspray.vip/runtime-secret-revision: "2026-08-09-1"
+    soyspray.vip/runtime-secret-revision: "2026-08-09-2"
   pdb:
     enabled: true
     minAvailable: 1

--- a/playbooks/argocd/applications/security/authentik/values.yaml
+++ b/playbooks/argocd/applications/security/authentik/values.yaml
@@ -13,6 +13,8 @@ blueprints:
 
 server:
   replicas: 2
+  podAnnotations:
+    soyspray.vip/runtime-secret-revision: "2026-08-09-1"
   pdb:
     enabled: true
     minAvailable: 1
@@ -41,6 +43,8 @@ server:
 
 worker:
   replicas: 2
+  podAnnotations:
+    soyspray.vip/runtime-secret-revision: "2026-08-09-1"
   pdb:
     enabled: true
     minAvailable: 1

--- a/playbooks/argocd/applications/security/authentik/values.yaml
+++ b/playbooks/argocd/applications/security/authentik/values.yaml
@@ -42,7 +42,7 @@ server:
           - auth.soyspray.vip
 
 worker:
-  replicas: 2
+  replicas: 1
   podAnnotations:
     soyspray.vip/runtime-secret-revision: "2026-08-09-3"
   pdb:

--- a/playbooks/argocd/applications/security/authentik/values.yaml
+++ b/playbooks/argocd/applications/security/authentik/values.yaml
@@ -14,7 +14,7 @@ blueprints:
 server:
   replicas: 2
   podAnnotations:
-    soyspray.vip/runtime-secret-revision: "2026-08-09-2"
+    soyspray.vip/runtime-secret-revision: "2026-08-09-3"
   pdb:
     enabled: true
     minAvailable: 1
@@ -44,7 +44,7 @@ server:
 worker:
   replicas: 2
   podAnnotations:
-    soyspray.vip/runtime-secret-revision: "2026-08-09-2"
+    soyspray.vip/runtime-secret-revision: "2026-08-09-3"
   pdb:
     enabled: true
     minAvailable: 1

--- a/playbooks/argocd/applications/security/authentik/values.yaml
+++ b/playbooks/argocd/applications/security/authentik/values.yaml
@@ -43,6 +43,9 @@ server:
 
 worker:
   replicas: 1
+  env:
+    - name: AUTHENTIK_WORKER__THREADS
+      value: "1"
   podAnnotations:
     soyspray.vip/runtime-secret-revision: "2026-08-09-3"
   pdb:

--- a/playbooks/argocd/applications/security/authentik/values.yaml
+++ b/playbooks/argocd/applications/security/authentik/values.yaml
@@ -1,0 +1,59 @@
+authentik:
+  existingSecret:
+    secretName: authentik-runtime
+  error_reporting:
+    enabled: false
+
+postgresql:
+  enabled: false
+
+blueprints:
+  configMaps:
+    - authentik-blueprints
+
+server:
+  replicas: 2
+  pdb:
+    enabled: true
+    minAvailable: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      selector:
+        release: kube-prometheus-stack
+  ingress:
+    enabled: true
+    ingressClassName: nginx
+    hosts:
+      - auth.soyspray.vip
+    tls:
+      - secretName: prod-cert-tls
+        hosts:
+          - auth.soyspray.vip
+
+worker:
+  replicas: 2
+  pdb:
+    enabled: true
+    minAvailable: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      selector:
+        release: kube-prometheus-stack

--- a/playbooks/argocd/config/argocd-cm.yaml
+++ b/playbooks/argocd/config/argocd-cm.yaml
@@ -13,3 +13,18 @@ data:
   # https://www.reddit.com/r/kubernetes/comments/194wrup/psa_if_you_deploy_kubeprometheusstack_with_argocd/
   application.instanceLabelKey: argocd.argoproj.io/instance
   ui.theme: auto
+  url: https://argocd.soyspray.vip
+  admin.enabled: "true"
+  oidc.config: |
+    name: authentik
+    issuer: https://auth.soyspray.vip/application/o/argocd/
+    clientID: soyspray-argocd
+    clientSecret: $oidc.authentik.clientSecret
+    requestedScopes:
+      - openid
+      - profile
+      - email
+      - groups
+    requestedIDTokenClaims:
+      groups:
+        essential: true

--- a/playbooks/argocd/config/argocd-cm.yaml
+++ b/playbooks/argocd/config/argocd-cm.yaml
@@ -15,6 +15,7 @@ data:
   ui.theme: auto
   url: https://argocd.soyspray.vip
   admin.enabled: "true"
+  oidc.tls.insecure.skip.verify: "true"
   oidc.config: |
     name: authentik
     issuer: https://auth.soyspray.vip/application/o/argocd/

--- a/playbooks/argocd/config/argocd-rbac-cm.yaml
+++ b/playbooks/argocd/config/argocd-rbac-cm.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-rbac-cm
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: argocd-rbac-cm
+    app.kubernetes.io/part-of: argocd
+data:
+  policy.csv: |
+    g, cluster-admins, role:admin
+  policy.default: role:readonly
+  scopes: '[groups, email]'

--- a/playbooks/deploy-argocd-apps.yml
+++ b/playbooks/deploy-argocd-apps.yml
@@ -8,6 +8,9 @@
     # Roles own their internal task tags (e.g. `prometheus-crds`). This playbook
     # always includes all roles so `--tags <tag>` works as expected.
     argocd_app_roles:
+      # Security and identity
+      - { name: Authentik, role: apps/authentik }
+
       # Observability
       - { name: Prometheus, role: apps/prometheus }
       - { name: Alloy Loki Manual, role: apps/alloy-loki-manual }

--- a/playbooks/operations/security/kubernetes-authentik-oidc-vars.yml
+++ b/playbooks/operations/security/kubernetes-authentik-oidc-vars.yml
@@ -1,0 +1,8 @@
+---
+kube_oidc_auth: true
+kube_oidc_url: https://auth.soyspray.vip/application/o/headlamp/
+kube_oidc_client_id: headlamp
+kube_oidc_username_claim: preferred_username
+kube_oidc_username_prefix: 'oidc:'
+kube_oidc_groups_claim: groups
+kube_oidc_groups_prefix: 'oidc:'

--- a/playbooks/operations/security/kubernetes-authentik-oidc-vars.yml
+++ b/playbooks/operations/security/kubernetes-authentik-oidc-vars.yml
@@ -7,5 +7,3 @@ kube_oidc_username_claim: preferred_username
 kube_oidc_username_prefix: 'oidc:'
 kube_oidc_groups_claim: groups
 kube_oidc_groups_prefix: 'oidc:'
-dns_etchosts: |
-  192.168.20.20 auth.soyspray.vip

--- a/playbooks/operations/security/kubernetes-authentik-oidc-vars.yml
+++ b/playbooks/operations/security/kubernetes-authentik-oidc-vars.yml
@@ -1,4 +1,5 @@
 ---
+upgrade_cluster_setup: true
 kube_oidc_auth: true
 kube_oidc_url: https://auth.soyspray.vip/application/o/headlamp/
 kube_oidc_client_id: headlamp

--- a/playbooks/operations/security/kubernetes-authentik-oidc-vars.yml
+++ b/playbooks/operations/security/kubernetes-authentik-oidc-vars.yml
@@ -6,3 +6,5 @@ kube_oidc_username_claim: preferred_username
 kube_oidc_username_prefix: 'oidc:'
 kube_oidc_groups_claim: groups
 kube_oidc_groups_prefix: 'oidc:'
+dns_etchosts: |
+  192.168.20.20 auth.soyspray.vip

--- a/roles/apps/authentik/defaults/main.yml
+++ b/roles/apps/authentik/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+authentik_target_revision: HEAD

--- a/roles/apps/authentik/tasks/main.yml
+++ b/roles/apps/authentik/tasks/main.yml
@@ -304,6 +304,34 @@
     definition: "{{ lookup('file', playbook_dir + '/argocd/applications/infrastructure/cert-manager/prod-certificate.yaml') }}"
   tags: authentik
 
+- name: Read the wildcard certificate for Authentik
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: prod-cert-tls
+    namespace: cert-manager
+    kubeconfig: "{{ kubeconfig_path }}"
+  register: authentik_wildcard_certificate
+  no_log: true
+  tags: authentik
+
+- name: Request the Authentik wildcard certificate mirror
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig_path }}"
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: prod-cert-tls
+        namespace: authentik
+        annotations:
+          reflector.v1.k8s.emberstack.com/reflects: cert-manager/prod-cert-tls
+      type: kubernetes.io/tls
+      data: "{{ authentik_wildcard_certificate.resources[0].data }}"
+  no_log: true
+  tags: authentik
+
 - name: Apply the Authentik PostgreSQL application
   kubernetes.core.k8s:
     state: present

--- a/roles/apps/authentik/tasks/main.yml
+++ b/roles/apps/authentik/tasks/main.yml
@@ -63,6 +63,10 @@
         {{ (existing['HEADLAMP_OIDC_CLIENT_SECRET'] | b64decode)
            if 'HEADLAMP_OIDC_CLIENT_SECRET' in existing
            else lookup('password', '/dev/null length=64 chars=ascii_letters,digits') }}
+      IMMICH_OIDC_CLIENT_SECRET: >-
+        {{ (existing['IMMICH_OIDC_CLIENT_SECRET'] | b64decode)
+           if 'IMMICH_OIDC_CLIENT_SECRET' in existing
+           else lookup('password', '/dev/null length=64 chars=ascii_letters,digits') }}
       SOYSPRAY_BREAK_GLASS_PASSWORD: >-
         {{ (existing['SOYSPRAY_BREAK_GLASS_PASSWORD'] | b64decode)
            if 'SOYSPRAY_BREAK_GLASS_PASSWORD' in existing
@@ -200,6 +204,8 @@
       data:
         cluster-sso.yaml: >-
           {{ lookup('file', playbook_dir + '/argocd/applications/security/authentik/blueprints/cluster-sso.yaml') }}
+        native-apps.yaml: >-
+          {{ lookup('file', playbook_dir + '/argocd/applications/security/authentik/blueprints/native-apps.yaml') }}
   tags: authentik
 
 - name: Create the Grafana SSO and break-glass secret
@@ -312,6 +318,10 @@
     definition: >-
       {{ lookup('file', playbook_dir + '/argocd/applications/security/authentik/authentik-application.yaml')
          | replace('targetRevision: "HEAD"', 'targetRevision: "' + authentik_target_revision + '"') }}
+  tags: authentik
+
+- name: Configure native application SSO
+  ansible.builtin.include_tasks: native-apps.yml
   tags: authentik
 
 - name: Apply Grafana SSO through the Prometheus application

--- a/roles/apps/authentik/tasks/main.yml
+++ b/roles/apps/authentik/tasks/main.yml
@@ -288,6 +288,24 @@
     loop_var: argocd_config_file
   tags: authentik
 
+- name: Restart Argo CD when the OIDC configuration changes
+  kubernetes.core.k8s:
+    state: patched
+    kubeconfig: "{{ kubeconfig_path }}"
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: argocd-server
+        namespace: argocd
+      spec:
+        template:
+          metadata:
+            annotations:
+              soyspray.vip/oidc-config-hash: >-
+                {{ lookup('file', playbook_dir + '/argocd/config/argocd-cm.yaml') | hash('sha256') }}
+  tags: authentik
+
 - name: Point cert-manager config at the Authentik revision
   kubernetes.core.k8s:
     state: present

--- a/roles/apps/authentik/tasks/main.yml
+++ b/roles/apps/authentik/tasks/main.yml
@@ -58,6 +58,11 @@
         {{ (existing['GRAFANA_OIDC_CLIENT_SECRET'] | b64decode)
            if 'GRAFANA_OIDC_CLIENT_SECRET' in existing
            else lookup('password', '/dev/null length=64 chars=ascii_letters,digits') }}
+      HEADLAMP_OIDC_CLIENT_ID: headlamp
+      HEADLAMP_OIDC_CLIENT_SECRET: >-
+        {{ (existing['HEADLAMP_OIDC_CLIENT_SECRET'] | b64decode)
+           if 'HEADLAMP_OIDC_CLIENT_SECRET' in existing
+           else lookup('password', '/dev/null length=64 chars=ascii_letters,digits') }}
       SOYSPRAY_BREAK_GLASS_PASSWORD: >-
         {{ (existing['SOYSPRAY_BREAK_GLASS_PASSWORD'] | b64decode)
            if 'SOYSPRAY_BREAK_GLASS_PASSWORD' in existing
@@ -216,6 +221,36 @@
   no_log: true
   tags: authentik
 
+- name: Ensure the Headlamp namespace exists
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig_path }}"
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: headlamp
+  tags: authentik
+
+- name: Create the Headlamp OIDC secret
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig_path }}"
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: headlamp-oidc
+        namespace: headlamp
+      type: Opaque
+      stringData:
+        OIDC_CLIENT_ID: "{{ authentik_runtime_values['HEADLAMP_OIDC_CLIENT_ID'] }}"
+        OIDC_CLIENT_SECRET: "{{ authentik_runtime_values['HEADLAMP_OIDC_CLIENT_SECRET'] }}"
+        OIDC_ISSUER_URL: https://auth.soyspray.vip/application/o/headlamp/
+        OIDC_SCOPES: profile,email,offline_access
+  no_log: true
+  tags: authentik
+
 - name: Configure the Argo CD SSO client and local recovery account
   kubernetes.core.k8s:
     state: patched
@@ -285,5 +320,14 @@
     kubeconfig: "{{ kubeconfig_path }}"
     definition: >-
       {{ lookup('file', playbook_dir + '/argocd/applications/observability/prometheus/prometheus-application.yaml')
+         | replace('targetRevision: "HEAD"', 'targetRevision: "' + authentik_target_revision + '"') }}
+  tags: authentik
+
+- name: Apply Headlamp SSO
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig_path }}"
+    definition: >-
+      {{ lookup('file', playbook_dir + '/argocd/applications/infrastructure/headlamp/headlamp-application.yaml')
          | replace('targetRevision: "HEAD"', 'targetRevision: "' + authentik_target_revision + '"') }}
   tags: authentik

--- a/roles/apps/authentik/tasks/main.yml
+++ b/roles/apps/authentik/tasks/main.yml
@@ -245,6 +245,15 @@
     loop_var: argocd_config_file
   tags: authentik
 
+- name: Point cert-manager config at the Authentik revision
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig_path }}"
+    definition: >-
+      {{ lookup('file', playbook_dir + '/argocd/applications/infrastructure/cert-manager/cert-manager-application.yaml')
+         | replace('targetRevision: "HEAD"', 'targetRevision: "' + authentik_target_revision + '"') }}
+  tags: authentik
+
 - name: Allow the wildcard certificate in the Authentik namespace
   kubernetes.core.k8s:
     state: present

--- a/roles/apps/authentik/tasks/main.yml
+++ b/roles/apps/authentik/tasks/main.yml
@@ -237,10 +237,12 @@
   kubernetes.core.k8s:
     state: present
     kubeconfig: "{{ kubeconfig_path }}"
-    definition: "{{ lookup('file', playbook_dir + '/argocd/config/' + item) }}"
+    definition: "{{ lookup('file', playbook_dir + '/argocd/config/' + argocd_config_file) }}"
   loop:
     - argocd-cm.yaml
     - argocd-rbac-cm.yaml
+  loop_control:
+    loop_var: argocd_config_file
   tags: authentik
 
 - name: Allow the wildcard certificate in the Authentik namespace

--- a/roles/apps/authentik/tasks/main.yml
+++ b/roles/apps/authentik/tasks/main.yml
@@ -206,6 +206,8 @@
           {{ lookup('file', playbook_dir + '/argocd/applications/security/authentik/blueprints/cluster-sso.yaml') }}
         native-apps.yaml: >-
           {{ lookup('file', playbook_dir + '/argocd/applications/security/authentik/blueprints/native-apps.yaml') }}
+        legacy-forward-auth.yaml: >-
+          {{ lookup('file', playbook_dir + '/argocd/applications/security/authentik/blueprints/legacy-forward-auth.yaml') }}
   tags: authentik
 
 - name: Create the Grafana SSO and break-glass secret
@@ -340,4 +342,20 @@
     definition: >-
       {{ lookup('file', playbook_dir + '/argocd/applications/infrastructure/headlamp/headlamp-application.yaml')
          | replace('targetRevision: "HEAD"', 'targetRevision: "' + authentik_target_revision + '"') }}
+  tags: authentik
+
+- name: Apply legacy forward-auth applications
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig_path }}"
+    definition: >-
+      {{ lookup('file', playbook_dir + '/argocd/applications/' + authentik_legacy_application)
+         | replace('targetRevision: "HEAD"', 'targetRevision: "' + authentik_target_revision + '"') }}
+  loop:
+    - infrastructure/longhorn/longhorn-application.yaml
+    - home-automation/zigbee2mqtt/zigbee2mqtt-application.yaml
+    - media/lazylibrarian/lazylibrarian-application.yaml
+    - media/qbittorrent/qbittorrent-application.yaml
+  loop_control:
+    loop_var: authentik_legacy_application
   tags: authentik

--- a/roles/apps/authentik/tasks/main.yml
+++ b/roles/apps/authentik/tasks/main.yml
@@ -1,0 +1,278 @@
+---
+- name: Ensure the Authentik namespace exists
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig_path }}"
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: authentik
+  tags: authentik
+
+- name: Read the existing Authentik runtime secret
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: authentik-runtime
+    namespace: authentik
+    kubeconfig: "{{ kubeconfig_path }}"
+  register: authentik_runtime_secret
+  no_log: true
+  tags: authentik
+
+- name: Resolve stable Authentik credentials
+  ansible.builtin.set_fact:
+    authentik_runtime_values:
+      AUTHENTIK_SECRET_KEY: >-
+        {{ (existing['AUTHENTIK_SECRET_KEY'] | b64decode)
+           if 'AUTHENTIK_SECRET_KEY' in existing
+           else lookup('password', '/dev/null length=60 chars=ascii_letters,digits') }}
+      AUTHENTIK_POSTGRESQL__HOST: authentik-postgresql-rw.authentik.svc.cluster.local
+      AUTHENTIK_POSTGRESQL__NAME: authentik
+      AUTHENTIK_POSTGRESQL__USER: authentik
+      AUTHENTIK_POSTGRESQL__PASSWORD: >-
+        {{ (existing['AUTHENTIK_POSTGRESQL__PASSWORD'] | b64decode)
+           if 'AUTHENTIK_POSTGRESQL__PASSWORD' in existing
+           else lookup('password', '/dev/null length=48 chars=ascii_letters,digits') }}
+      AUTHENTIK_BOOTSTRAP_EMAIL: kpoxo6op@gmail.com
+      AUTHENTIK_BOOTSTRAP_PASSWORD: >-
+        {{ (existing['AUTHENTIK_BOOTSTRAP_PASSWORD'] | b64decode)
+           if 'AUTHENTIK_BOOTSTRAP_PASSWORD' in existing
+           else lookup('env', 'SOYSPRAY_BREAK_GLASS_PASSWORD') }}
+      AUTHENTIK_BOOTSTRAP_TOKEN: >-
+        {{ (existing['AUTHENTIK_BOOTSTRAP_TOKEN'] | b64decode)
+           if 'AUTHENTIK_BOOTSTRAP_TOKEN' in existing
+           else lookup('password', '/dev/null length=64 chars=ascii_letters,digits') }}
+      SSO_PASSWORD: >-
+        {{ (existing['SSO_PASSWORD'] | b64decode)
+           if 'SSO_PASSWORD' in existing
+           else lookup('env', 'SOYSPRAY_SSO_PASSWORD') }}
+      ARGOCD_OIDC_CLIENT_ID: soyspray-argocd
+      ARGOCD_OIDC_CLIENT_SECRET: >-
+        {{ (existing['ARGOCD_OIDC_CLIENT_SECRET'] | b64decode)
+           if 'ARGOCD_OIDC_CLIENT_SECRET' in existing
+           else lookup('password', '/dev/null length=64 chars=ascii_letters,digits') }}
+      GRAFANA_OIDC_CLIENT_ID: soyspray-grafana
+      GRAFANA_OIDC_CLIENT_SECRET: >-
+        {{ (existing['GRAFANA_OIDC_CLIENT_SECRET'] | b64decode)
+           if 'GRAFANA_OIDC_CLIENT_SECRET' in existing
+           else lookup('password', '/dev/null length=64 chars=ascii_letters,digits') }}
+      SOYSPRAY_BREAK_GLASS_PASSWORD: >-
+        {{ (existing['SOYSPRAY_BREAK_GLASS_PASSWORD'] | b64decode)
+           if 'SOYSPRAY_BREAK_GLASS_PASSWORD' in existing
+           else lookup('env', 'SOYSPRAY_BREAK_GLASS_PASSWORD') }}
+      ARGOCD_ADMIN_PASSWORD_HASH: >-
+        {{ (existing['ARGOCD_ADMIN_PASSWORD_HASH'] | b64decode)
+           if 'ARGOCD_ADMIN_PASSWORD_HASH' in existing
+           else lookup('env', 'SOYSPRAY_ARGOCD_ADMIN_PASSWORD_HASH') }}
+      ARGOCD_ADMIN_PASSWORD_MTIME: >-
+        {{ (existing['ARGOCD_ADMIN_PASSWORD_MTIME'] | b64decode)
+           if 'ARGOCD_ADMIN_PASSWORD_MTIME' in existing
+           else now(utc=true, fmt='%Y-%m-%dT%H:%M:%SZ') }}
+  vars:
+    existing: >-
+      {{ authentik_runtime_secret.resources[0].data
+         if authentik_runtime_secret.resources | length > 0 else {} }}
+  no_log: true
+  tags: authentik
+
+- name: Validate operator-supplied login credentials
+  ansible.builtin.assert:
+    that:
+      - authentik_runtime_values['SSO_PASSWORD'] | length >= 20
+      - authentik_runtime_values['SOYSPRAY_BREAK_GLASS_PASSWORD'] | length >= 20
+      - authentik_runtime_values['ARGOCD_ADMIN_PASSWORD_HASH'] | length >= 20
+    fail_msg: >-
+      Set SOYSPRAY_SSO_PASSWORD, SOYSPRAY_BREAK_GLASS_PASSWORD, and
+      SOYSPRAY_ARGOCD_ADMIN_PASSWORD_HASH for the first deployment.
+  no_log: true
+  tags: authentik
+
+- name: Create the stable Authentik runtime secret
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig_path }}"
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: authentik-runtime
+        namespace: authentik
+        labels:
+          app.kubernetes.io/name: authentik
+          soyspray.vip/credential-source: runtime-generated-not-committed
+      type: Opaque
+      stringData: "{{ authentik_runtime_values }}"
+  no_log: true
+  tags: authentik
+
+- name: Create the Authentik PostgreSQL application secret
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig_path }}"
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: authentik-postgresql-app
+        namespace: authentik
+      type: kubernetes.io/basic-auth
+      stringData:
+        username: authentik
+        password: "{{ authentik_runtime_values['AUTHENTIK_POSTGRESQL__PASSWORD'] }}"
+  no_log: true
+  tags: authentik
+
+- name: Read the existing Authentik backup secret
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: authentik-offsite-writer
+    namespace: authentik
+    kubeconfig: "{{ kubeconfig_path }}"
+  register: authentik_backup_secret
+  no_log: true
+  tags: authentik
+
+- name: Resolve the Authentik backup credentials
+  ansible.builtin.set_fact:
+    authentik_backup_values:
+      AWS_ACCESS_KEY_ID: >-
+        {{ (existing['AWS_ACCESS_KEY_ID'] | b64decode)
+           if 'AWS_ACCESS_KEY_ID' in existing
+           else lookup('env', 'OFFSITE_BACKUP_WRITER_AWS_ACCESS_KEY_ID') }}
+      AWS_SECRET_ACCESS_KEY: >-
+        {{ (existing['AWS_SECRET_ACCESS_KEY'] | b64decode)
+           if 'AWS_SECRET_ACCESS_KEY' in existing
+           else lookup('env', 'OFFSITE_BACKUP_WRITER_AWS_SECRET_ACCESS_KEY') }}
+      AWS_REGION: >-
+        {{ (existing['AWS_REGION'] | b64decode)
+           if 'AWS_REGION' in existing
+           else lookup('env', 'OFFSITE_BACKUP_AWS_REGION') }}
+  vars:
+    existing: >-
+      {{ authentik_backup_secret.resources[0].data
+         if authentik_backup_secret.resources | length > 0 else {} }}
+  no_log: true
+  tags: authentik
+
+- name: Validate Authentik backup credentials
+  ansible.builtin.assert:
+    that:
+      - authentik_backup_values['AWS_ACCESS_KEY_ID'] | length > 0
+      - authentik_backup_values['AWS_SECRET_ACCESS_KEY'] | length > 0
+      - authentik_backup_values['AWS_REGION'] | length > 0
+    fail_msg: Set the existing OFFSITE_BACKUP writer variables for the first deployment.
+  no_log: true
+  tags: authentik
+
+- name: Create the Authentik backup secret
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig_path }}"
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: authentik-offsite-writer
+        namespace: authentik
+      type: Opaque
+      stringData: "{{ authentik_backup_values }}"
+  no_log: true
+  tags: authentik
+
+- name: Create the Authentik blueprint ConfigMap
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig_path }}"
+    definition:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: authentik-blueprints
+        namespace: authentik
+      data:
+        cluster-sso.yaml: >-
+          {{ lookup('file', playbook_dir + '/argocd/applications/security/authentik/blueprints/cluster-sso.yaml') }}
+  tags: authentik
+
+- name: Create the Grafana SSO and break-glass secret
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig_path }}"
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: grafana-oidc
+        namespace: monitoring
+      type: Opaque
+      stringData:
+        GRAFANA_OIDC_CLIENT_ID: "{{ authentik_runtime_values['GRAFANA_OIDC_CLIENT_ID'] }}"
+        GRAFANA_OIDC_CLIENT_SECRET: "{{ authentik_runtime_values['GRAFANA_OIDC_CLIENT_SECRET'] }}"
+        admin-user: admin
+        admin-password: "{{ authentik_runtime_values['SOYSPRAY_BREAK_GLASS_PASSWORD'] }}"
+  no_log: true
+  tags: authentik
+
+- name: Configure the Argo CD SSO client and local recovery account
+  kubernetes.core.k8s:
+    state: patched
+    kubeconfig: "{{ kubeconfig_path }}"
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: argocd-secret
+        namespace: argocd
+      stringData:
+        oidc.authentik.clientSecret: "{{ authentik_runtime_values['ARGOCD_OIDC_CLIENT_SECRET'] }}"
+        admin.password: "{{ authentik_runtime_values['ARGOCD_ADMIN_PASSWORD_HASH'] }}"
+        admin.passwordMtime: "{{ authentik_runtime_values['ARGOCD_ADMIN_PASSWORD_MTIME'] }}"
+  no_log: true
+  tags: authentik
+
+- name: Apply the Argo CD OIDC configuration
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig_path }}"
+    definition: "{{ lookup('file', playbook_dir + '/argocd/config/' + item) }}"
+  loop:
+    - argocd-cm.yaml
+    - argocd-rbac-cm.yaml
+  tags: authentik
+
+- name: Allow the wildcard certificate in the Authentik namespace
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig_path }}"
+    definition: "{{ lookup('file', playbook_dir + '/argocd/applications/infrastructure/cert-manager/prod-certificate.yaml') }}"
+  tags: authentik
+
+- name: Apply the Authentik PostgreSQL application
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig_path }}"
+    definition: >-
+      {{ lookup('file', playbook_dir + '/argocd/applications/security/authentik/database/authentik-postgresql-application.yaml')
+         | replace('targetRevision: "HEAD"', 'targetRevision: "' + authentik_target_revision + '"') }}
+  tags: authentik
+
+- name: Apply Authentik
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig_path }}"
+    definition: >-
+      {{ lookup('file', playbook_dir + '/argocd/applications/security/authentik/authentik-application.yaml')
+         | replace('targetRevision: "HEAD"', 'targetRevision: "' + authentik_target_revision + '"') }}
+  tags: authentik
+
+- name: Apply Grafana SSO through the Prometheus application
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig_path }}"
+    definition: >-
+      {{ lookup('file', playbook_dir + '/argocd/applications/observability/prometheus/prometheus-application.yaml')
+         | replace('targetRevision: "HEAD"', 'targetRevision: "' + authentik_target_revision + '"') }}
+  tags: authentik

--- a/roles/apps/authentik/tasks/native-apps.yml
+++ b/roles/apps/authentik/tasks/native-apps.yml
@@ -37,6 +37,53 @@
       delay: 5
       changed_when: false
 
+    - name: Reset the Immich administrator password
+      when:
+        - authentik_reset_immich_admin_password | default(false) | bool
+        - not ansible_check_mode
+      no_log: true
+      block:
+        - name: Select the ready Immich server pod
+          kubernetes.core.k8s_info:
+            api_version: v1
+            kind: Pod
+            namespace: immich
+            kubeconfig: "{{ kubeconfig_path }}"
+            label_selectors:
+              - app.kubernetes.io/instance=immich
+              - app.kubernetes.io/name=server
+            field_selectors:
+              - status.phase=Running
+          register: authentik_immich_server_pods
+          until: >-
+            (authentik_immich_server_pods.resources | length == 1)
+            and
+            (authentik_immich_server_pods.resources[0].status.conditions
+            | selectattr('type', 'equalto', 'Ready')
+            | selectattr('status', 'equalto', 'True')
+            | list | length == 1)
+          retries: 30
+          delay: 5
+          changed_when: false
+
+        - name: Reset the Immich administrator password in the server pod
+          kubernetes.core.k8s_exec:
+            kubeconfig: "{{ kubeconfig_path }}"
+            namespace: immich
+            pod: "{{ authentik_immich_server_pods.resources[0].metadata.name }}"
+            container: immich-server
+            command: >-
+              /bin/sh -c 'printf "%s\n" "$1" |
+              /usr/src/app/server/bin/immich-admin reset-admin-password'
+              immich-admin-reset
+              {{ authentik_immich_admin_password | quote }}
+          register: authentik_immich_admin_password_reset
+          failed_when: >-
+            authentik_immich_admin_password_reset.rc != 0
+            or 'The admin password has been updated.' not in
+            authentik_immich_admin_password_reset.stdout
+          changed_when: true
+
     - name: Log in to Immich with the local administrator
       ansible.builtin.uri:
         url: https://immich.soyspray.vip/api/auth/login

--- a/roles/apps/authentik/tasks/native-apps.yml
+++ b/roles/apps/authentik/tasks/native-apps.yml
@@ -1,0 +1,193 @@
+---
+- name: Configure native applications with Authentik
+  when: authentik_configure_native_apps | default(false) | bool
+  no_log: true
+  tags: authentik
+  vars:
+    authentik_immich_admin_email: "{{ lookup('env', 'SOYSPRAY_IMMICH_ADMIN_EMAIL') }}"
+    authentik_immich_admin_password: "{{ lookup('env', 'SOYSPRAY_IMMICH_ADMIN_PASSWORD') }}"
+    authentik_booklore_admin_username: "{{ lookup('env', 'SOYSPRAY_BOOKLORE_ADMIN_USERNAME') }}"
+    authentik_booklore_admin_password: "{{ lookup('env', 'SOYSPRAY_BOOKLORE_ADMIN_PASSWORD') }}"
+  block:
+    - name: Validate native application administrator credentials
+      ansible.builtin.assert:
+        that:
+          - authentik_immich_admin_email | length > 0
+          - authentik_immich_admin_password | length > 0
+          - authentik_booklore_admin_username | length > 0
+          - authentik_booklore_admin_password | length > 0
+          - authentik_runtime_values['IMMICH_OIDC_CLIENT_SECRET'] | length > 0
+        fail_msg: >-
+          Set SOYSPRAY_IMMICH_ADMIN_EMAIL, SOYSPRAY_IMMICH_ADMIN_PASSWORD,
+          SOYSPRAY_BOOKLORE_ADMIN_USERNAME, and SOYSPRAY_BOOKLORE_ADMIN_PASSWORD.
+
+    - name: Wait for native application OIDC discovery
+      ansible.builtin.uri:
+        url: "{{ authentik_native_oidc_discovery_url }}"
+        method: GET
+        status_code: 200
+      loop:
+        - https://auth.soyspray.vip/application/o/immich/.well-known/openid-configuration
+        - https://auth.soyspray.vip/application/o/booklore/.well-known/openid-configuration
+      loop_control:
+        loop_var: authentik_native_oidc_discovery_url
+      register: authentik_native_oidc_discovery
+      until: authentik_native_oidc_discovery.status == 200
+      retries: 30
+      delay: 5
+      changed_when: false
+
+    - name: Log in to Immich with the local administrator
+      ansible.builtin.uri:
+        url: https://immich.soyspray.vip/api/auth/login
+        method: POST
+        body_format: json
+        body:
+          email: "{{ authentik_immich_admin_email }}"
+          password: "{{ authentik_immich_admin_password }}"
+        status_code: 200
+      register: authentik_immich_admin_login
+      changed_when: false
+
+    - name: Read the full current Immich configuration
+      ansible.builtin.uri:
+        url: https://immich.soyspray.vip/api/system-config
+        method: GET
+        headers:
+          Authorization: "Bearer {{ authentik_immich_admin_login.json.accessToken }}"
+        status_code: 200
+      register: authentik_immich_current_config
+      changed_when: false
+
+    - name: Define the Immich SSO configuration
+      ansible.builtin.set_fact:
+        authentik_immich_oauth_sso:
+          autoLaunch: false
+          autoRegister: false
+          buttonText: Login with SSO
+          clientId: immich
+          clientSecret: "{{ authentik_runtime_values['IMMICH_OIDC_CLIENT_SECRET'] }}"
+          enabled: true
+          issuerUrl: https://auth.soyspray.vip/application/o/immich/
+          mobileOverrideEnabled: false
+          scope: openid email profile
+          tokenEndpointAuthMethod: client_secret_post
+        authentik_immich_password_login_sso:
+          enabled: true
+
+    - name: Build the full Immich SSO configuration
+      ansible.builtin.set_fact:
+        authentik_immich_sso_config: >-
+          {{
+            authentik_immich_current_config.json
+            | combine(
+                {
+                  'oauth': authentik_immich_current_config.json['oauth']
+                    | combine(authentik_immich_oauth_sso),
+                  'passwordLogin': authentik_immich_current_config.json['passwordLogin']
+                    | combine(authentik_immich_password_login_sso)
+                },
+                recursive=true
+              )
+          }}
+
+    - name: Update the full Immich configuration
+      ansible.builtin.uri:
+        url: https://immich.soyspray.vip/api/system-config
+        method: PUT
+        headers:
+          Authorization: "Bearer {{ authentik_immich_admin_login.json.accessToken }}"
+        body_format: json
+        body: "{{ authentik_immich_sso_config }}"
+        status_code: 200
+      when: authentik_immich_current_config.json != authentik_immich_sso_config
+
+    - name: Log in to BookLore with the local administrator
+      ansible.builtin.uri:
+        url: https://booklore.soyspray.vip/api/v1/auth/login
+        method: POST
+        body_format: json
+        body:
+          username: "{{ authentik_booklore_admin_username }}"
+          password: "{{ authentik_booklore_admin_password }}"
+        status_code: 200
+      register: authentik_booklore_admin_login
+      changed_when: false
+
+    - name: Read the full current BookLore configuration
+      ansible.builtin.uri:
+        url: https://booklore.soyspray.vip/api/v1/settings
+        method: GET
+        headers:
+          Authorization: "Bearer {{ authentik_booklore_admin_login.json.accessToken }}"
+        status_code: 200
+      register: authentik_booklore_current_settings
+      changed_when: false
+
+    - name: Define the BookLore SSO configuration
+      ansible.builtin.set_fact:
+        authentik_booklore_oidc_provider:
+          providerName: Authentik
+          clientId: booklore
+          clientSecret: ''
+          issuerUri: https://auth.soyspray.vip/application/o/booklore/
+          scopes: openid profile email offline_access
+          claimMapping:
+            username: preferred_username
+            name: name
+            email: email
+            groups: groups
+        authentik_booklore_oidc_auto_provision:
+          enableAutoProvisioning: false
+          allowLocalAccountLinking: true
+          defaultPermissions: []
+          defaultLibraryIds: []
+
+    - name: Check the current BookLore SSO configuration
+      vars:
+        authentik_booklore_current_provider: >-
+          {{ authentik_booklore_current_settings.json.get('oidcProviderDetails') or {} }}
+        authentik_booklore_current_provision: >-
+          {{ authentik_booklore_current_settings.json.get('oidcAutoProvisionDetails') or {} }}
+      ansible.builtin.set_fact:
+        authentik_booklore_sso_is_current: >-
+          {{
+            authentik_booklore_current_settings.json.get('oidcEnabled', false)
+            and not authentik_booklore_current_settings.json.get('oidcForceOnlyMode', false)
+            and authentik_booklore_current_provider.get('providerName')
+              == authentik_booklore_oidc_provider['providerName']
+            and authentik_booklore_current_provider.get('clientId')
+              == authentik_booklore_oidc_provider['clientId']
+            and (authentik_booklore_current_provider.get('clientSecret') or '') == ''
+            and authentik_booklore_current_provider.get('issuerUri')
+              == authentik_booklore_oidc_provider['issuerUri']
+            and authentik_booklore_current_provider.get('scopes')
+              == authentik_booklore_oidc_provider['scopes']
+            and authentik_booklore_current_provider.get('claimMapping')
+              == authentik_booklore_oidc_provider['claimMapping']
+            and not authentik_booklore_current_provision.get('enableAutoProvisioning', false)
+            and authentik_booklore_current_provision.get('allowLocalAccountLinking', false)
+            and authentik_booklore_current_settings.json.get('oidcGroupSyncMode')
+              == 'ON_LOGIN_ADDITIVE'
+          }}
+
+    - name: Update BookLore SSO settings
+      ansible.builtin.uri:
+        url: https://booklore.soyspray.vip/api/v1/settings
+        method: PUT
+        headers:
+          Authorization: "Bearer {{ authentik_booklore_admin_login.json.accessToken }}"
+        body_format: json
+        body:
+          - name: OIDC_PROVIDER_DETAILS
+            value: "{{ authentik_booklore_oidc_provider }}"
+          - name: OIDC_AUTO_PROVISION_DETAILS
+            value: "{{ authentik_booklore_oidc_auto_provision }}"
+          - name: OIDC_FORCE_ONLY_MODE
+            value: false
+          - name: OIDC_GROUP_SYNC_MODE
+            value: ON_LOGIN_ADDITIVE
+          - name: OIDC_ENABLED
+            value: true
+        status_code: 200
+      when: not authentik_booklore_sso_is_current

--- a/roles/apps/authentik/tasks/native-apps.yml
+++ b/roles/apps/authentik/tasks/native-apps.yml
@@ -92,7 +92,7 @@
         body:
           email: "{{ authentik_immich_admin_email }}"
           password: "{{ authentik_immich_admin_password }}"
-        status_code: 200
+        status_code: 201
       register: authentik_immich_admin_login
       changed_when: false
 

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -92,3 +92,12 @@ def test_prometheus_application_returns_to_the_reviewed_head_revision() -> None:
     )
 
     assert app["spec"]["source"]["targetRevision"] == "HEAD"
+    assert app["spec"]["source"]["kustomize"] == {}
+    assert "retry" not in app["spec"]["syncPolicy"]["automated"]
+    assert app["spec"]["syncPolicy"]["retry"]["limit"] == 5
+
+
+def test_authentik_role_does_not_reuse_the_parent_loop_variable() -> None:
+    tasks = (ROOT / "roles/apps/authentik/tasks/main.yml").read_text()
+
+    assert "loop_var: argocd_config_file" in tasks

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -48,7 +48,9 @@ def test_authentik_blueprint_reads_credentials_from_environment() -> None:
     assert "!Env GRAFANA_OIDC_CLIENT_SECRET" in blueprint
     assert "client_secret:" not in blueprint.replace(
         "client_secret: !Env ARGOCD_OIDC_CLIENT_SECRET", ""
-    ).replace("client_secret: !Env GRAFANA_OIDC_CLIENT_SECRET", "")
+    ).replace("client_secret: !Env GRAFANA_OIDC_CLIENT_SECRET", "").replace(
+        "client_secret: !Env HEADLAMP_OIDC_CLIENT_SECRET", ""
+    )
 
 
 def test_authentik_role_preserves_generated_secrets() -> None:

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -70,6 +70,7 @@ def test_argocd_uses_authentik_oidc_and_keeps_local_admin() -> None:
 
     assert "auth.soyspray.vip" in config["oidc.config"]
     assert "$oidc.authentik.clientSecret" in config["oidc.config"]
+    assert config["oidc.tls.insecure.skip.verify"] == "true"
     assert config.get("admin.enabled", "true") == "true"
     assert "cluster-admins" in rbac["policy.csv"]
     assert rbac["policy.default"] == "role:readonly"

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -76,6 +76,13 @@ def test_argocd_uses_authentik_oidc_and_keeps_local_admin() -> None:
     assert rbac["policy.default"] == "role:readonly"
 
 
+def test_argocd_restarts_when_the_oidc_config_changes() -> None:
+    tasks = (ROOT / "roles/apps/authentik/tasks/main.yml").read_text()
+
+    assert "soyspray.vip/oidc-config-hash" in tasks
+    assert "argocd/config/argocd-cm.yaml') | hash('sha256')" in tasks
+
+
 def test_grafana_uses_authentik_and_disables_anonymous_access() -> None:
     values = load_yaml("playbooks/argocd/applications/observability/prometheus/values.yaml")
     grafana = values["grafana"]

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from conftest import ROOT, load_all, load_yaml
+
+AUTHENTIK_DIR = ROOT / "playbooks/argocd/applications/security/authentik"
+
+
+def test_authentik_uses_pinned_official_chart_and_external_database() -> None:
+    app = load_yaml("playbooks/argocd/applications/security/authentik/authentik-application.yaml")
+    chart = app["spec"]["sources"][0]
+    values = load_yaml("playbooks/argocd/applications/security/authentik/values.yaml")
+
+    assert chart["repoURL"] == "https://charts.goauthentik.io"
+    assert chart["chart"] == "authentik"
+    assert chart["targetRevision"] == "2026.5.6"
+    assert app["spec"]["destination"]["namespace"] == "authentik"
+    assert app["spec"]["syncPolicy"]["automated"] == {
+        "prune": True,
+        "selfHeal": True,
+    }
+    assert values["postgresql"]["enabled"] is False
+    assert values["authentik"]["existingSecret"]["secretName"] == "authentik-runtime"
+    assert values["blueprints"]["configMaps"] == ["authentik-blueprints"]
+
+
+def test_authentik_database_is_dedicated_and_monitored() -> None:
+    resources = load_all("playbooks/argocd/applications/security/authentik/database/cluster.yaml")
+    cluster = next(item for item in resources if item["kind"] == "Cluster")
+
+    assert cluster["metadata"]["name"] == "authentik-postgresql"
+    assert cluster["metadata"]["namespace"] == "authentik"
+    assert cluster["spec"]["instances"] >= 2
+    assert cluster["spec"]["monitoring"]["enablePodMonitor"] is True
+    assert cluster["spec"]["storage"]["storageClass"] == "longhorn"
+
+
+def test_authentik_blueprint_reads_credentials_from_environment() -> None:
+    blueprint = (AUTHENTIK_DIR / "blueprints/cluster-sso.yaml").read_text()
+
+    assert "model: authentik_core.user" in blueprint
+    assert "username: boris" in blueprint
+    assert "cluster-admins" in blueprint
+    assert "model: authentik_providers_oauth2.oauth2provider" in blueprint
+    assert "model: authentik_core.application" in blueprint
+    assert blueprint.count("model: authentik_blueprints.metaapplyblueprint") >= 4
+    assert "!Env SSO_PASSWORD" in blueprint
+    assert "!Env ARGOCD_OIDC_CLIENT_SECRET" in blueprint
+    assert "!Env GRAFANA_OIDC_CLIENT_SECRET" in blueprint
+    assert "client_secret:" not in blueprint.replace(
+        "client_secret: !Env ARGOCD_OIDC_CLIENT_SECRET", ""
+    ).replace("client_secret: !Env GRAFANA_OIDC_CLIENT_SECRET", "")
+
+
+def test_authentik_role_preserves_generated_secrets() -> None:
+    tasks = (ROOT / "roles/apps/authentik/tasks/main.yml").read_text()
+
+    assert "kubernetes.core.k8s_info" in tasks
+    assert "authentik-runtime" in tasks
+    assert "no_log: true" in tasks
+    assert "lookup('password'" in tasks
+    assert "state: present" in tasks
+    assert "authentik-application.yaml" in tasks
+
+
+def test_argocd_uses_authentik_oidc_and_keeps_local_admin() -> None:
+    config = load_yaml("playbooks/argocd/config/argocd-cm.yaml")["data"]
+    rbac = load_yaml("playbooks/argocd/config/argocd-rbac-cm.yaml")["data"]
+
+    assert "auth.soyspray.vip" in config["oidc.config"]
+    assert "$oidc.authentik.clientSecret" in config["oidc.config"]
+    assert config.get("admin.enabled", "true") == "true"
+    assert "cluster-admins" in rbac["policy.csv"]
+    assert rbac["policy.default"] == "role:readonly"
+
+
+def test_grafana_uses_authentik_and_disables_anonymous_access() -> None:
+    values = load_yaml("playbooks/argocd/applications/observability/prometheus/values.yaml")
+    grafana = values["grafana"]
+    oauth = grafana["grafana.ini"]["auth.generic_oauth"]
+
+    assert grafana["grafana.ini"]["auth.anonymous"]["enabled"] is False
+    assert grafana["envFromSecret"] == "grafana-oidc"
+    assert oauth["enabled"] is True
+    assert oauth["auth_url"].startswith("https://auth.soyspray.vip/application/o/authorize/")
+    assert oauth["client_secret"] == "$__env{GRAFANA_OIDC_CLIENT_SECRET}"
+    assert "cluster-admins" in oauth["role_attribute_path"]
+
+
+def test_prometheus_application_returns_to_the_reviewed_head_revision() -> None:
+    app = load_yaml(
+        "playbooks/argocd/applications/observability/prometheus/prometheus-application.yaml"
+    )
+
+    assert app["spec"]["source"]["targetRevision"] == "HEAD"

--- a/tests/test_sso_headlamp.py
+++ b/tests/test_sso_headlamp.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from conftest import ROOT, load_yaml
+
+
+def test_headlamp_uses_an_external_oidc_secret_and_group_rbac() -> None:
+    values = load_yaml(
+        "playbooks/argocd/applications/infrastructure/headlamp/values.yaml"
+    )
+
+    assert values["config"]["oidc"]["secret"]["create"] is False
+    assert values["config"]["oidc"]["externalSecret"] == {
+        "enabled": True,
+        "name": "headlamp-oidc",
+    }
+
+    manifests = "\n".join(values["extraManifests"])
+    assert "kind: ClusterRoleBinding" in manifests
+    assert "name: oidc:cluster-admins" in manifests
+    assert "name: cluster-admin" in manifests
+
+
+def test_authentik_restarts_when_runtime_oidc_clients_change() -> None:
+    values = load_yaml(
+        "playbooks/argocd/applications/security/authentik/values.yaml"
+    )
+
+    expected = {"soyspray.vip/runtime-secret-revision": "2026-08-09-1"}
+    assert values["server"]["podAnnotations"] == expected
+    assert values["worker"]["podAnnotations"] == expected
+
+
+def test_authentik_has_a_headlamp_oidc_client() -> None:
+    blueprint = (
+        ROOT
+        / "playbooks/argocd/applications/security/authentik/blueprints/cluster-sso.yaml"
+    ).read_text()
+
+    assert "id: headlamp-provider" in blueprint
+    assert "client_id: headlamp" in blueprint
+    assert "client_secret: !Env HEADLAMP_OIDC_CLIENT_SECRET" in blueprint
+    assert "url: https://headlamp.soyspray.vip/oidc-callback" in blueprint
+    assert "slug: headlamp" in blueprint
+
+
+def test_kubernetes_oidc_flags_match_the_headlamp_provider() -> None:
+    variables = load_yaml(
+        "playbooks/operations/security/kubernetes-authentik-oidc-vars.yml"
+    )
+
+    assert variables == {
+        "kube_oidc_auth": True,
+        "kube_oidc_url": "https://auth.soyspray.vip/application/o/headlamp/",
+        "kube_oidc_client_id": "headlamp",
+        "kube_oidc_username_claim": "preferred_username",
+        "kube_oidc_username_prefix": "oidc:",
+        "kube_oidc_groups_claim": "groups",
+        "kube_oidc_groups_prefix": "oidc:",
+    }
+
+
+def test_authentik_role_creates_and_deploys_headlamp_oidc() -> None:
+    tasks = (ROOT / "roles/apps/authentik/tasks/main.yml").read_text()
+
+    assert "HEADLAMP_OIDC_CLIENT_SECRET" in tasks
+    assert "name: headlamp-oidc" in tasks
+    assert "OIDC_ISSUER_URL" in tasks
+    assert "headlamp-application.yaml" in tasks
+    assert "authentik_target_revision" in tasks

--- a/tests/test_sso_headlamp.py
+++ b/tests/test_sso_headlamp.py
@@ -49,6 +49,7 @@ def test_kubernetes_oidc_flags_match_the_headlamp_provider() -> None:
         "kube_oidc_username_prefix": "oidc:",
         "kube_oidc_groups_claim": "groups",
         "kube_oidc_groups_prefix": "oidc:",
+        "dns_etchosts": "192.168.20.20 auth.soyspray.vip\n",
     }
 
 

--- a/tests/test_sso_headlamp.py
+++ b/tests/test_sso_headlamp.py
@@ -21,7 +21,7 @@ def test_headlamp_uses_an_external_oidc_secret_and_group_rbac() -> None:
 def test_authentik_restarts_when_runtime_oidc_clients_change() -> None:
     values = load_yaml("playbooks/argocd/applications/security/authentik/values.yaml")
 
-    expected = {"soyspray.vip/runtime-secret-revision": "2026-08-09-2"}
+    expected = {"soyspray.vip/runtime-secret-revision": "2026-08-09-3"}
     assert values["server"]["podAnnotations"] == expected
     assert values["worker"]["podAnnotations"] == expected
 

--- a/tests/test_sso_headlamp.py
+++ b/tests/test_sso_headlamp.py
@@ -42,6 +42,7 @@ def test_kubernetes_oidc_flags_match_the_headlamp_provider() -> None:
     variables = load_yaml("playbooks/operations/security/kubernetes-authentik-oidc-vars.yml")
 
     assert variables == {
+        "upgrade_cluster_setup": True,
         "kube_oidc_auth": True,
         "kube_oidc_url": "https://auth.soyspray.vip/application/o/headlamp/",
         "kube_oidc_client_id": "headlamp",

--- a/tests/test_sso_headlamp.py
+++ b/tests/test_sso_headlamp.py
@@ -4,9 +4,7 @@ from conftest import ROOT, load_yaml
 
 
 def test_headlamp_uses_an_external_oidc_secret_and_group_rbac() -> None:
-    values = load_yaml(
-        "playbooks/argocd/applications/infrastructure/headlamp/values.yaml"
-    )
+    values = load_yaml("playbooks/argocd/applications/infrastructure/headlamp/values.yaml")
 
     assert values["config"]["oidc"]["secret"]["create"] is False
     assert values["config"]["oidc"]["externalSecret"] == {
@@ -21,9 +19,7 @@ def test_headlamp_uses_an_external_oidc_secret_and_group_rbac() -> None:
 
 
 def test_authentik_restarts_when_runtime_oidc_clients_change() -> None:
-    values = load_yaml(
-        "playbooks/argocd/applications/security/authentik/values.yaml"
-    )
+    values = load_yaml("playbooks/argocd/applications/security/authentik/values.yaml")
 
     expected = {"soyspray.vip/runtime-secret-revision": "2026-08-09-1"}
     assert values["server"]["podAnnotations"] == expected
@@ -32,8 +28,7 @@ def test_authentik_restarts_when_runtime_oidc_clients_change() -> None:
 
 def test_authentik_has_a_headlamp_oidc_client() -> None:
     blueprint = (
-        ROOT
-        / "playbooks/argocd/applications/security/authentik/blueprints/cluster-sso.yaml"
+        ROOT / "playbooks/argocd/applications/security/authentik/blueprints/cluster-sso.yaml"
     ).read_text()
 
     assert "id: headlamp-provider" in blueprint
@@ -44,9 +39,7 @@ def test_authentik_has_a_headlamp_oidc_client() -> None:
 
 
 def test_kubernetes_oidc_flags_match_the_headlamp_provider() -> None:
-    variables = load_yaml(
-        "playbooks/operations/security/kubernetes-authentik-oidc-vars.yml"
-    )
+    variables = load_yaml("playbooks/operations/security/kubernetes-authentik-oidc-vars.yml")
 
     assert variables == {
         "kube_oidc_auth": True,

--- a/tests/test_sso_headlamp.py
+++ b/tests/test_sso_headlamp.py
@@ -21,7 +21,7 @@ def test_headlamp_uses_an_external_oidc_secret_and_group_rbac() -> None:
 def test_authentik_restarts_when_runtime_oidc_clients_change() -> None:
     values = load_yaml("playbooks/argocd/applications/security/authentik/values.yaml")
 
-    expected = {"soyspray.vip/runtime-secret-revision": "2026-08-09-1"}
+    expected = {"soyspray.vip/runtime-secret-revision": "2026-08-09-2"}
     assert values["server"]["podAnnotations"] == expected
     assert values["worker"]["podAnnotations"] == expected
 

--- a/tests/test_sso_headlamp.py
+++ b/tests/test_sso_headlamp.py
@@ -50,7 +50,6 @@ def test_kubernetes_oidc_flags_match_the_headlamp_provider() -> None:
         "kube_oidc_username_prefix": "oidc:",
         "kube_oidc_groups_claim": "groups",
         "kube_oidc_groups_prefix": "oidc:",
-        "dns_etchosts": "192.168.20.20 auth.soyspray.vip\n",
     }
 
 

--- a/tests/test_sso_legacy_proxy.py
+++ b/tests/test_sso_legacy_proxy.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import yaml
+from conftest import ROOT, load_all, load_yaml
+
+BLUEPRINT = ROOT / (
+    "playbooks/argocd/applications/security/authentik/blueprints/legacy-forward-auth.yaml"
+)
+
+APPLICATIONS = {
+    "longhorn": {
+        "directory": "playbooks/argocd/applications/infrastructure/longhorn",
+        "host": "longhorn.soyspray.vip",
+        "namespace": "longhorn-system",
+        "config_map": "auth-proxy-set-headers-longhorn",
+        "service": "authentik-server-longhorn",
+    },
+    "prometheus": {
+        "directory": "playbooks/argocd/applications/observability/prometheus",
+        "host": "prometheus.soyspray.vip",
+        "namespace": "monitoring",
+        "config_map": "auth-proxy-set-headers-prometheus",
+        "service": "authentik-server-prometheus",
+    },
+    "zigbee2mqtt": {
+        "directory": "playbooks/argocd/applications/home-automation/zigbee2mqtt",
+        "host": "zigbee2mqtt.soyspray.vip",
+        "namespace": "home-automation",
+        "config_map": "auth-proxy-set-headers-zigbee2mqtt",
+        "service": "authentik-server-zigbee2mqtt",
+    },
+    "lazylibrarian": {
+        "directory": "playbooks/argocd/applications/media/lazylibrarian",
+        "host": "lazylibrarian.soyspray.vip",
+        "namespace": "media",
+        "config_map": "auth-proxy-set-headers-lazylibrarian",
+        "service": "authentik-server-lazylibrarian",
+    },
+    "qbittorrent": {
+        "directory": "playbooks/argocd/applications/media/qbittorrent",
+        "host": "torrent.soyspray.vip",
+        "namespace": "media",
+        "config_map": "auth-proxy-set-headers-qbittorrent",
+        "service": "authentik-server-qbittorrent",
+    },
+}
+
+AUTH_ANNOTATIONS = {
+    "nginx.ingress.kubernetes.io/auth-url",
+    "nginx.ingress.kubernetes.io/auth-signin",
+    "nginx.ingress.kubernetes.io/auth-response-headers",
+    "nginx.ingress.kubernetes.io/auth-proxy-set-headers",
+}
+
+
+def _blueprint_entries() -> list[dict]:
+    class BlueprintLoader(yaml.SafeLoader):
+        pass
+
+    def construct_tagged(loader: BlueprintLoader, _suffix: str, node: yaml.Node):
+        if isinstance(node, yaml.ScalarNode):
+            return loader.construct_scalar(node)
+        if isinstance(node, yaml.SequenceNode):
+            return loader.construct_sequence(node)
+        return loader.construct_mapping(node)
+
+    BlueprintLoader.add_multi_constructor("!", construct_tagged)
+    return yaml.load(BLUEPRINT.read_text(), Loader=BlueprintLoader)["entries"]
+
+
+def _ingress_annotations(name: str) -> dict[str, str]:
+    if name == "longhorn":
+        return load_yaml(f"{APPLICATIONS[name]['directory']}/values.yaml")["ingress"]["annotations"]
+    if name == "prometheus":
+        return load_yaml(f"{APPLICATIONS[name]['directory']}/values.yaml")["prometheus"]["ingress"][
+            "annotations"
+        ]
+    return load_yaml(f"{APPLICATIONS[name]['directory']}/ingress.yaml")["metadata"]["annotations"]
+
+
+def test_blueprint_has_five_bound_single_application_proxy_providers() -> None:
+    entries = _blueprint_entries()
+    providers = [
+        item for item in entries if item["model"] == "authentik_providers_proxy.proxyprovider"
+    ]
+    applications = [item for item in entries if item["model"] == "authentik_core.application"]
+    bindings = [item for item in entries if item["model"] == "authentik_policies.policybinding"]
+    outposts = [item for item in entries if item["model"] == "authentik_outposts.outpost"]
+
+    assert len(providers) == 5
+    assert {item["attrs"]["external_host"] for item in providers} == {
+        f"https://{settings['host']}" for settings in APPLICATIONS.values()
+    }
+    assert {item["attrs"]["mode"] for item in providers} == {"forward_single"}
+    assert len(applications) == 5
+    assert len(bindings) == 5
+    assert all(
+        item["attrs"]["group"] == ["authentik_core.group", ["name", "cluster-admins"]]
+        for item in bindings
+    )
+    assert len(outposts) == 1
+    assert outposts[0]["identifiers"]["managed"] == "goauthentik.io/outposts/embedded"
+    assert len(outposts[0]["attrs"]["providers"]) == 5
+
+
+def test_blueprint_preserves_native_machine_api_paths() -> None:
+    entries = _blueprint_entries()
+    providers = {
+        item["id"]: item["attrs"]
+        for item in entries
+        if item["model"] == "authentik_providers_proxy.proxyprovider"
+    }
+
+    assert providers["lazylibrarian-proxy-provider"]["skip_path_regex"] == (
+        r"^/(api|opds|rss_feed)(/|$)|^/nzbfile\.nzb(/|$)"
+    )
+    assert providers["qbittorrent-proxy-provider"]["skip_path_regex"] == r"^/api/v2(/|$)"
+    assert all(
+        "skip_path_regex" not in providers[f"{name}-proxy-provider"]
+        for name in ("longhorn", "prometheus", "zigbee2mqtt")
+    )
+
+
+def test_each_web_ingress_uses_authentik_forward_auth() -> None:
+    response_headers = {
+        "Set-Cookie",
+        "X-authentik-username",
+        "X-authentik-groups",
+        "X-authentik-entitlements",
+        "X-authentik-email",
+        "X-authentik-name",
+        "X-authentik-uid",
+    }
+
+    for name, settings in APPLICATIONS.items():
+        annotations = _ingress_annotations(name)
+
+        assert AUTH_ANNOTATIONS <= annotations.keys()
+        assert annotations["nginx.ingress.kubernetes.io/auth-url"] == (
+            "http://authentik-server.authentik.svc.cluster.local/outpost.goauthentik.io/auth/nginx"
+        )
+        assert annotations["nginx.ingress.kubernetes.io/auth-signin"] == (
+            f"https://{settings['host']}/outpost.goauthentik.io/start?"
+            "rd=$scheme://$http_host$escaped_request_uri"
+        )
+        assert (
+            set(annotations["nginx.ingress.kubernetes.io/auth-response-headers"].split(","))
+            == response_headers
+        )
+        assert annotations["nginx.ingress.kubernetes.io/auth-proxy-set-headers"] == (
+            f"{settings['namespace']}/{settings['config_map']}"
+        )
+
+
+def test_each_application_owns_its_outpost_route_and_namespace_support() -> None:
+    for settings in APPLICATIONS.values():
+        directory = Path(settings["directory"])
+        resources = load_all(f"{directory}/authentik-forward-auth.yaml")
+        by_kind = {item["kind"]: item for item in resources}
+        kustomization = load_yaml(f"{directory}/kustomization.yaml")
+
+        assert "authentik-forward-auth.yaml" in kustomization["resources"]
+        assert by_kind["ConfigMap"]["metadata"]["name"] == settings["config_map"]
+        assert by_kind["ConfigMap"]["data"]["X-Forwarded-Host"] == "$http_host"
+        assert by_kind["Service"]["metadata"]["name"] == settings["service"]
+        assert by_kind["Service"]["spec"] == {
+            "type": "ExternalName",
+            "externalName": "authentik-server.authentik.svc.cluster.local",
+            "ports": [
+                {
+                    "name": "http",
+                    "port": 80,
+                    "protocol": "TCP",
+                    "targetPort": 80,
+                }
+            ],
+        }
+
+        ingress = by_kind["Ingress"]
+        assert not (AUTH_ANNOTATIONS & ingress["metadata"].get("annotations", {}).keys())
+        rule = ingress["spec"]["rules"][0]
+        assert rule["host"] == settings["host"]
+        path = rule["http"]["paths"][0]
+        assert path["path"] == "/outpost.goauthentik.io"
+        assert path["pathType"] == "Prefix"
+        assert path["backend"]["service"]["name"] == settings["service"]
+        assert path["backend"]["service"]["port"]["number"] == 80
+
+
+def test_external_name_services_render_without_application_selectors() -> None:
+    for name in ("zigbee2mqtt", "qbittorrent"):
+        settings = APPLICATIONS[name]
+        result = subprocess.run(
+            ["kubectl", "kustomize", settings["directory"]],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        resources = [item for item in yaml.safe_load_all(result.stdout) if item]
+        service = next(
+            item
+            for item in resources
+            if item["kind"] == "Service" and item["metadata"]["name"] == settings["service"]
+        )
+
+        assert "selector" not in service["spec"]
+
+
+def test_prometheus_and_qbittorrent_have_no_direct_web_load_balancer_bypass() -> None:
+    prometheus = load_yaml("playbooks/argocd/applications/observability/prometheus/values.yaml")[
+        "prometheus"
+    ]["service"]
+    qbittorrent = load_yaml("playbooks/argocd/applications/media/qbittorrent/service.yaml")["spec"]
+
+    assert prometheus == {"type": "ClusterIP"}
+    assert qbittorrent["type"] == "ClusterIP"
+    assert "loadBalancerIP" not in qbittorrent
+
+
+def test_authentik_role_mounts_and_deploys_legacy_proxy_configuration() -> None:
+    tasks = (ROOT / "roles/apps/authentik/tasks/main.yml").read_text()
+
+    assert "legacy-forward-auth.yaml" in tasks
+    for manifest in (
+        "longhorn-application.yaml",
+        "zigbee2mqtt-application.yaml",
+        "lazylibrarian-application.yaml",
+        "qbittorrent-application.yaml",
+    ):
+        assert manifest in tasks
+    assert tasks.count("authentik_target_revision") >= 6
+    assert "loop_var: authentik_legacy_application" in tasks

--- a/tests/test_sso_legacy_proxy.py
+++ b/tests/test_sso_legacy_proxy.py
@@ -217,6 +217,17 @@ def test_external_name_services_render_without_application_selectors() -> None:
         assert "selector" not in service["spec"]
 
 
+def test_zigbee2mqtt_keeps_its_live_immutable_selector() -> None:
+    deployment = load_yaml(
+        "playbooks/argocd/applications/home-automation/zigbee2mqtt/deployment.yaml"
+    )
+    selector = deployment["spec"]["selector"]["matchLabels"]
+    pod_labels = deployment["spec"]["template"]["metadata"]["labels"]
+
+    assert selector == {"app": "zigbee2mqtt", "managed-by": "argocd"}
+    assert selector.items() <= pod_labels.items()
+
+
 def test_prometheus_and_qbittorrent_have_no_direct_web_load_balancer_bypass() -> None:
     prometheus = load_yaml("playbooks/argocd/applications/observability/prometheus/values.yaml")[
         "prometheus"

--- a/tests/test_sso_legacy_proxy.py
+++ b/tests/test_sso_legacy_proxy.py
@@ -110,8 +110,7 @@ def test_blueprint_has_five_bound_single_application_proxy_providers() -> None:
     assert outposts[0]["identifiers"]["managed"] == "goauthentik.io/outposts/embedded"
     assert len(outposts[0]["attrs"]["providers"]) == 5
     assert outposts[0]["attrs"]["config"] == {
-        "authentik_host": "http://localhost:9000",
-        "authentik_host_browser": "https://auth.soyspray.vip",
+        "authentik_host": "https://auth.soyspray.vip",
     }
     assert "Soyspray cluster SSO" in dependencies
     assert "System - Proxy Provider - Scopes" in dependencies

--- a/tests/test_sso_legacy_proxy.py
+++ b/tests/test_sso_legacy_proxy.py
@@ -83,6 +83,11 @@ def _ingress_annotations(name: str) -> dict[str, str]:
 
 def test_blueprint_has_five_bound_single_application_proxy_providers() -> None:
     entries = _blueprint_entries()
+    dependencies = {
+        item["attrs"]["identifiers"]["name"]
+        for item in entries
+        if item["model"] == "authentik_blueprints.metaapplyblueprint"
+    }
     providers = [
         item for item in entries if item["model"] == "authentik_providers_proxy.proxyprovider"
     ]
@@ -104,6 +109,8 @@ def test_blueprint_has_five_bound_single_application_proxy_providers() -> None:
     assert len(outposts) == 1
     assert outposts[0]["identifiers"]["managed"] == "goauthentik.io/outposts/embedded"
     assert len(outposts[0]["attrs"]["providers"]) == 5
+    assert "Soyspray cluster SSO" in dependencies
+    assert "System - Proxy Provider - Scopes" in dependencies
 
 
 def test_blueprint_preserves_native_machine_api_paths() -> None:

--- a/tests/test_sso_legacy_proxy.py
+++ b/tests/test_sso_legacy_proxy.py
@@ -110,7 +110,7 @@ def test_blueprint_has_five_bound_single_application_proxy_providers() -> None:
     assert outposts[0]["identifiers"]["managed"] == "goauthentik.io/outposts/embedded"
     assert len(outposts[0]["attrs"]["providers"]) == 5
     assert outposts[0]["attrs"]["config"] == {
-        "authentik_host": "https://auth.soyspray.vip",
+        "authentik_host": "http://localhost:9000",
         "authentik_host_browser": "https://auth.soyspray.vip",
     }
     assert "Soyspray cluster SSO" in dependencies

--- a/tests/test_sso_legacy_proxy.py
+++ b/tests/test_sso_legacy_proxy.py
@@ -109,6 +109,10 @@ def test_blueprint_has_five_bound_single_application_proxy_providers() -> None:
     assert len(outposts) == 1
     assert outposts[0]["identifiers"]["managed"] == "goauthentik.io/outposts/embedded"
     assert len(outposts[0]["attrs"]["providers"]) == 5
+    assert outposts[0]["attrs"]["config"] == {
+        "authentik_host": "https://auth.soyspray.vip",
+        "authentik_host_browser": "https://auth.soyspray.vip",
+    }
     assert "Soyspray cluster SSO" in dependencies
     assert "System - Proxy Provider - Scopes" in dependencies
 

--- a/tests/test_sso_native_apps.py
+++ b/tests/test_sso_native_apps.py
@@ -145,6 +145,50 @@ def test_native_app_tasks_keep_local_accounts_and_link_existing_users() -> None:
     assert "ON_LOGIN_ADDITIVE" in tasks
 
 
+def test_immich_admin_password_reset_is_explicit_and_private() -> None:
+    document = yaml.safe_load(TASKS.read_text())
+    configure = document[0]
+    reset = next(
+        task
+        for task in configure["block"]
+        if task["name"] == "Reset the Immich administrator password"
+    )
+    query, execute = reset["block"]
+
+    assert reset["when"] == [
+        "authentik_reset_immich_admin_password | default(false) | bool",
+        "not ansible_check_mode",
+    ]
+    assert reset["no_log"] is True
+
+    info = query["kubernetes.core.k8s_info"]
+    assert info["kind"] == "Pod"
+    assert info["namespace"] == "immich"
+    assert info["label_selectors"] == [
+        "app.kubernetes.io/instance=immich",
+        "app.kubernetes.io/name=server",
+    ]
+    assert info["field_selectors"] == ["status.phase=Running"]
+    assert "resources | length == 1" in query["until"]
+    assert "'Ready'" in query["until"]
+    assert query["changed_when"] is False
+
+    run = execute["kubernetes.core.k8s_exec"]
+    assert run["container"] == "immich-server"
+    assert "authentik_immich_server_pods.resources[0].metadata.name" in run["pod"]
+    assert "/usr/src/app/server/bin/immich-admin reset-admin-password" in run["command"]
+    assert '"$1"' in run["command"]
+    assert "authentik_immich_admin_password | quote" in run["command"]
+    assert execute["changed_when"] is True
+    assert "rc != 0" in execute["failed_when"]
+    assert "The admin password has been updated." in execute["failed_when"]
+
+    names = [task["name"] for task in configure["block"]]
+    assert names.index("Reset the Immich administrator password") < names.index(
+        "Log in to Immich with the local administrator"
+    )
+
+
 def test_authentik_role_mounts_and_runs_native_app_configuration() -> None:
     tasks = (ROOT / "roles/apps/authentik/tasks/main.yml").read_text()
 

--- a/tests/test_sso_native_apps.py
+++ b/tests/test_sso_native_apps.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import yaml
+from conftest import ROOT
+
+BLUEPRINT = ROOT / "playbooks/argocd/applications/security/authentik/blueprints/native-apps.yaml"
+TASKS = ROOT / "roles/apps/authentik/tasks/native-apps.yml"
+
+
+def _blueprint_entries() -> list[dict]:
+    class BlueprintLoader(yaml.SafeLoader):
+        pass
+
+    def construct_tagged(loader: BlueprintLoader, _suffix: str, node: yaml.Node):
+        if isinstance(node, yaml.ScalarNode):
+            return loader.construct_scalar(node)
+        if isinstance(node, yaml.SequenceNode):
+            return loader.construct_sequence(node)
+        return loader.construct_mapping(node)
+
+    BlueprintLoader.add_multi_constructor("!", construct_tagged)
+    return yaml.load(BLUEPRINT.read_text(), Loader=BlueprintLoader)["entries"]
+
+
+def test_native_app_blueprint_uses_exact_oidc_clients() -> None:
+    entries = _blueprint_entries()
+    providers = {
+        item["id"]: item["attrs"]
+        for item in entries
+        if item["model"] == "authentik_providers_oauth2.oauth2provider"
+    }
+
+    immich = providers["immich-provider"]
+    assert immich["client_type"] == "confidential"
+    assert immich["client_id"] == "immich"
+    assert immich["client_secret"] == "IMMICH_OIDC_CLIENT_SECRET"
+    assert immich["grant_types"] == ["authorization_code", "refresh_token"]
+    assert immich["redirect_uris"] == [
+        {
+            "matching_mode": "strict",
+            "url": "https://immich.soyspray.vip/auth/login",
+            "redirect_uri_type": "authorization",
+        },
+        {
+            "matching_mode": "strict",
+            "url": "https://immich.soyspray.vip/user-settings",
+            "redirect_uri_type": "authorization",
+        },
+        {
+            "matching_mode": "strict",
+            "url": "app.immich:///oauth-callback",
+            "redirect_uri_type": "authorization",
+        },
+    ]
+
+    booklore = providers["booklore-provider"]
+    assert booklore["client_type"] == "public"
+    assert booklore["client_id"] == "booklore"
+    assert "client_secret" not in booklore
+    assert booklore["grant_types"] == ["authorization_code", "refresh_token"]
+    assert booklore["redirect_uris"] == [
+        {
+            "matching_mode": "strict",
+            "url": "https://booklore.soyspray.vip/oauth2-callback",
+            "redirect_uri_type": "authorization",
+        },
+        {
+            "matching_mode": "strict",
+            "url": "booklore://oauth2-callback",
+            "redirect_uri_type": "authorization",
+        },
+        {
+            "matching_mode": "strict",
+            "url": "https://booklore.soyspray.vip/login",
+            "redirect_uri_type": "logout",
+        },
+    ]
+    assert booklore["logout_method"] == "backchannel"
+    assert booklore["logout_uri"] == (
+        "https://booklore.soyspray.vip/api/v1/auth/oidc/backchannel-logout"
+    )
+
+
+def test_native_apps_are_limited_to_cluster_admins() -> None:
+    entries = _blueprint_entries()
+    applications = {
+        item["id"]: item for item in entries if item["model"] == "authentik_core.application"
+    }
+    bindings = [item for item in entries if item["model"] == "authentik_policies.policybinding"]
+
+    assert set(applications) == {"immich-application", "booklore-application"}
+    assert {item["identifiers"]["target"] for item in bindings} == {
+        "immich-application",
+        "booklore-application",
+    }
+    assert all(
+        item["attrs"]["group"] == ["authentik_core.group", ["name", "cluster-admins"]]
+        for item in bindings
+    )
+
+
+def test_native_app_tasks_use_supported_admin_apis_idempotently() -> None:
+    tasks = TASKS.read_text()
+
+    assert "authentik_configure_native_apps | default(false)" in tasks
+    assert "ansible.builtin.assert:" in tasks
+    assert "SOYSPRAY_IMMICH_ADMIN_EMAIL" in tasks
+    assert "SOYSPRAY_IMMICH_ADMIN_PASSWORD" in tasks
+    assert "SOYSPRAY_BOOKLORE_ADMIN_USERNAME" in tasks
+    assert "SOYSPRAY_BOOKLORE_ADMIN_PASSWORD" in tasks
+    assert "no_log: true" in tasks
+
+    immich_get = tasks.index("url: https://immich.soyspray.vip/api/system-config")
+    immich_put = tasks.index("url: https://immich.soyspray.vip/api/system-config", immich_get + 1)
+    booklore_get = tasks.index("url: https://booklore.soyspray.vip/api/v1/settings")
+    booklore_put = tasks.index(
+        "url: https://booklore.soyspray.vip/api/v1/settings", booklore_get + 1
+    )
+    assert immich_get < immich_put
+    assert booklore_get < booklore_put
+    assert tasks.count("method: GET") >= 2
+    assert tasks.count("method: PUT") == 2
+    assert tasks.count("changed_when: false") >= 4
+    assert "when: authentik_immich_current_config.json != authentik_immich_sso_config" in tasks
+    assert "when: not authentik_booklore_sso_is_current" in tasks
+    assert "register: authentik_immich_admin_login" in tasks
+    assert "register: authentik_booklore_admin_login" in tasks
+
+
+def test_native_app_tasks_keep_local_accounts_and_link_existing_users() -> None:
+    tasks = TASKS.read_text()
+
+    assert "tokenEndpointAuthMethod: client_secret_post" in tasks
+    assert "autoRegister: false" in tasks
+    assert "passwordLogin" in tasks
+    assert "enabled: true" in tasks
+    assert "enableAutoProvisioning: false" in tasks
+    assert "allowLocalAccountLinking: true" in tasks
+    assert "OIDC_FORCE_ONLY_MODE" in tasks
+    assert "value: false" in tasks
+    assert "preferred_username" in tasks
+    assert "openid profile email offline_access" in tasks
+    assert "clientSecret: ''" in tasks
+    assert "OIDC_GROUP_SYNC_MODE" in tasks
+    assert "ON_LOGIN_ADDITIVE" in tasks
+
+
+def test_authentik_role_mounts_and_runs_native_app_configuration() -> None:
+    tasks = (ROOT / "roles/apps/authentik/tasks/main.yml").read_text()
+
+    assert "IMMICH_OIDC_CLIENT_SECRET" in tasks
+    assert "native-apps.yaml" in tasks
+    assert "include_tasks: native-apps.yml" in tasks
+    assert tasks.index("Apply Authentik") < tasks.index("include_tasks: native-apps.yml")

--- a/tests/test_sso_native_apps.py
+++ b/tests/test_sso_native_apps.py
@@ -188,6 +188,13 @@ def test_immich_admin_password_reset_is_explicit_and_private() -> None:
         "Log in to Immich with the local administrator"
     )
 
+    login = next(
+        task
+        for task in configure["block"]
+        if task["name"] == "Log in to Immich with the local administrator"
+    )
+    assert login["ansible.builtin.uri"]["status_code"] == 201
+
 
 def test_authentik_role_mounts_and_runs_native_app_configuration() -> None:
     tasks = (ROOT / "roles/apps/authentik/tasks/main.yml").read_text()

--- a/tests/test_sso_runtime_fixes.py
+++ b/tests/test_sso_runtime_fixes.py
@@ -46,6 +46,12 @@ def test_authentik_database_has_cpu_for_blueprint_reconciliation() -> None:
     assert cluster["spec"]["resources"]["limits"]["cpu"] == "1"
 
 
+def test_authentik_serializes_blueprint_work_on_one_worker() -> None:
+    values = load_yaml("playbooks/argocd/applications/security/authentik/values.yaml")
+
+    assert values["worker"]["replicas"] == 1
+
+
 def test_authentik_requests_a_tls_mirror_after_updating_the_allowlist() -> None:
     tasks = (ROOT / "roles/apps/authentik/tasks/main.yml").read_text()
     allowlist_task = "Allow the wildcard certificate in the Authentik namespace"

--- a/tests/test_sso_runtime_fixes.py
+++ b/tests/test_sso_runtime_fixes.py
@@ -40,9 +40,7 @@ def test_authentik_role_points_cert_manager_at_the_branch_before_certificate_cha
 
 
 def test_authentik_database_has_cpu_for_blueprint_reconciliation() -> None:
-    resources = load_all(
-        "playbooks/argocd/applications/security/authentik/database/cluster.yaml"
-    )
+    resources = load_all("playbooks/argocd/applications/security/authentik/database/cluster.yaml")
     cluster = next(item for item in resources if item["kind"] == "Cluster")
 
     assert cluster["spec"]["resources"]["limits"]["cpu"] == "1"

--- a/tests/test_sso_runtime_fixes.py
+++ b/tests/test_sso_runtime_fixes.py
@@ -44,3 +44,17 @@ def test_authentik_database_has_cpu_for_blueprint_reconciliation() -> None:
     cluster = next(item for item in resources if item["kind"] == "Cluster")
 
     assert cluster["spec"]["resources"]["limits"]["cpu"] == "1"
+
+
+def test_authentik_requests_a_tls_mirror_after_updating_the_allowlist() -> None:
+    tasks = (ROOT / "roles/apps/authentik/tasks/main.yml").read_text()
+    allowlist_task = "Allow the wildcard certificate in the Authentik namespace"
+    mirror_task = "Request the Authentik wildcard certificate mirror"
+
+    assert mirror_task in tasks
+    assert "Read the wildcard certificate for Authentik" in tasks
+    assert "register: authentik_wildcard_certificate" in tasks
+    assert "reflector.v1.k8s.emberstack.com/reflects" in tasks
+    assert "cert-manager/prod-cert-tls" in tasks
+    assert 'data: "{{ authentik_wildcard_certificate.resources[0].data }}"' in tasks
+    assert tasks.index(allowlist_task) < tasks.index(mirror_task)

--- a/tests/test_sso_runtime_fixes.py
+++ b/tests/test_sso_runtime_fixes.py
@@ -50,6 +50,8 @@ def test_authentik_serializes_blueprint_work_on_one_worker() -> None:
     values = load_yaml("playbooks/argocd/applications/security/authentik/values.yaml")
 
     assert values["worker"]["replicas"] == 1
+    worker_env = {item["name"]: item["value"] for item in values["worker"]["env"]}
+    assert worker_env["AUTHENTIK_WORKER__THREADS"] == "1"
 
 
 def test_authentik_requests_a_tls_mirror_after_updating_the_allowlist() -> None:

--- a/tests/test_sso_runtime_fixes.py
+++ b/tests/test_sso_runtime_fixes.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from conftest import ROOT, load_yaml
+from conftest import ROOT, load_all, load_yaml
 
 
 def test_cnpg_operator_can_read_authentik_instance_status() -> None:
@@ -37,3 +37,12 @@ def test_authentik_role_points_cert_manager_at_the_branch_before_certificate_cha
     assert "cert-manager/cert-manager-application.yaml" in tasks
     assert "authentik_target_revision" in tasks
     assert tasks.index(application_task) < tasks.index(certificate_task)
+
+
+def test_authentik_database_has_cpu_for_blueprint_reconciliation() -> None:
+    resources = load_all(
+        "playbooks/argocd/applications/security/authentik/database/cluster.yaml"
+    )
+    cluster = next(item for item in resources if item["kind"] == "Cluster")
+
+    assert cluster["spec"]["resources"]["limits"]["cpu"] == "1"

--- a/tests/test_sso_runtime_fixes.py
+++ b/tests/test_sso_runtime_fixes.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from conftest import ROOT, load_yaml
+
+
+def test_cnpg_operator_can_read_authentik_instance_status() -> None:
+    policy = load_yaml(
+        "playbooks/argocd/applications/security/authentik/database/networkpolicy.yaml"
+    )
+
+    assert policy["spec"]["ingress"] == [
+        {
+            "from": [{"podSelector": {}}],
+            "ports": [{"protocol": "TCP", "port": 5432}],
+        },
+        {
+            "from": [
+                {
+                    "namespaceSelector": {
+                        "matchLabels": {
+                            "kubernetes.io/metadata.name": "cnpg-system",
+                        },
+                    },
+                },
+            ],
+            "ports": [{"protocol": "TCP", "port": 8000}],
+        },
+    ]
+
+
+def test_authentik_role_points_cert_manager_at_the_branch_before_certificate_change() -> None:
+    tasks = (ROOT / "roles/apps/authentik/tasks/main.yml").read_text()
+    application_task = "Point cert-manager config at the Authentik revision"
+    certificate_task = "Allow the wildcard certificate in the Authentik namespace"
+
+    assert application_task in tasks
+    assert "cert-manager/cert-manager-application.yaml" in tasks
+    assert "authentik_target_revision" in tasks
+    assert tasks.index(application_task) < tasks.index(certificate_task)


### PR DESCRIPTION
## Outcome

The cluster now has one Authentik login for interactive administration.

- Native OIDC: Argo CD, Grafana, Headlamp, Immich, and BookLore.
- Authentik forward auth: Longhorn, Prometheus, Zigbee2MQTT, LazyLibrarian, and qBittorrent.
- Kubernetes API authentication for Headlamp uses the Authentik user and group claims.
- Existing local accounts remain available for recovery.
- Home Assistant, CouchDB, MQTT, and application protocol endpoints keep their native authentication paths.

Closes #183.

## Safety and operating facts

- Login passwords and OIDC client secrets are created or preserved at runtime. No credential value is stored in Git.
- The Authentik database is a dedicated two-instance CloudNativePG cluster with a scheduled off-site backup.
- The wildcard certificate is mirrored into the Authentik namespace through the existing reflector workflow.
- The public Authentik issuer resolves to the LAN ingress from CoreDNS and NodeLocalDNS.
- Argo CD, Grafana, Immich, and BookLore retain tested local recovery logins.
- Argo CD v2.14.5 uses its supported OIDC TLS skip-verify setting for the in-cluster issuer path. Follow-up #188 tracks later hardening.
- Direct LoadBalancer bypasses and non-browser protocol hardening are intentionally separate in #186 and #187.

## Review map

- `playbooks/argocd/applications/security/authentik/`: Authentik, database, network policy, and three blueprints.
- `roles/apps/authentik/`: stable runtime secrets, deployment order, Argo/Grafana/Headlamp setup, and native application configuration.
- `playbooks/argocd/config/`: Argo CD OIDC, group RBAC, and local administrator recovery.
- `playbooks/argocd/applications/infrastructure/headlamp/` and `playbooks/operations/security/`: Headlamp OIDC and Kubernetes API OIDC variables.
- Longhorn, Prometheus, Zigbee2MQTT, LazyLibrarian, and qBittorrent leaf folders: forward-auth routes and callback paths.
- `kubespray`: merged inventory commit from kpoxo6op/kubespray#11 for the Authentik DNS override.
- `tests/test_sso*.py`: platform, native OIDC, forward-auth, ordering, recovery, and regression coverage.

## Deployment

Set the required operator-only environment variables before the first run:

- `SOYSPRAY_SSO_PASSWORD`
- `SOYSPRAY_BREAK_GLASS_PASSWORD`
- `SOYSPRAY_ARGOCD_ADMIN_PASSWORD_HASH`
- Existing off-site backup writer variables
- Existing Immich and BookLore administrator credentials when native app configuration is enabled

Deploy a review commit:

```bash
make go VENV=/home/boris/code/soyspray/soyspray-venv
source soyspray-venv/bin/activate
ansible-playbook -i kubespray/inventory/soycluster/hosts.yml \
  --become --become-user=root --user ubuntu \
  playbooks/deploy-argocd-apps.yml --tags authentik \
  -e authentik_target_revision=<pushed-commit-sha> \
  -e authentik_configure_native_apps=true
ansible-playbook -i kubespray/inventory/soycluster/hosts.yml \
  --become --become-user=root --user ubuntu \
  kubespray/cluster.yml --tags control-plane,coredns \
  -e @playbooks/operations/security/kubernetes-authentik-oidc-vars.yml
```

After merge, run the Authentik role with `authentik_target_revision=HEAD` so every temporary branch or commit pin is removed.

## Verification

- Local gate: 128 tests passed; formatting, Ansible lint, YAML, OpenAPI, render, documentation, and deployment preflight passed.
- GitHub Actions: both current PR check runs passed.
- Kubernetes: all three nodes are Ready on v1.35.4; all three API servers have the expected OIDC flags.
- DNS: the Argo server resolves `auth.soyspray.vip` to `192.168.20.20`; OIDC discovery returns HTTP 200.
- SSO browser tests passed for Argo CD, Grafana, Headlamp, Immich, BookLore, Longhorn, Prometheus, Zigbee2MQTT, LazyLibrarian, and qBittorrent's Authentik gate.
- A clean browser context accepted the new Authentik username and password and opened Argo CD with administrator controls.
- Recovery tests passed for Authentik, Argo CD, Grafana, Immich, and BookLore.
- Immich SSO and local recovery resolve to the same existing user. BookLore SSO opens the existing `boris` account with 31 books.
- The SSO applications are Synced and Healthy. The two pre-existing Immich database transition applications remain outside this change.

## Rollback

1. Use a tested local recovery account if Authentik is unavailable.
2. Revert this PR and push the revert.
3. Run the Authentik application role from `HEAD`.
4. Reconcile the Kubernetes control plane and CoreDNS from the reverted Kubespray inventory.
5. Confirm Argo CD, the Kubernetes API, and the native application logins before removing any recovery entry.

<details>
<summary>Commit list</summary>

- `9f14802` Add Authentik SSO configuration tests
- `40e27c9` Add Authentik identity platform manifests
- `701de65` Deploy Authentik with stable runtime secrets
- `9e8adc2` Configure Argo CD for Authentik OIDC
- `52f1dac` Reflect the wildcard certificate to Authentik
- `6a69d9e` Configure Grafana for Authentik OIDC
- `6091713` Add SSO deployment regression tests
- `05f82ee` Use an isolated Argo config loop variable
- `b921459` Fix the Prometheus Argo application schema
- `2c89af8` Fix Authentik first-start reconciliation
- `bc8e7be` Add Headlamp and Kubernetes OIDC
- `1fa7c49` Give Authentik database reconciliation headroom
- `b322d55` Format SSO regression tests
- `d5cb3d7` Add native SSO for Immich and BookLore
- `25b9baf` Add Authentik providers for legacy web UIs
- `45a8bba` Protect the Longhorn UI with Authentik
- `6b5e4e3` Protect Prometheus with Authentik
- `7cc5864` Protect Zigbee2MQTT with Authentik
- `9b2700f` Protect LazyLibrarian with Authentik
- `d9535d8` Protect qBittorrent with Authentik
- `7335ad9` Add legacy SSO regression tests
- `c6e7337` Fix Authentik TLS mirror bootstrap
- `b325cc6` Order legacy proxy blueprint dependencies
- `904eff6` Preserve the Zigbee2MQTT deployment selector
- `867a252` Set the embedded outpost public URL
- `3267aa1` Keep the embedded outpost callback local
- `338ccad` Resolve Authentik through the cluster ingress
- `64961cf` Add explicit Immich recovery password reset
- `5a74f0c` Reconcile Kubernetes OIDC configuration
- `a3e8199` Accept the Immich login response
- `6bb282c` Use the public embedded outpost URL
- `9271f40` Restart Authentik for blueprint discovery
- `40d244c` Allow Argo OIDC through the cluster ingress
- `a249857` Restart Argo CD after OIDC changes
- `c467cc2` Persist the Authentik cluster DNS override
- `66f93eb` Serialize Authentik blueprint work
- `6bb22e7` Reconcile the legacy Authentik blueprint
- `a90fb50` Serialize Authentik blueprint tasks

</details>
