### PR TITLE
Add Authentik observability dashboard and alerts

### DIFF
--- a/playbooks/argocd/applications/observability/prometheus/alerts/authentik.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/alerts/authentik.yaml
@@ -1,0 +1,156 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: authentik
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: authentik.product
+      rules:
+        - alert: AuthentikHighHTTP5xxRate
+          expr: |
+            (
+              sum(rate(django_http_responses_total_by_status_total{
+                namespace="authentik",
+                job="authentik-server-metrics",
+                status=~"5.."
+              }[5m]))
+              /
+              clamp_min(sum(rate(django_http_responses_total_by_status_total{
+                namespace="authentik",
+                job="authentik-server-metrics"
+              }[5m])), 0.001)
+            ) > 0.05
+            and
+            sum(rate(django_http_responses_total_by_status_total{
+              namespace="authentik",
+              job="authentik-server-metrics"
+            }[5m])) > 0.1
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: Authentik returns too many server errors
+            description: >-
+              Check the Authentik server logs and recent configuration changes;
+              more than 5% of HTTP responses were 5xx for ten minutes.
+
+        - alert: AuthentikTaskQueueBacklog
+          expr: |
+            max(sum by (queue_name) (authentik_tasks_queued{
+              namespace="authentik",
+              job="authentik-worker-metrics"
+            })) > 25
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: Authentik worker queue is not draining
+            description: >-
+              Check the Authentik worker logs and resource use; at least one
+              task queue has held more than 25 tasks for fifteen minutes.
+
+        - alert: AuthentikWorkerVersionMismatch
+          expr: |
+            max(authentik_tasks_workers{
+              namespace="authentik",
+              job="authentik-worker-metrics",
+              version_matched="False"
+            }) > 0
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: Authentik server and worker versions do not match
+            description: >-
+              Check the Authentik rollout and image versions; a worker has
+              reported a version mismatch for ten minutes.
+
+        - alert: AuthentikEmbeddedOutpostDisconnected
+          expr: |
+            min(authentik_outpost_connection{
+              namespace="authentik",
+              job="authentik-server-metrics",
+              outpost_type="proxy"
+            }) < 1
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Authentik embedded proxy outpost is disconnected
+            description: >-
+              Check the embedded outpost status and Authentik server logs;
+              protected applications can no longer complete forward auth.
+
+        - alert: AuthentikPostgreSQLBackupStale
+          expr: |
+            max(cnpg_collector_last_available_backup_timestamp{
+              namespace="authentik",
+              job="authentik/authentik-postgresql"
+            }) == 0
+            or
+            time() - max(cnpg_collector_last_available_backup_timestamp{
+              namespace="authentik",
+              job="authentik/authentik-postgresql"
+            }) > 93600
+          for: 30m
+          labels:
+            severity: critical
+          annotations:
+            summary: Authentik PostgreSQL has no recent base backup
+            description: >-
+              Check the CloudNativePG Backup resources, object-store access,
+              and operator logs; no usable base backup is newer than 26 hours.
+
+        - alert: AuthentikPostgreSQLReplicationLag
+          expr: |
+            max(cnpg_pg_replication_lag{
+              namespace="authentik",
+              job="authentik/authentik-postgresql"
+            }) > 60
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: Authentik PostgreSQL replica is behind
+            description: >-
+              Check the CloudNativePG cluster, replica logs, and network;
+              replication lag has exceeded 60 seconds for ten minutes.
+
+        - alert: AuthentikPostgreSQLWALArchivingStalled
+          expr: |
+            sum(cnpg_collector_pg_wal_archive_status{
+              namespace="authentik",
+              job="authentik/authentik-postgresql",
+              value="ready"
+            }) > 0
+            and
+            max(cnpg_pg_stat_archiver_seconds_since_last_archival{
+              namespace="authentik",
+              job="authentik/authentik-postgresql"
+            }) > 900
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: Authentik PostgreSQL WAL archiving is stalled
+            description: >-
+              Check the PostgreSQL archiver, object-store credentials, and
+              network; ready WAL files have waited more than fifteen minutes.
+
+        - alert: AuthentikPostgreSQLArchiverFailures
+          expr: |
+            sum(increase(cnpg_pg_stat_archiver_failed_count{
+              namespace="authentik",
+              job="authentik/authentik-postgresql"
+            }[15m])) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: Authentik PostgreSQL WAL archiver is failing
+            description: >-
+              Check the PostgreSQL and CloudNativePG operator logs; at least
+              one WAL archive operation failed during the last fifteen minutes.

