### PR TITLE
Add Home Assistant and qBittorrent single sign-on

### DIFF
--- a/playbooks/argocd/applications/home-automation/home-assistant/configmap-bootstrap.yaml
+++ b/playbooks/argocd/applications/home-automation/home-assistant/configmap-bootstrap.yaml
@@ -34,7 +34,7 @@ data:
       discovery_url: https://auth.soyspray.vip/application/o/home-assistant/.well-known/openid-configuration
       display_name: Authentik
       features:
-        automatic_user_linking: true
+        automatic_user_linking: false
         default_redirect: false
         include_groups_scope: false
       roles:

--- a/playbooks/argocd/applications/home-automation/home-assistant/configmap-bootstrap.yaml
+++ b/playbooks/argocd/applications/home-automation/home-assistant/configmap-bootstrap.yaml
@@ -35,7 +35,7 @@ data:
       display_name: Authentik
       features:
         automatic_user_linking: true
-        default_redirect: true
+        default_redirect: false
         include_groups_scope: false
       roles:
         admin: cluster-admins

--- a/playbooks/argocd/applications/home-automation/home-assistant/configmap-bootstrap.yaml
+++ b/playbooks/argocd/applications/home-automation/home-assistant/configmap-bootstrap.yaml
@@ -29,6 +29,17 @@ data:
         - 172.16.0.0/12
         - 192.168.0.0/16
 
+    auth_oidc:
+      client_id: home-assistant
+      discovery_url: https://auth.soyspray.vip/application/o/home-assistant/.well-known/openid-configuration
+      display_name: Authentik
+      features:
+        automatic_user_linking: true
+        default_redirect: true
+        include_groups_scope: false
+      roles:
+        admin: cluster-admins
+
     input_boolean:
       tapo_bedtime_motion_guard:
         name: Tapo bedtime motion guard

--- a/playbooks/argocd/applications/home-automation/home-assistant/deployment.yaml
+++ b/playbooks/argocd/applications/home-automation/home-assistant/deployment.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        soyspray.vip/bootstrap-config-revision: "2026-05-24-bedtime-motion-guard"
+        soyspray.vip/bootstrap-config-revision: "2026-08-09-authentik-oidc"
       labels:
         app: home-assistant
         component: main
@@ -61,6 +61,34 @@ spec:
               rm -rf "${install_dir}"
               mkdir -p "${install_dir}"
               unzip -q "${tmp_dir}/dreame_vacuum.zip" -d "${install_dir}"
+              echo "${version}" > "${version_file}"
+              rm -rf "${tmp_dir}"
+          volumeMounts:
+            - name: config
+              mountPath: /config
+        - name: install-oidc-auth
+          image: alpine:3.20
+          command:
+            - sh
+            - -c
+            - |
+              set -euo pipefail
+              apk add --no-cache ca-certificates unzip wget >/dev/null
+              version="v1.1.1"
+              expected_sha256="9ce9e6153f80c781e360b93e097ff7d87d09235430fc48e7a67d97dda5fc3322"
+              install_dir="/config/custom_components/auth_oidc"
+              version_file="${install_dir}/.soyspray-version"
+
+              if [ -f "${version_file}" ] && [ "$(cat "${version_file}")" = "${version}" ]; then
+                exit 0
+              fi
+
+              tmp_dir="$(mktemp -d)"
+              wget -q -O "${tmp_dir}/hass-oidc-auth.zip" "https://github.com/christiaangoossens/hass-oidc-auth/releases/download/${version}/hass-oidc-auth.zip"
+              echo "${expected_sha256}  ${tmp_dir}/hass-oidc-auth.zip" | sha256sum -c -
+              rm -rf "${install_dir}"
+              mkdir -p "${install_dir}"
+              unzip -q "${tmp_dir}/hass-oidc-auth.zip" -d "${install_dir}"
               echo "${version}" > "${version_file}"
               rm -rf "${tmp_dir}"
           volumeMounts:

--- a/playbooks/argocd/applications/home-automation/home-assistant/deployment.yaml
+++ b/playbooks/argocd/applications/home-automation/home-assistant/deployment.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        soyspray.vip/bootstrap-config-revision: "2026-08-09-authentik-oidc"
+        soyspray.vip/bootstrap-config-revision: "2026-08-09-authentik-oidc-linked"
       labels:
         app: home-assistant
         component: main

--- a/playbooks/argocd/applications/media/qbittorrent/deployment.yaml
+++ b/playbooks/argocd/applications/media/qbittorrent/deployment.yaml
@@ -1,10 +1,10 @@
 # playbooks/yaml/argocd-apps/qbittorrent/deployment.yaml
 #------------------------------------------------------------------------------
 # Minimal qBittorrent Deployment (raw Kubernetes)
-# * Pinned image: linuxserver/qbittorrent:libtorrentv1-release-5.0.5_v1.2.20-ls73
-#   - qBittorrent 5.0.5
+# * Pinned image: linuxserver/qbittorrent:libtorrentv1-5.2.3_v1.2.20-ls126
+#   - qBittorrent 5.2.3
 #   - libtorrent 1.2.20
-#   - linuxserver build ls73 (multi‑arch: amd64 & arm64)
+#   - linuxserver build ls126 (multi‑arch: amd64 & arm64)
 # * Volumes:
 #     • /config  -> pvc: qbittorrent-config (1 Gi, Longhorn)
 #     • /downloads -> pvc: media-downloads (1800 Gi, local PV on /srv/media/downloads)
@@ -52,7 +52,7 @@ spec:
       #
       containers:
         - name: qbittorrent
-          image: linuxserver/qbittorrent:libtorrentv1-release-5.0.5_v1.2.20-ls73
+          image: linuxserver/qbittorrent:libtorrentv1-5.2.3_v1.2.20-ls126
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/playbooks/argocd/applications/media/qbittorrent/ingress.yaml
+++ b/playbooks/argocd/applications/media/qbittorrent/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/auth-url: "http://authentik-server.authentik.svc.cluster.local/outpost.goauthentik.io/auth/nginx"
     nginx.ingress.kubernetes.io/auth-signin: "https://torrent.soyspray.vip/outpost.goauthentik.io/start?rd=$scheme://$http_host$escaped_request_uri"
-    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-entitlements,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,Authorization,X-authentik-username,X-authentik-groups,X-authentik-entitlements,X-authentik-email,X-authentik-name,X-authentik-uid"
     nginx.ingress.kubernetes.io/auth-proxy-set-headers: "media/auth-proxy-set-headers-qbittorrent"
 spec:
   ingressClassName: nginx

--- a/playbooks/argocd/applications/security/authentik/blueprints/cluster-sso.yaml
+++ b/playbooks/argocd/applications/security/authentik/blueprints/cluster-sso.yaml
@@ -27,6 +27,10 @@ entries:
     id: cluster-admins
     identifiers:
       name: cluster-admins
+    attrs:
+      attributes:
+        qbittorrent_username: !Env QBITTORRENT_WEB_USERNAME
+        qbittorrent_password: !Env QBITTORRENT_WEB_PASSWORD
 
   - model: authentik_core.user
     id: boris-user

--- a/playbooks/argocd/applications/security/authentik/blueprints/legacy-forward-auth.yaml
+++ b/playbooks/argocd/applications/security/authentik/blueprints/legacy-forward-auth.yaml
@@ -152,6 +152,10 @@ entries:
       external_host: https://torrent.soyspray.vip
       mode: forward_single
       skip_path_regex: ^/api/v2(/|$)
+      basic_auth_enabled: true
+      basic_auth_user_attribute: qbittorrent_username
+      basic_auth_password_attribute: qbittorrent_password
+      intercept_header_auth: false
 
   - model: authentik_core.application
     id: qbittorrent-proxy-application

--- a/playbooks/argocd/applications/security/authentik/blueprints/native-apps.yaml
+++ b/playbooks/argocd/applications/security/authentik/blueprints/native-apps.yaml
@@ -129,7 +129,7 @@ entries:
       invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
       client_type: public
       client_id: home-assistant