--- a/playbooks/argocd/applications/observability/prometheus/dashboards/authentik.json
+++ b/playbooks/argocd/applications/observability/prometheus/dashboards/authentik.json
@@ -42,7 +42,7 @@
       },
       "id": 1,
       "options": {
-        "content": "# Authentik · identity control plane\nOne view of SSO request health, protected-app proxy traffic, worker queues, pod resources, and the two-node CloudNativePG PostgreSQL database. Green status cards show the expected live replicas. PostgreSQL panels depend on the metrics NetworkPolicy path. **Authentik 2026.5.6** · refresh 1m · all data stays inside the cluster.",
+        "content": "# Authentik · SSO\nLive sign-in, app, worker, PostgreSQL, and backup health · **2026.5.6**.",
         "mode": "markdown"
       },
       "pluginVersion": "11.3.0",

--- a/playbooks/argocd/applications/observability/prometheus/dashboards/authentik.json
+++ b/playbooks/argocd/applications/observability/prometheus/dashboards/authentik.json
@@ -1,0 +1,2203 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(255, 96, 61, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Open Authentik",
+      "type": "link",
+      "url": "https://auth.soyspray.vip"
+    }
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "content": "# Authentik · identity control plane\nOne view of SSO request health, protected-app proxy traffic, worker queues, pod resources, and the two-node CloudNativePG PostgreSQL database. Green status cards show the expected live replicas. PostgreSQL panels depend on the metrics NetworkPolicy path. **Authentik 2026.5.6** · refresh 1m · all data stays inside the cluster.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.3.0",
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 2,
+      "panels": [],
+      "title": "Status",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Expected: two Authentik server metrics targets.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              },
+              {
+                "color": "dark-green",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 4
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(up{namespace=\"authentik\", job=\"authentik-server-metrics\"})",
+          "instant": true,
+          "legendFormat": "servers",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Servers online",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Expected: one Authentik worker metrics target.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              },
+              {
+                "color": "dark-green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 4
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(up{namespace=\"authentik\", job=\"authentik-worker-metrics\"})",
+          "instant": true,
+          "legendFormat": "workers",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Worker online",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Expected: both CloudNativePG instances are reachable on metrics port 9187.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              },
+              {
+                "color": "dark-green",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 4
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(up{namespace=\"authentik\", job=\"authentik/authentik-postgresql\"})",
+          "instant": true,
+          "legendFormat": "database targets",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Database targets",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "A value of one means every scraped server sees its embedded proxy outpost connection.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "dark-red",
+                  "text": "Disconnected"
+                },
+                "1": {
+                  "color": "dark-green",
+                  "text": "Connected"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              },
+              {
+                "color": "dark-green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 4
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "min(authentik_outpost_connection{namespace=\"authentik\", job=\"authentik-server-metrics\", outpost_type=\"proxy\"})",
+          "instant": true,
+          "legendFormat": "outpost",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Embedded outpost",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Server-error responses during the current Prometheus rate interval.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-green",
+                "value": null
+              },
+              {
+                "color": "dark-red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 4
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(django_http_responses_total_by_status_total{namespace=\"authentik\", job=\"authentik-server-metrics\", status=~\"5..\"}[$__rate_interval])) or vector(0)",
+          "instant": true,
+          "legendFormat": "5xx",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Recent 5xx",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Largest queue reported by the Authentik worker.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-green",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 10
+              },
+              {
+                "color": "dark-red",
+                "value": 25
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 4
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "max(sum by (queue_name) (authentik_tasks_queued{namespace=\"authentik\", job=\"authentik-worker-metrics\"})) or vector(0)",
+          "instant": true,
+          "legendFormat": "queued",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Task queue",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 9,
+      "panels": [],
+      "title": "Traffic, latency, and errors",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "HTTP request rate by method across both Authentik servers.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "opacity",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 9
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (method) (rate(django_http_requests_total_by_method_total{namespace=\"authentik\", job=\"authentik-server-metrics\"}[$__rate_interval]))",
+          "legendFormat": "{{method}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Request rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Core request latency percentiles across both server replicas.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "opacity",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 9
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(authentik_main_request_duration_seconds_bucket{namespace=\"authentik\", job=\"authentik-server-metrics\", dest=\"core\"}[$__rate_interval])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(authentik_main_request_duration_seconds_bucket{namespace=\"authentik\", job=\"authentik-server-metrics\", dest=\"core\"}[$__rate_interval])))",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(authentik_main_request_duration_seconds_bucket{namespace=\"authentik\", job=\"authentik-server-metrics\", dest=\"core\"}[$__rate_interval])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Core latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Response rate grouped by HTTP status code.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "opacity",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 9
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (status) (rate(django_http_responses_total_by_status_total{namespace=\"authentik\", job=\"authentik-server-metrics\"}[$__rate_interval]))",
+          "legendFormat": "HTTP {{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Responses by status",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 13,
+      "panels": [],
+      "title": "Embedded outpost and proxy traffic",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Requests that Authentik proxies to each protected application.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 16,
+            "gradientMode": "opacity",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (host, method) (rate(authentik_outpost_proxy_request_duration_seconds_count{namespace=\"authentik\", job=\"authentik-server-metrics\", type=\"app\"}[$__rate_interval]))",
+          "legendFormat": "{{host}} · {{method}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Protected-app request rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "95th-percentile proxy latency for each protected host.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 16,
+            "gradientMode": "opacity",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, host) (rate(authentik_outpost_proxy_request_duration_seconds_bucket{namespace=\"authentik\", job=\"authentik-server-metrics\", type=\"app\"}[$__rate_interval]))) and on (host) (sum by (host) (rate(authentik_outpost_proxy_request_duration_seconds_count{namespace=\"authentik\", job=\"authentik-server-metrics\", type=\"app\"}[$__rate_interval])) > 0)",
+          "legendFormat": "{{host}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Protected-app p95 latency",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 16,
+      "panels": [],
+      "title": "Worker and task health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Worker processes that report the same Authentik version as the server.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              },
+              {
+                "color": "dark-green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 27
+      },
+      "id": 17,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(authentik_tasks_workers{namespace=\"authentik\", job=\"authentik-worker-metrics\", version_matched=\"True\"})",
+          "instant": true,
+          "legendFormat": "matched",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Compatible workers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Largest queued value reported by the worker endpoint.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-green",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 10
+              },
+              {
+                "color": "dark-red",
+                "value": 25
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 27
+      },
+      "id": 18,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "max(sum by (queue_name) (authentik_tasks_queued{namespace=\"authentik\", job=\"authentik-worker-metrics\"})) or vector(0)",
+          "instant": true,
+          "legendFormat": "queued",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Largest queue",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Tasks that are currently running in the worker.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-green",
+                "value": null
+              },
+              {
+                "color": "dark-blue",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 27
+      },
+      "id": 19,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(authentik_tasks_in_progress{namespace=\"authentik\", job=\"authentik-worker-metrics\"}) or vector(0)",
+          "instant": true,
+          "legendFormat": "running",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Tasks in progress",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "95th-percentile worker task duration.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-green",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 5000
+              },
+              {
+                "color": "dark-red",
+                "value": 15000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 27
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(histogram_quantile(0.95, sum by (le) (rate(authentik_tasks_duration_milliseconds_bucket{namespace=\"authentik\", job=\"authentik-worker-metrics\"}[$__rate_interval]))) and on () (sum(rate(authentik_tasks_duration_milliseconds_count{namespace=\"authentik\", job=\"authentik-worker-metrics\"}[$__rate_interval])) > 0)) or vector(0)",
+          "instant": true,
+          "legendFormat": "p95",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Task p95",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Task execution rate grouped by actor.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 14,
+            "gradientMode": "opacity",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (actor_name) (rate(authentik_tasks_total{namespace=\"authentik\", job=\"authentik-worker-metrics\"}[$__rate_interval])) > 0",
+          "legendFormat": "{{actor_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Task throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "95th-percentile task duration grouped by actor.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 14,
+            "gradientMode": "opacity",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 31
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, actor_name) (rate(authentik_tasks_duration_milliseconds_bucket{namespace=\"authentik\", job=\"authentik-worker-metrics\"}[$__rate_interval]))) and on (actor_name) (sum by (actor_name) (rate(authentik_tasks_duration_milliseconds_count{namespace=\"authentik\", job=\"authentik-worker-metrics\"}[$__rate_interval])) > 0)",
+          "legendFormat": "{{actor_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Task duration by actor",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 23,
+      "panels": [],
+      "title": "Pod resources",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "CPU cores used by Authentik server, worker, and PostgreSQL pods.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "opacity",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "cores"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 40
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{namespace=\"authentik\", container=~\"server|worker|postgres\"}[$__rate_interval]))",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU by pod",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Working-set memory used by Authentik server, worker, and PostgreSQL pods.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "opacity",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 40
+      },
+      "id": 25,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod) (container_memory_working_set_bytes{namespace=\"authentik\", container=~\"server|worker|postgres\"})",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Memory by pod",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Container restarts by Authentik pod during the selected range.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 35,
+            "gradientMode": "opacity",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 40
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod) (increase(kube_pod_container_status_restarts_total{namespace=\"authentik\", container=~\"server|worker|postgres\"}[$__rate_interval]))",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Restarts",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 48
+      },
+      "id": 27,
+      "panels": [],
+      "title": "Authentik PostgreSQL",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "CloudNativePG collectors reporting healthy. Expected: two.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              },
+              {
+                "color": "dark-green",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 49
+      },
+      "id": 28,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(cnpg_collector_up{namespace=\"authentik\", job=\"authentik/authentik-postgresql\"})",
+          "instant": true,
+          "legendFormat": "collectors",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Collectors healthy",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Largest observed CloudNativePG replication lag.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-green",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 30
+              },
+              {
+                "color": "dark-red",
+                "value": 60
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 49
+      },
+      "id": 29,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "max(cnpg_pg_replication_lag{namespace=\"authentik\", job=\"authentik/authentik-postgresql\"})",
+          "instant": true,
+          "legendFormat": "lag",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Replication lag",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Age of the newest available PostgreSQL base backup.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-green",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 86400
+              },
+              {
+                "color": "dark-red",
+                "value": 93600
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 49
+      },
+      "id": 30,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "time() - max(cnpg_collector_last_available_backup_timestamp{namespace=\"authentik\", job=\"authentik/authentik-postgresql\"})",
+          "instant": true,
+          "legendFormat": "age",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Newest backup age",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Current size of the Authentik application database.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 49
+      },
+      "id": 31,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "max(cnpg_pg_database_size_bytes{namespace=\"authentik\", job=\"authentik/authentik-postgresql\", datname=\"authentik\"})",
+          "instant": true,
+          "legendFormat": "size",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Database size",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "WAL archive delay when ready files are waiting; zero means no archive backlog.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-green",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 600
+              },
+              {
+                "color": "dark-red",
+                "value": 900
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 49
+      },
+      "id": 32,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "max(cnpg_pg_stat_archiver_seconds_since_last_archival{namespace=\"authentik\", job=\"authentik/authentik-postgresql\"}) * (sum(cnpg_collector_pg_wal_archive_status{namespace=\"authentik\", job=\"authentik/authentik-postgresql\", value=\"ready\"}) > bool 0)",
+          "instant": true,
+          "legendFormat": "archive gap",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Archive gap",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "WAL archive failures observed during the last 24 hours.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-green",
+                "value": null
+              },
+              {
+                "color": "dark-red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 49
+      },
+      "id": 33,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(cnpg_pg_stat_archiver_failed_count{namespace=\"authentik\", job=\"authentik/authentik-postgresql\"}[24h]))",
+          "instant": true,
+          "legendFormat": "failures",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Archiver failures",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Database size by PostgreSQL instance and database name.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "opacity",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 53
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod, datname) (cnpg_pg_database_size_bytes{namespace=\"authentik\", job=\"authentik/authentik-postgresql\", datname=\"authentik\"})",
+          "legendFormat": "{{pod}} · {{datname}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Database growth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "CloudNativePG replication lag for each PostgreSQL pod.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "opacity",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 53
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "max by (pod) (cnpg_pg_replication_lag{namespace=\"authentik\", job=\"authentik/authentik-postgresql\"})",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Replication lag by pod",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Current PostgreSQL backends grouped by pod and state.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "opacity",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 53
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod, state) (cnpg_backends_total{namespace=\"authentik\", job=\"authentik/authentik-postgresql\"})",
+          "legendFormat": "{{pod}} · {{state}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Database connections",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 40,
+  "tags": [
+    "authentik",
+    "identity",
+    "soyspray"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "30s",
+      "1m",
+      "5m",
+      "15m"
+    ],
+    "time_options": [
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d"
+    ]
+  },
+  "timezone": "Pacific/Auckland",
+  "title": "Authentik",
+  "uid": "authentik",
+  "version": 1,
+  "weekStart": "monday"
+}

--- a/playbooks/argocd/applications/observability/prometheus/kustomization.yaml
+++ b/playbooks/argocd/applications/observability/prometheus/kustomization.yaml
@@ -65,6 +65,15 @@ configMapGenerator:
       annotations:
         kustomize.toolkit.fluxcd.io/substitute: disabled
 
+  - name: grafana-dashboard-authentik
+    files:
+      - dashboards/authentik.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+      annotations:
+        kustomize.toolkit.fluxcd.io/substitute: disabled
+
   - name: grafana-dashboard-node-hardware
     files:
       - dashboards/node-hardware.json
@@ -91,4 +100,5 @@ resources:
   - alerts/backups-essential.yaml
   - alerts/cert-expiry.yaml
   - alerts/domain-health.yaml
+  - alerts/authentik.yaml
   - alerts/node-hardware.yaml

--- a/playbooks/argocd/applications/security/authentik/database/networkpolicy.yaml
+++ b/playbooks/argocd/applications/security/authentik/database/networkpolicy.yaml
@@ -22,3 +22,14 @@ spec:
       ports:
         - protocol: TCP
           port: 8000
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+              prometheus: kube-prometheus-stack-prometheus
+      ports:
+        - protocol: TCP
+          port: 9187

--- a/tests/test_authentik_dashboard.py
+++ b/tests/test_authentik_dashboard.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import json
+
+from conftest import ROOT, load_yaml
+
+DASHBOARD_PATH = ROOT / (
+    "playbooks/argocd/applications/observability/prometheus/dashboards/authentik.json"
+)
+ALERTS_PATH = "playbooks/argocd/applications/observability/prometheus/alerts/authentik.yaml"
+KUSTOMIZATION_PATH = "playbooks/argocd/applications/observability/prometheus/kustomization.yaml"
+PROMETHEUS = {"type": "prometheus", "uid": "${datasource}"}
+
+
+def load_dashboard() -> dict:
+    return json.loads(DASHBOARD_PATH.read_text())
+
+
+def dashboard_expressions(dashboard: dict) -> list[str]:
+    return [target["expr"] for panel in dashboard["panels"] for target in panel.get("targets", [])]
+
+
+def test_authentik_dashboard_is_native_focused_and_well_laid_out() -> None:
+    dashboard = load_dashboard()
+    panels = dashboard["panels"]
+
+    assert dashboard["title"] == "Authentik"
+    assert dashboard["uid"] == "authentik"
+    assert dashboard["schemaVersion"] >= 39
+    assert {"authentik", "identity", "soyspray"} <= set(dashboard["tags"])
+    assert DASHBOARD_PATH.stat().st_size < 150_000
+
+    variables = {item["name"]: item for item in dashboard["templating"]["list"]}
+    assert variables["datasource"]["type"] == "datasource"
+    assert variables["datasource"]["query"] == "prometheus"
+
+    assert {panel["type"] for panel in panels} <= {
+        "bargauge",
+        "row",
+        "stat",
+        "text",
+        "timeseries",
+    }
+    text_panels = [panel for panel in panels if panel["type"] == "text"]
+    assert len(text_panels) == 1
+    intro = text_panels[0]["options"]["content"]
+    assert "2026.5.6" in intro
+    assert "PostgreSQL" in intro
+    assert len(intro) < 650
+    assert "<img" not in intro
+    assert "![" not in intro
+
+    ids = [panel["id"] for panel in panels]
+    assert len(ids) == len(set(ids))
+    occupied: set[tuple[int, int]] = set()
+    for panel in panels:
+        position = panel["gridPos"]
+        assert position["x"] >= 0
+        assert position["y"] >= 0
+        assert position["w"] > 0
+        assert position["h"] > 0
+        assert position["x"] + position["w"] <= 24
+        cells = {
+            (x, y)
+            for x in range(position["x"], position["x"] + position["w"])
+            for y in range(position["y"], position["y"] + position["h"])
+        }
+        assert occupied.isdisjoint(cells), panel["title"]
+        occupied.update(cells)
+
+        if panel["type"] in {"row", "text"}:
+            continue
+        assert panel["datasource"] == PROMETHEUS
+        assert panel["targets"]
+        for target in panel["targets"]:
+            assert target["datasource"] == PROMETHEUS
+            assert target["expr"]
+
+
+def test_authentik_dashboard_covers_live_authentik_and_cnpg_metrics() -> None:
+    dashboard = load_dashboard()
+    expressions = dashboard_expressions(dashboard)
+    query_text = "\n".join(expressions)
+    row_titles = {panel["title"] for panel in dashboard["panels"] if panel["type"] == "row"}
+
+    assert {
+        "Status",
+        "Traffic, latency, and errors",
+        "Embedded outpost and proxy traffic",
+        "Worker and task health",
+        "Pod resources",
+        "Authentik PostgreSQL",
+    } <= row_titles
+
+    required_metrics = {
+        "django_http_requests_total_by_method_total",
+        "django_http_responses_total_by_status_total",
+        "authentik_main_request_duration_seconds_bucket",
+        "authentik_outpost_connection",
+        "authentik_outpost_proxy_request_duration_seconds_count",
+        "authentik_outpost_proxy_request_duration_seconds_bucket",
+        "authentik_tasks_workers",
+        "authentik_tasks_queued",
+        "authentik_tasks_in_progress",
+        "authentik_tasks_duration_milliseconds_bucket",
+        "container_cpu_usage_seconds_total",
+        "container_memory_working_set_bytes",
+        "kube_pod_container_status_restarts_total",
+        "cnpg_collector_up",
+        "cnpg_pg_replication_lag",
+        "cnpg_collector_last_available_backup_timestamp",
+        "cnpg_pg_database_size_bytes",
+        "cnpg_pg_stat_archiver_seconds_since_last_archival",
+        "cnpg_pg_stat_archiver_failed_count",
+        "cnpg_backends_total",
+    }
+    assert all(metric in query_text for metric in required_metrics)
+    assert any(
+        "authentik_outpost_proxy_request_duration_seconds_count" in expression
+        and "by (host, method)" in expression
+        for expression in expressions
+    )
+    assert any(
+        "authentik_outpost_proxy_request_duration_seconds_bucket" in expression
+        and "by (le, host)" in expression
+        for expression in expressions
+    )
+
+    cnpg_expressions = [expression for expression in expressions if "cnpg_" in expression]
+    assert cnpg_expressions
+    assert all('namespace="authentik"' in expression for expression in cnpg_expressions)
+    assert all(
+        'job="authentik/authentik-postgresql"' in expression for expression in cnpg_expressions
+    )
+    assert all("or vector(0)" not in expression for expression in cnpg_expressions)
+
+
+def test_authentik_dashboard_keeps_idle_series_useful_and_covers_all_pods() -> None:
+    expressions = dashboard_expressions(load_dashboard())
+
+    resource_expressions = [
+        expression
+        for expression in expressions
+        if any(
+            metric in expression
+            for metric in (
+                "container_cpu_usage_seconds_total",
+                "container_memory_working_set_bytes",
+                "kube_pod_container_status_restarts_total",
+            )
+        )
+    ]
+    assert len(resource_expressions) == 3
+    assert all(
+        'container=~"server|worker|postgres"' in expression for expression in resource_expressions
+    )
+
+    archive_gap = next(
+        expression
+        for expression in expressions
+        if "cnpg_pg_stat_archiver_seconds_since_last_archival" in expression
+    )
+    assert "cnpg_collector_pg_wal_archive_status" in archive_gap
+    assert 'value="ready"' in archive_gap
+
+    proxy_p95 = next(
+        expression
+        for expression in expressions
+        if "authentik_outpost_proxy_request_duration_seconds_bucket" in expression
+    )
+    assert "authentik_outpost_proxy_request_duration_seconds_count" in proxy_p95
+    assert "> 0" in proxy_p95
+
+    task_p95_expressions = [
+        expression
+        for expression in expressions
+        if "authentik_tasks_duration_milliseconds_bucket" in expression
+    ]
+    assert task_p95_expressions
+    assert all(
+        "authentik_tasks_duration_milliseconds_count" in expression and "> 0" in expression
+        for expression in task_p95_expressions
+    )
+
+    task_throughput = next(
+        expression for expression in expressions if "authentik_tasks_total" in expression
+    )
+    assert "> 0" in task_throughput
+
+    database_growth = next(
+        expression for expression in expressions if "sum by (pod, datname)" in expression
+    )
+    assert 'datname="authentik"' in database_growth
+
+
+def test_authentik_alerts_are_product_specific_and_actionable() -> None:
+    manifest = load_yaml(ALERTS_PATH)
+    assert manifest["kind"] == "PrometheusRule"
+    assert manifest["metadata"]["name"] == "authentik"
+    assert manifest["metadata"]["namespace"] == "monitoring"
+    assert manifest["metadata"]["labels"]["release"] == "kube-prometheus-stack"
+
+    rules = manifest["spec"]["groups"][0]["rules"]
+    alerts = {rule["alert"]: rule for rule in rules}
+    assert set(alerts) == {
+        "AuthentikHighHTTP5xxRate",
+        "AuthentikTaskQueueBacklog",
+        "AuthentikWorkerVersionMismatch",
+        "AuthentikEmbeddedOutpostDisconnected",
+        "AuthentikPostgreSQLBackupStale",
+        "AuthentikPostgreSQLReplicationLag",
+        "AuthentikPostgreSQLWALArchivingStalled",
+        "AuthentikPostgreSQLArchiverFailures",
+    }
+    for rule in rules:
+        assert rule["for"]
+        assert rule["labels"]["severity"] in {"warning", "critical"}
+        assert rule["annotations"]["summary"]
+        assert rule["annotations"]["description"].startswith("Check ")
+
+    alert_queries = "\n".join(str(rule["expr"]) for rule in rules)
+    assert "django_http_responses_total_by_status_total" in alert_queries
+    assert "authentik_tasks_queued" in alert_queries
+    assert 'version_matched="False"' in alert_queries
+    assert "authentik_outpost_connection" in alert_queries
+    assert "cnpg_collector_last_available_backup_timestamp" in alert_queries
+    assert "cnpg_pg_replication_lag" in alert_queries
+    assert "cnpg_pg_stat_archiver_seconds_since_last_archival" in alert_queries
+    assert "cnpg_pg_stat_archiver_failed_count" in alert_queries
+    assert "KubePod" not in alert_queries
+    assert "TargetDown" not in alert_queries
+
+
+def test_authentik_dashboard_and_alerts_are_provisioned() -> None:
+    kustomization = load_yaml(KUSTOMIZATION_PATH)
+    generators = {item["name"]: item for item in kustomization["configMapGenerator"]}
+    dashboard = generators["grafana-dashboard-authentik"]
+
+    assert dashboard["files"] == ["dashboards/authentik.json"]
+    assert dashboard["options"]["labels"]["grafana_dashboard"] == "1"
+    assert (
+        dashboard["options"]["annotations"]["kustomize.toolkit.fluxcd.io/substitute"] == "disabled"
+    )
+    assert "alerts/authentik.yaml" in kustomization["resources"]

--- a/tests/test_authentik_dashboard.py
+++ b/tests/test_authentik_dashboard.py
@@ -44,6 +44,9 @@ def test_authentik_dashboard_is_native_focused_and_well_laid_out() -> None:
     text_panels = [panel for panel in panels if panel["type"] == "text"]
     assert len(text_panels) == 1
     intro = text_panels[0]["options"]["content"]
+    intro_lines = intro.splitlines()
+    assert len(intro_lines[0]) <= 24
+    assert len(" ".join(intro_lines[1:])) <= 90
     assert "2026.5.6" in intro
     assert "PostgreSQL" in intro
     assert len(intro) < 650

--- a/tests/test_authentik_postgresql_metrics.py
+++ b/tests/test_authentik_postgresql_metrics.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from conftest import load_yaml
+
+
+def test_kube_prometheus_stack_can_scrape_authentik_postgresql_metrics() -> None:
+    policy = load_yaml(
+        "playbooks/argocd/applications/security/authentik/database/networkpolicy.yaml"
+    )
+
+    assert {
+        "from": [
+            {
+                "namespaceSelector": {
+                    "matchLabels": {
+                        "kubernetes.io/metadata.name": "monitoring",
+                    },
+                },
+                "podSelector": {
+                    "matchLabels": {
+                        "app.kubernetes.io/name": "prometheus",
+                        "prometheus": "kube-prometheus-stack-prometheus",
+                    },
+                },
+            },
+        ],
+        "ports": [{"protocol": "TCP", "port": 9187}],
+    } in policy["spec"]["ingress"]

--- a/tests/test_sso_runtime_fixes.py
+++ b/tests/test_sso_runtime_fixes.py
@@ -25,6 +25,24 @@ def test_cnpg_operator_can_read_authentik_instance_status() -> None:
             ],
             "ports": [{"protocol": "TCP", "port": 8000}],
         },
+        {
+            "from": [
+                {
+                    "namespaceSelector": {
+                        "matchLabels": {
+                            "kubernetes.io/metadata.name": "monitoring",
+                        },
+                    },
+                    "podSelector": {
+                        "matchLabels": {
+                            "app.kubernetes.io/name": "prometheus",
+                            "prometheus": "kube-prometheus-stack-prometheus",
+                        },
+                    },
+                },
+            ],
+            "ports": [{"protocol": "TCP", "port": 9187}],
+        },
     ]
 
 


### PR DESCRIPTION
## Outcome

- Allow the real Prometheus pod to scrape both Authentik PostgreSQL metrics endpoints.
- Add a native Grafana dashboard for Authentik, its embedded proxy outpost, workers, pods, PostgreSQL, replication, WAL archiving, and backups.
- Add eight product-specific alerts for Authentik and its database.

## Safety facts

- The NetworkPolicy opens only TCP 9187 from namespace `monitoring` and the exact kube-prometheus-stack Prometheus pod selector.
- PostgreSQL port 5432 remains limited to the Authentik namespace.
- The dashboard uses native Grafana panels. It has no external images or extra plugins.
- The alerts do not duplicate the existing generic target-down or pod alerts.
- No secret, application data, PVC, or SSO configuration changes in this PR.
- Checked-in Argo CD Application manifests still use `HEAD`. The live review deployment is temporarily pinned to the immutable PR commit.

## Review map

- `e806849`: narrow PostgreSQL metrics NetworkPolicy rule and regression tests.
- `6773c20`: executable dashboard, alert, layout, and provisioning contracts.
- `ab71b76`: the focused Authentik operations dashboard.
- `ca3cc56`: Grafana provisioning and the product-specific alert rules.
- `c4aafca`: small-screen header correction found during live Chrome review.

<details>
<summary>Complete commit list</summary>

- `e806849` Allow Prometheus to scrape Authentik PostgreSQL
- `6773c20` Test Authentik observability contracts
- `ab71b76` Add the Authentik operations dashboard
- `ca3cc56` Provision Authentik alerts and dashboard
- `c4aafca` Keep the dashboard header readable on small screens

</details>

## Deployment

```bash
source soyspray-venv/bin/activate
ansible-playbook \
  -i kubespray/inventory/soycluster/hosts.yml \
  --become --become-user=root --user ubuntu \
  playbooks/deploy-argocd-apps.yml \
  --tags authentik \
  -e authentik_target_revision=c4aafca231aceb5db960f53793f6b082b51659b5 \
  -e authentik_configure_native_apps=false
```

## Verification

- `make go`: passed with 140 tests, 99 YAML files, 6 OpenAPI documents, production Ansible lint, docs, and render checks.
- Argo CD: `authentik-postgresql` and `kube-prometheus-stack` are Synced and Healthy at `c4aafca231aceb5db960f53793f6b082b51659b5`; both sync operations succeeded.
- Prometheus targets: `authentik-postgresql-1` and `authentik-postgresql-2` are both `up` with empty scrape errors.
- Dashboard: 36 panels and 31 PromQL expressions; all expressions parse, and the live six-hour view has no `No data` panels or query errors.
- Browser: inspected in the credentialed visible Chrome session at 1440 pixels and 390 pixels. The final reload had no console exceptions or failed Grafana requests.
- Backup: the first scheduled Authentik PostgreSQL base backup completed at `2026-08-09T03:30:13Z` and appears in the dashboard.
- Alerts: all eight rules parse; no new Authentik alert is pending or firing after deployment.
- Related SSO applications remain Synced and Healthy at the review revision.

## Rollback

Before merge, run the same role against `HEAD`:

```bash
source soyspray-venv/bin/activate
ansible-playbook \
  -i kubespray/inventory/soycluster/hosts.yml \
  --become --become-user=root --user ubuntu \
  playbooks/deploy-argocd-apps.yml \
  --tags authentik \
  -e authentik_target_revision=HEAD \
  -e authentik_configure_native_apps=false
```

This removes the review-only runtime pin and restores the current `main` manifests. After merge, revert this PR first if the feature itself must be removed.