-      grant_types: [authorization_code, refresh_token]
+      grant_types: [authorization_code]
       redirect_uris:
         - matching_mode: strict
           url: https://homeassistant.soyspray.vip/auth/oidc/callback

--- a/playbooks/argocd/applications/security/authentik/blueprints/native-apps.yaml
+++ b/playbooks/argocd/applications/security/authentik/blueprints/native-apps.yaml
@@ -118,3 +118,42 @@ entries:
       order: 0
     attrs:
       group: !Find [authentik_core.group, [name, cluster-admins]]
+
+  - model: authentik_providers_oauth2.oauth2provider
+    id: home-assistant-provider
+    identifiers:
+      name: Home Assistant
+    attrs:
+      authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      client_type: public
+      client_id: home-assistant
+      grant_types: [authorization_code, refresh_token]
+      redirect_uris:
+        - matching_mode: strict
+          url: https://homeassistant.soyspray.vip/auth/oidc/callback
+          redirect_uri_type: authorization
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-openid]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-profile]]
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+      issuer_mode: per_provider
+      include_claims_in_id_token: true
+
+  - model: authentik_core.application
+    id: home-assistant-application
+    identifiers:
+      slug: home-assistant
+    attrs:
+      name: Home Assistant
+      provider: !KeyOf home-assistant-provider
+      meta_launch_url: https://homeassistant.soyspray.vip
+      policy_engine_mode: all
+
+  - model: authentik_policies.policybinding
+    identifiers:
+      target: !KeyOf home-assistant-application
+      order: 0
+    attrs:
+      group: !Find [authentik_core.group, [name, cluster-admins]]

--- a/playbooks/argocd/applications/security/authentik/values.yaml
+++ b/playbooks/argocd/applications/security/authentik/values.yaml
@@ -46,6 +46,12 @@ worker:
   env:
     - name: AUTHENTIK_WORKER__THREADS
       value: "1"
+  livenessProbe:
+    timeoutSeconds: 15
+  readinessProbe:
+    timeoutSeconds: 15
+  startupProbe:
+    timeoutSeconds: 15
   podAnnotations:
     soyspray.vip/runtime-secret-revision: "2026-08-09-3"
   pdb:

--- a/roles/apps/authentik/tasks/main.yml
+++ b/roles/apps/authentik/tasks/main.yml
@@ -396,15 +396,6 @@
          | replace('targetRevision: "HEAD"', 'targetRevision: "' + authentik_target_revision + '"') }}
   tags: authentik
 
-- name: Apply Home Assistant SSO
-  kubernetes.core.k8s:
-    state: present
-    kubeconfig: "{{ kubeconfig_path }}"
-    definition: >-
-      {{ lookup('file', playbook_dir + '/argocd/applications/home-automation/home-assistant/homeassistant-application.yaml')
-         | replace('targetRevision: "HEAD"', 'targetRevision: "' + authentik_target_revision + '"') }}
-  tags: authentik
-
 - name: Apply legacy forward-auth applications
   kubernetes.core.k8s:
     state: present

--- a/roles/apps/authentik/tasks/main.yml
+++ b/roles/apps/authentik/tasks/main.yml
@@ -67,6 +67,12 @@
         {{ (existing['IMMICH_OIDC_CLIENT_SECRET'] | b64decode)
            if 'IMMICH_OIDC_CLIENT_SECRET' in existing
            else lookup('password', '/dev/null length=64 chars=ascii_letters,digits') }}
+      QBITTORRENT_WEB_USERNAME: >-
+        {{ (existing['QBITTORRENT_WEB_USERNAME'] | b64decode)
+           if 'QBITTORRENT_WEB_USERNAME' in existing else 'admin' }}
+      QBITTORRENT_WEB_PASSWORD: >-
+        {{ (existing['QBITTORRENT_WEB_PASSWORD'] | b64decode)
+           if 'QBITTORRENT_WEB_PASSWORD' in existing else '123' }}
       SOYSPRAY_BREAK_GLASS_PASSWORD: >-
         {{ (existing['SOYSPRAY_BREAK_GLASS_PASSWORD'] | b64decode)
            if 'SOYSPRAY_BREAK_GLASS_PASSWORD' in existing
@@ -387,6 +393,15 @@
     kubeconfig: "{{ kubeconfig_path }}"
     definition: >-
       {{ lookup('file', playbook_dir + '/argocd/applications/infrastructure/headlamp/headlamp-application.yaml')
+         | replace('targetRevision: "HEAD"', 'targetRevision: "' + authentik_target_revision + '"') }}
+  tags: authentik
+
+- name: Apply Home Assistant SSO
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig_path }}"
+    definition: >-
+      {{ lookup('file', playbook_dir + '/argocd/applications/home-automation/home-assistant/homeassistant-application.yaml')
          | replace('targetRevision: "HEAD"', 'targetRevision: "' + authentik_target_revision + '"') }}
   tags: authentik
 

--- a/roles/apps/homeassistant/defaults/main.yml
+++ b/roles/apps/homeassistant/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+homeassistant_target_revision: HEAD

--- a/roles/apps/homeassistant/tasks/main.yml
+++ b/roles/apps/homeassistant/tasks/main.yml
@@ -4,5 +4,7 @@
     state: present
     kubeconfig: "{{ kubeconfig_path }}"
     namespace: argocd
-    definition: "{{ lookup('file', playbook_dir + '/argocd/applications/home-automation/home-assistant/homeassistant-application.yaml') }}"
+    definition: >-
+      {{ lookup('file', playbook_dir + '/argocd/applications/home-automation/home-assistant/homeassistant-application.yaml')
+         | replace('targetRevision: "HEAD"', 'targetRevision: "' + homeassistant_target_revision + '"') }}
   tags: homeassistant

--- a/tests/test_sso_headlamp.py
+++ b/tests/test_sso_headlamp.py
@@ -26,6 +26,13 @@ def test_authentik_restarts_when_runtime_oidc_clients_change() -> None:
     assert values["worker"]["podAnnotations"] == expected
 
 
+def test_authentik_worker_probe_allows_blueprint_apply_time() -> None:
+    values = load_yaml("playbooks/argocd/applications/security/authentik/values.yaml")
+
+    for probe_name in ("livenessProbe", "readinessProbe", "startupProbe"):
+        assert values["worker"][probe_name]["timeoutSeconds"] == 15
+
+
 def test_authentik_has_a_headlamp_oidc_client() -> None:
     blueprint = (
         ROOT / "playbooks/argocd/applications/security/authentik/blueprints/cluster-sso.yaml"

--- a/tests/test_sso_home_assistant_qbittorrent.py
+++ b/tests/test_sso_home_assistant_qbittorrent.py
@@ -33,7 +33,7 @@ def test_home_assistant_uses_authentik_and_keeps_native_recovery() -> None:
     )
     assert "display_name: Authentik" in bootstrap
     assert "include_groups_scope: false" in bootstrap
-    assert "automatic_user_linking: true" in bootstrap
+    assert "automatic_user_linking: false" in bootstrap
     assert "admin: cluster-admins" in bootstrap
     assert "default_redirect: false" in bootstrap
     assert "auth_providers:" not in bootstrap

--- a/tests/test_sso_home_assistant_qbittorrent.py
+++ b/tests/test_sso_home_assistant_qbittorrent.py
@@ -35,16 +35,19 @@ def test_home_assistant_uses_authentik_and_keeps_native_recovery() -> None:
     assert "include_groups_scope: false" in bootstrap
     assert "automatic_user_linking: true" in bootstrap
     assert "admin: cluster-admins" in bootstrap
-    assert "default_redirect: true" in bootstrap
+    assert "default_redirect: false" in bootstrap
     assert "auth_providers:" not in bootstrap
 
 
 def test_authentik_deploys_home_assistant_from_the_tested_revision() -> None:
-    tasks = (ROOT / "roles/apps/authentik/tasks/main.yml").read_text()
+    defaults = load_yaml("roles/apps/homeassistant/defaults/main.yml")
+    tasks = (ROOT / "roles/apps/homeassistant/tasks/main.yml").read_text()
+    authentik_tasks = (ROOT / "roles/apps/authentik/tasks/main.yml").read_text()
 
-    assert "- name: Apply Home Assistant SSO" in tasks
+    assert defaults["homeassistant_target_revision"] == "HEAD"
     assert "home-assistant/homeassistant-application.yaml" in tasks
-    assert tasks.count("authentik_target_revision") >= 7
+    assert "homeassistant_target_revision" in tasks
+    assert "- name: Apply Home Assistant SSO" not in authentik_tasks
 
 
 def test_qbittorrent_accepts_authentik_basic_auth_and_keeps_native_api() -> None:

--- a/tests/test_sso_home_assistant_qbittorrent.py
+++ b/tests/test_sso_home_assistant_qbittorrent.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from conftest import ROOT, load_yaml
+
+
+def test_home_assistant_installs_the_pinned_oidc_release() -> None:
+    deployment = load_yaml(
+        "playbooks/argocd/applications/home-automation/home-assistant/deployment.yaml"
+    )
+    init_containers = {
+        item["name"]: item for item in deployment["spec"]["template"]["spec"]["initContainers"]
+    }
+    installer = init_containers["install-oidc-auth"]
+    script = installer["command"][-1]
+
+    assert installer["image"] == "alpine:3.20"
+    assert "v1.1.1" in script
+    assert "hass-oidc-auth.zip" in script
+    assert "9ce9e6153f80c781e360b93e097ff7d87d09235430fc48e7a67d97dda5fc3322" in script
+    assert 'install_dir="/config/custom_components/auth_oidc"' in script
+
+
+def test_home_assistant_uses_authentik_and_keeps_native_recovery() -> None:
+    bootstrap = load_yaml(
+        "playbooks/argocd/applications/home-automation/home-assistant/configmap-bootstrap.yaml"
+    )["data"]["configuration.yaml"]
+
+    assert "auth_oidc:" in bootstrap
+    assert "client_id: home-assistant" in bootstrap
+    assert (
+        "discovery_url: https://auth.soyspray.vip/application/o/home-assistant/"
+        ".well-known/openid-configuration" in bootstrap
+    )
+    assert "display_name: Authentik" in bootstrap
+    assert "include_groups_scope: false" in bootstrap
+    assert "automatic_user_linking: true" in bootstrap
+    assert "admin: cluster-admins" in bootstrap
+    assert "default_redirect: true" in bootstrap
+    assert "auth_providers:" not in bootstrap
+
+
+def test_authentik_deploys_home_assistant_from_the_tested_revision() -> None:
+    tasks = (ROOT / "roles/apps/authentik/tasks/main.yml").read_text()
+
+    assert "- name: Apply Home Assistant SSO" in tasks
+    assert "home-assistant/homeassistant-application.yaml" in tasks
+    assert tasks.count("authentik_target_revision") >= 7
+
+
+def test_qbittorrent_accepts_authentik_basic_auth_and_keeps_native_api() -> None:
+    deployment = load_yaml("playbooks/argocd/applications/media/qbittorrent/deployment.yaml")
+    image = deployment["spec"]["template"]["spec"]["containers"][0]["image"]
+    ingress = load_yaml("playbooks/argocd/applications/media/qbittorrent/ingress.yaml")
+    response_headers = set(
+        ingress["metadata"]["annotations"][
+            "nginx.ingress.kubernetes.io/auth-response-headers"
+        ].split(",")
+    )
+    blueprint = (
+        ROOT
+        / "playbooks/argocd/applications/security/authentik/blueprints/legacy-forward-auth.yaml"
+    ).read_text()
+
+    assert image == "linuxserver/qbittorrent:libtorrentv1-5.2.3_v1.2.20-ls126"
+    assert "Authorization" in response_headers
+    assert "basic_auth_enabled: true" in blueprint
+    assert "basic_auth_user_attribute: qbittorrent_username" in blueprint
+    assert "basic_auth_password_attribute: qbittorrent_password" in blueprint
+    assert "intercept_header_auth: false" in blueprint
+    assert "skip_path_regex: ^/api/v2(/|$)" in blueprint
+
+
+def test_qbittorrent_basic_auth_values_stay_in_the_runtime_secret() -> None:
+    cluster_blueprint = (
+        ROOT / "playbooks/argocd/applications/security/authentik/blueprints/cluster-sso.yaml"
+    ).read_text()
+    tasks = (ROOT / "roles/apps/authentik/tasks/main.yml").read_text()
+
+    assert "qbittorrent_username: !Env QBITTORRENT_WEB_USERNAME" in cluster_blueprint
+    assert "qbittorrent_password: !Env QBITTORRENT_WEB_PASSWORD" in cluster_blueprint
+    assert "QBITTORRENT_WEB_USERNAME" in tasks
+    assert "QBITTORRENT_WEB_PASSWORD" in tasks

--- a/tests/test_sso_legacy_proxy.py
+++ b/tests/test_sso_legacy_proxy.py
@@ -156,9 +156,12 @@ def test_each_web_ingress_uses_authentik_forward_auth() -> None:
             f"https://{settings['host']}/outpost.goauthentik.io/start?"
             "rd=$scheme://$http_host$escaped_request_uri"
         )
+        expected_headers = response_headers | (
+            {"Authorization"} if name == "qbittorrent" else set()
+        )
         assert (
             set(annotations["nginx.ingress.kubernetes.io/auth-response-headers"].split(","))
-            == response_headers
+            == expected_headers
         )
         assert annotations["nginx.ingress.kubernetes.io/auth-proxy-set-headers"] == (
             f"{settings['namespace']}/{settings['config_map']}"

--- a/tests/test_sso_native_apps.py
+++ b/tests/test_sso_native_apps.py
@@ -84,7 +84,7 @@ def test_native_app_blueprint_uses_exact_oidc_clients() -> None:
     assert home_assistant["client_type"] == "public"
     assert home_assistant["client_id"] == "home-assistant"
     assert "client_secret" not in home_assistant
-    assert home_assistant["grant_types"] == ["authorization_code", "refresh_token"]
+    assert home_assistant["grant_types"] == ["authorization_code"]
     assert home_assistant["redirect_uris"] == [
         {
             "matching_mode": "strict",

--- a/tests/test_sso_native_apps.py
+++ b/tests/test_sso_native_apps.py
@@ -80,6 +80,19 @@ def test_native_app_blueprint_uses_exact_oidc_clients() -> None:
         "https://booklore.soyspray.vip/api/v1/auth/oidc/backchannel-logout"
     )
 
+    home_assistant = providers["home-assistant-provider"]
+    assert home_assistant["client_type"] == "public"
+    assert home_assistant["client_id"] == "home-assistant"
+    assert "client_secret" not in home_assistant
+    assert home_assistant["grant_types"] == ["authorization_code", "refresh_token"]
+    assert home_assistant["redirect_uris"] == [
+        {
+            "matching_mode": "strict",
+            "url": "https://homeassistant.soyspray.vip/auth/oidc/callback",
+            "redirect_uri_type": "authorization",
+        }
+    ]
+
 
 def test_native_apps_are_limited_to_cluster_admins() -> None:
     entries = _blueprint_entries()
@@ -88,10 +101,15 @@ def test_native_apps_are_limited_to_cluster_admins() -> None:
     }
     bindings = [item for item in entries if item["model"] == "authentik_policies.policybinding"]
 
-    assert set(applications) == {"immich-application", "booklore-application"}
+    assert set(applications) == {
+        "immich-application",
+        "booklore-application",
+        "home-assistant-application",
+    }
     assert {item["identifiers"]["target"] for item in bindings} == {
         "immich-application",
         "booklore-application",
+        "home-assistant-application",
     }
     assert all(
         item["attrs"]["group"] == ["authentik_core.group", ["name", "cluster-admins"]]


### PR DESCRIPTION
## Outcome

- Add Home Assistant browser and Companion App sign-in through Authentik OIDC.
- Link Authentik user `boris` to the existing Home Assistant owner account, then disable automatic account linking.
- Keep the native Home Assistant login available for recovery.
- Remove the second qBittorrent browser login through Authentik HTTP Basic handoff.
- Keep qBittorrent `/api/v2` on native qBittorrent authentication.

## Safety facts

- Home Assistant uses a public OIDC client with PKCE. It has no client secret.
- The pinned `hass-oidc-auth` v1.1.1 release asset is verified with SHA-256 before installation.
- The existing Home Assistant `/config` PVC, owner user, native credential, integrations, dashboards, and devices remain in place.
- Automatic user linking was used once for the existing Boris owner account and is `false` in the final revision.
- Home Assistant is not behind Authentik ingress forward-auth. Its REST, WebSocket, webhook, and Companion endpoints keep their native protocol behavior.
- qBittorrent 5.2.3 accepts Authentik's Basic-auth handoff for the browser while its native API remains separate.
- Authentik worker probes allow 15 seconds so blueprint work does not trigger false liveness failures.

## Review map

- `5bc8fce`: executable SSO contracts.
- `eeab50d`: Authentik providers, runtime values, and branch deployment wiring.
- `5ab0b0f`: pinned Home Assistant OIDC integration and bootstrap configuration.
- `097eb18`: qBittorrent 5.2.3 and forwarded `Authorization` header.
- `32a14f5`: safe first-login migration settings.
- `95f9c63`: durable Home Assistant target revision propagation.
- `8724591`: Authentik worker probe timeout supported by the observed failure.
- `8548fd8`: final Home Assistant state after the existing owner account was linked.

<details>
<summary>Complete commit list</summary>

- `5bc8fce` Test Home Assistant and qBittorrent SSO contracts
- `eeab50d` Connect Home Assistant and qBittorrent to Authentik
- `5ab0b0f` Add Authentik OIDC login to Home Assistant
- `097eb18` Remove the second qBittorrent browser login
- `32a14f5` Keep Home Assistant recovery available during migration
- `95f9c63` Propagate the Home Assistant test revision
- `8724591` Allow Authentik worker health checks to finish
- `8548fd8` Lock Home Assistant OIDC to the linked account

</details>

## Deployment

```bash
source soyspray-venv/bin/activate
ansible-playbook \
  -i kubespray/inventory/soycluster/hosts.yml \
  --become --become-user=root --user ubuntu \
  playbooks/deploy-argocd-apps.yml \
  --tags authentik,homeassistant \
  -e authentik_target_revision=feat/187-ha-qb-sso \
  -e homeassistant_target_revision=feat/187-ha-qb-sso
```

## Verification

- `make go`: passed with 134 tests, 99 YAML files, 6 OpenAPI documents, production Ansible lint, docs, and render checks.
- GitHub CI: both current-head checks passed.
- Live Argo CD: Authentik, Home Assistant, and qBittorrent are Synced and Healthy at `8548fd8`.
- Authentik: two servers and one worker are Ready; the new worker has zero restarts after the probe fix.
- qBittorrent Chrome test: after clearing both qBittorrent and Authentik proxy cookies, the full 5.2.3 UI opened without its native login form and both cookies were rebuilt.
- qBittorrent API test: unauthenticated version request returned `403`; native login succeeded and reported `v5.2.3`.
- Home Assistant Chrome test: Authentik returned to the existing owner user `e6dc069482b64323b1b46397b7500d66`; there is one human user with both `auth_oidc` and `homeassistant` credentials.
- Home Assistant recovery test: an isolated Chrome context showed both `Login with Authentik` and `Continue with default login` after automatic linking was disabled.
- Pixel 9 Pro XL test: the existing Companion session survived the rollout, and a fresh Companion 2026.6.5 device-code login completed through Authentik and opened the Boris dashboard.
- Mobile cleanup: the phone has one active `Home` server entry, its device name remains `Pixel 9 Pro XL`, and Home Assistant has one mobile-app entry with that title.
- Protocol smoke tests: Home Assistant root returned `200`, unauthenticated `/api/` returned `401`, and OIDC discovery returned `200`.

## Rollback

Run the same Ansible roles with the Authentik and Home Assistant target revisions set to `HEAD`. The existing Home Assistant and qBittorrent PVC data remains intact.

Part of #187.
